### PR TITLE
Add Snapshot datasource.

### DIFF
--- a/digitalocean/datasource_digitalocean_image_test.go
+++ b/digitalocean/datasource_digitalocean_image_test.go
@@ -27,7 +27,7 @@ func TestAccDigitalOceanImage_Basic(t *testing.T) {
 				Config: testAccCheckDigitalOceanDropletConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
-					takeSnapshotsOfDroplet(rInt, &droplet, &snapshotsId),
+					takeSnapshotsOfDroplet(rInt, &droplet, false, &snapshotsId),
 				),
 			},
 			{
@@ -55,20 +55,28 @@ func TestAccDigitalOceanImage_Basic(t *testing.T) {
 			{
 				Config: " ",
 				Check: resource.ComposeTestCheckFunc(
-					deleteSnapshots(&snapshotsId),
+					deleteDropletSnapshots(&snapshotsId),
 				),
 			},
 		},
 	})
 }
 
-func takeSnapshotsOfDroplet(rInt int, droplet *godo.Droplet, snapshotsId *[]int) resource.TestCheckFunc {
+func takeSnapshotsOfDroplet(rInt int, droplet *godo.Droplet, increment bool, snapshotsId *[]int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*godo.Client)
 		for i := 0; i < 3; i++ {
-			err := takeSnapshotOfDroplet(rInt, i%2, droplet)
-			if err != nil {
-				return err
+			switch increment {
+			case true:
+				err := takeSnapshotOfDroplet(rInt, i, droplet)
+				if err != nil {
+					return err
+				}
+			case false:
+				err := takeSnapshotOfDroplet(rInt, i%2, droplet)
+				if err != nil {
+					return err
+				}
 			}
 		}
 		retrieveDroplet, _, err := client.Droplets.Get(context.Background(), (*droplet).ID)
@@ -90,9 +98,9 @@ func takeSnapshotOfDroplet(rInt, sInt int, droplet *godo.Droplet) error {
 	return nil
 }
 
-func deleteSnapshots(snapshotsId *[]int) resource.TestCheckFunc {
+func deleteDropletSnapshots(snapshotsId *[]int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		log.Printf("XXX Deleting snaps")
+		log.Printf("XXX Deleting Droplet snapshots")
 		client := testAccProvider.Meta().(*godo.Client)
 		snapshots := *snapshotsId
 		for _, value := range snapshots {

--- a/digitalocean/datasource_digitalocean_snapshot.go
+++ b/digitalocean/datasource_digitalocean_snapshot.go
@@ -1,0 +1,219 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceDigitalOceanSnapshot() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDoSnapshotRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateSnapshotNameRegex,
+			},
+			"most_recent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+			"region_filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"resource_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateResourceType,
+			},
+			// Computed values.
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"min_disk_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"regions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size_gigabytes": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// dataSourceDoSnapshotRead performs the Snapshot lookup.
+func dataSourceDoSnapshotRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*godo.Client)
+
+	resourceType := d.Get("resource_type")
+	nameRegex, nameRegexOk := d.GetOk("name_regex")
+	regionFilter, regionFilterOk := d.GetOk("region_filter")
+
+	pageOpt := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	var snapshotList []godo.Snapshot
+	for {
+		var snapshots []godo.Snapshot
+		var resp *godo.Response
+		var err error
+
+		switch resourceType {
+		case "droplet":
+			snapshots, resp, err = client.Snapshots.ListDroplet(context.Background(), pageOpt)
+		case "volume":
+			snapshots, resp, err = client.Snapshots.ListVolume(context.Background(), pageOpt)
+		}
+
+		for _, s := range snapshots {
+			snapshotList = append(snapshotList, s)
+		}
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return err
+		}
+
+		pageOpt.Page = page + 1
+	}
+
+	var snapshotsFilteredByName []godo.Snapshot
+	if nameRegexOk {
+		r := regexp.MustCompile(nameRegex.(string))
+		for _, snapshot := range snapshotList {
+			if r.MatchString(snapshot.Name) {
+				snapshotsFilteredByName = append(snapshotsFilteredByName, snapshot)
+			}
+		}
+	} else {
+		snapshotsFilteredByName = snapshotList[:]
+	}
+
+	var snapshotsFilteredByRegion []godo.Snapshot
+	if regionFilterOk {
+		for _, snapshot := range snapshotsFilteredByName {
+			for _, region := range snapshot.Regions {
+				if region == regionFilter {
+					snapshotsFilteredByRegion = append(snapshotsFilteredByRegion, snapshot)
+				}
+			}
+		}
+	} else {
+		snapshotsFilteredByRegion = snapshotsFilteredByName[:]
+	}
+
+	var snapshot godo.Snapshot
+	if len(snapshotsFilteredByRegion) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	recent := d.Get("most_recent").(bool)
+	if len(snapshotsFilteredByRegion) > 1 {
+		log.Printf("[DEBUG] do_snapshot - multiple results found and `most_recent` is set to: %t", recent)
+		if recent {
+			snapshot = mostRecentSnapshot(snapshotsFilteredByRegion)
+		} else {
+			return fmt.Errorf("Your query returned more than one result. Please try a more " +
+				"specific search criteria, or set `most_recent` attribute to true.")
+		}
+	} else {
+		// Query returned single result.
+		snapshot = snapshotsFilteredByRegion[0]
+	}
+
+	log.Printf("[DEBUG] do_snapshot - Single Snapshot found: %s", snapshot.ID)
+	return snapshotDescriptionAttributes(d, snapshot)
+}
+
+type snapshotSort []godo.Snapshot
+
+func (a snapshotSort) Len() int      { return len(a) }
+func (a snapshotSort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a snapshotSort) Less(i, j int) bool {
+	itime, _ := time.Parse(time.RFC3339, a[i].Created)
+	jtime, _ := time.Parse(time.RFC3339, a[j].Created)
+	return itime.Unix() < jtime.Unix()
+}
+
+// Returns the most recent Snapshot out of a slice of Snapshots.
+func mostRecentSnapshot(snapshots []godo.Snapshot) godo.Snapshot {
+	sortedSnapshots := snapshots
+	sort.Sort(snapshotSort(sortedSnapshots))
+	return sortedSnapshots[len(sortedSnapshots)-1]
+}
+
+// populate the numerous fields that the Snapshot description returns.
+func snapshotDescriptionAttributes(d *schema.ResourceData, snapshot godo.Snapshot) error {
+	d.SetId(snapshot.ID)
+	d.Set("created_at", snapshot.Created)
+	d.Set("min_disk_size", snapshot.MinDiskSize)
+	d.Set("name", snapshot.Name)
+	d.Set("regions", snapshot.Regions)
+	d.Set("resource_id", snapshot.ResourceID)
+	d.Set("size_gigabytes", snapshot.SizeGigaBytes)
+
+	return nil
+}
+
+func validateSnapshotNameRegex(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if _, err := regexp.Compile(value); err != nil {
+		errors = append(errors, fmt.Errorf(
+			"%q contains an invalid regular expression: %s",
+			k, err))
+	}
+	return
+}
+
+func validateResourceType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	switch value {
+	case
+		"droplet",
+		"volume":
+		return
+	}
+
+	errors = append(errors, fmt.Errorf(
+		"Invalid %q specified: %s",
+		k, value))
+
+	return
+}

--- a/digitalocean/datasource_digitalocean_snapshot_test.go
+++ b/digitalocean/datasource_digitalocean_snapshot_test.go
@@ -122,7 +122,7 @@ func deleteVolumeSnapshots(snapshotsId *[]string) resource.TestCheckFunc {
 		client := testAccProvider.Meta().(*godo.Client)
 		snapshots := *snapshotsId
 		for _, value := range snapshots {
-			log.Printf("XXX Deleting %d", value)
+			log.Printf("XXX Deleting %v", value)
 			_, err := client.Snapshots.Delete(context.Background(), value)
 			if err != nil {
 				return err

--- a/digitalocean/datasource_digitalocean_snapshot_test.go
+++ b/digitalocean/datasource_digitalocean_snapshot_test.go
@@ -1,0 +1,164 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDigitalOceanSnapshotDataSource_droplet(t *testing.T) {
+	var (
+		droplet             godo.Droplet
+		dropletSnapshotsIds []int
+	)
+
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
+					takeSnapshotsOfDroplet(rInt, &droplet, true, &dropletSnapshotsIds),
+				),
+			},
+			{
+				Config: testAccCheckDigitalOceanDropletSnapshotDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.droplet_test_snap", "name", fmt.Sprintf("snap-%d-2", rInt)),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.droplet_test_snap", "min_disk_size", "20"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.droplet_test_snap", "regions.0", "nyc3"),
+				),
+			},
+			{
+				Config:      testAccCheckDigitalOceanDropletSnapshotDataSourceConfig_fail,
+				ExpectError: regexp.MustCompile(`.*Your query returned more than one result.*`),
+			},
+			{
+				Config: " ",
+				Check: resource.ComposeTestCheckFunc(
+					deleteDropletSnapshots(&dropletSnapshotsIds),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanSnapshotDataSource_volume(t *testing.T) {
+	var volumeSnapshotsIds []string
+
+	rInt := acctest.RandInt()
+	name := fmt.Sprintf("volume-%v", rInt)
+	volume := godo.Volume{
+		Name: name,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanVolumeConfig_basic, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &volume),
+					takeSnapshotsOfVolume(rInt, &volume, &volumeSnapshotsIds),
+				),
+			},
+			{
+				Config: testAccCheckDigitalOceanVolumeSnapshotDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.volume_test_snap", "name", fmt.Sprintf("vol-snap-%d-2", rInt)),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.volume_test_snap", "min_disk_size", "100"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.volume_test_snap", "regions.0", "nyc1"),
+				),
+			},
+			{
+				Config:      testAccCheckDigitalOceanVolumeSnapshotDataSourceConfig_fail,
+				ExpectError: regexp.MustCompile(`.*Your query returned more than one result.*`),
+			},
+			{
+				Config: " ",
+				Check: resource.ComposeTestCheckFunc(
+					deleteVolumeSnapshots(&volumeSnapshotsIds),
+				),
+			},
+		},
+	})
+}
+
+func takeSnapshotsOfVolume(rInt int, volume *godo.Volume, snapshotsId *[]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*godo.Client)
+		for i := 0; i < 3; i++ {
+			createRequest := &godo.SnapshotCreateRequest{
+				VolumeID: (*volume).ID,
+				Name:     fmt.Sprintf("vol-snap-%d-%d", rInt, i),
+			}
+			volume, _, err := client.Storage.CreateSnapshot(context.Background(), createRequest)
+			if err != nil {
+				return err
+			}
+			*snapshotsId = append(*snapshotsId, volume.ID)
+		}
+		return nil
+	}
+}
+
+func deleteVolumeSnapshots(snapshotsId *[]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		log.Printf("XXX Deleting volume snapshots")
+		client := testAccProvider.Meta().(*godo.Client)
+		snapshots := *snapshotsId
+		for _, value := range snapshots {
+			log.Printf("XXX Deleting %d", value)
+			_, err := client.Snapshots.Delete(context.Background(), value)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+const testAccCheckDigitalOceanDropletSnapshotDataSourceConfig = `
+data "digitalocean_snapshot" "droplet_test_snap" {
+  most_recent = true
+  resource_type = "droplet"
+  name_regex = "^snap"
+}
+`
+
+const testAccCheckDigitalOceanDropletSnapshotDataSourceConfig_fail = `
+data "digitalocean_snapshot" "droplet_test_snap" {
+  most_recent = false
+  resource_type = "droplet"
+  name_regex = "^snap"
+}
+`
+
+const testAccCheckDigitalOceanVolumeSnapshotDataSourceConfig = `
+data "digitalocean_snapshot" "volume_test_snap" {
+    most_recent = true
+    resource_type = "volume"
+    name_regex = "^vol-snap"
+}
+`
+const testAccCheckDigitalOceanVolumeSnapshotDataSourceConfig_fail = `
+data "digitalocean_snapshot" "volume_test_snap" {
+    most_recent = false
+    resource_type = "volume"
+    name_regex = "^vol-snap"
+}
+`

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -18,7 +18,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"digitalocean_image": dataSourceDigitalOceanImage(),
+			"digitalocean_image":    dataSourceDigitalOceanImage(),
+			"digitalocean_snapshot": dataSourceDigitalOceanSnapshot(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/digitalocean/resource_digitalocean_volume.go
+++ b/digitalocean/resource_digitalocean_volume.go
@@ -53,6 +53,12 @@ func resourceDigitalOceanVolume() *schema.Resource {
 				Optional: true,
 				ForceNew: true, // Update-ability Coming Soon ™
 			},
+
+			"snapshot_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -65,6 +71,7 @@ func resourceDigitalOceanVolumeCreate(d *schema.ResourceData, meta interface{}) 
 		Name:          d.Get("name").(string),
 		Description:   d.Get("description").(string),
 		SizeGigaBytes: int64(d.Get("size").(int)),
+		SnapshotID:    d.Get("snapshot_id").(string),
 	}
 
 	log.Printf("[DEBUG] Volume create configuration: %#v", opts)

--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -17,6 +17,12 @@
           <a href="/docs/providers/do/d/image.html">digitalocean_image</a>
                     </li>
                 </ul>
+
+                <ul class="nav nav-visible">
+                    <li<%= sidebar_current("docs-do-datasource-snapshot") %>>
+                    <a href="/docs/providers/do/d/snapshot.html">digitalocean_snapshot</a>
+                    </li>
+                </ul>
         </li>
 
         <li<%= sidebar_current("docs-do-resource") %>>

--- a/website/docs/d/snapshot.html.md
+++ b/website/docs/d/snapshot.html.md
@@ -1,0 +1,48 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_snapshot"
+sidebar_current: "docs-do-datasource-snapshot"
+description: |-
+  Get information about a DigitalOcean snapshot.
+---
+
+# digitalocean\_snapshot
+
+Snapshots are saved instances of either a Droplet or a block storage volume. Use this data source to retrieve the ID of a DigitalOcean snapshot for use in other resources.
+
+## Example Usage
+
+```
+data "digitalocean_snapshot" "snapshot" {
+  most_recent = true
+  name_regex  = "^web"
+  region_filter = "nyc2"
+  resource_type = "droplet"
+}
+```
+
+## Argument Reference
+
+* `resource_type` - (Required) The type of DigitalOcean resource from which the snapshot originated. This currently must be either `droplet` or `volume`.
+
+* `most_recent` - (Optional) If more than one result is returned, use the most
+recent snapshot.
+
+* `name_regex` - (Optional) A regex string to apply to the snapshot list returned by DigitalOcean. This allows more advanced filtering not supported from the DigitalOcean API. This filtering is done locally on what DigitalOcean returns.
+
+* `region_filter` - (Optional) A "slug" representing a DigitalOcean region (e.g. `nyc1`). If set, only snapshots available in the region will be returned.
+
+~> **NOTE:** If more or less than a single match is returned by the search,
+Terraform will fail. Ensure that your search is specific enough to return
+a single snapshot ID only, or use `most_recent` to choose the most recent one.
+
+## Attributes Reference
+
+`id` is set to the ID of the found snapshot. In addition, the following attributes are exported:
+
+* `created_at` - The date and time the image was created.
+* `min_disk_size` - The minimum size in gigabytes required for a volume or Droplet to be created based on this snapshot.
+* `name` - The name of the snapshot.
+* `regions` - A list of DigitalOcean region "slugs" indicating where the snapshot is available.
+* `resource_id` - The ID of the resource from which the snapshot originated.
+* `size_gigabytes` - The billable size of the snapshot in gigabytes.

--- a/website/docs/r/volume.markdown
+++ b/website/docs/r/volume.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `name` - (Required) A name for the block storage volume. Must be lowercase and be composed only of numbers, letters and "-", up to a limit of 64 characters.
 * `size` - (Required) The size of the block storage volume in GiB.
 * `description` - (Optional) A free-form text field up to a limit of 1024 bytes to describe a block storage volume.
+* `snapshot_id` - (Optional) The ID of an existing volume snapshot from which the new volume will be created.
 * `droplet_ids` - (Computed) A list of associated droplet ids
 
 ## Attributes Reference


### PR DESCRIPTION
Finally got back around to this...

This adds a datasource for DigitalOcean snapshots similar to the aws_ami datasource. It allows for referencing user created snapshots when creating a new Droplet or volume.

```
$ make testacc TEST=./digitalocean TESTARGS='-run=TestAccDigitalOceanSnapshotDataSource*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./digitalocean -v -run=TestAccDigitalOceanSnapshotDataSource* -timeout 120m
=== RUN   TestAccDigitalOceanSnapshotDataSource_droplet
--- PASS: TestAccDigitalOceanSnapshotDataSource_droplet (240.15s)
=== RUN   TestAccDigitalOceanSnapshotDataSource_volume
--- PASS: TestAccDigitalOceanSnapshotDataSource_volume (30.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	270.48
```