### PR TITLE
cleanup: Adding the test sweepers to DO

### DIFF
--- a/digitalocean/resource_digitalocean_floating_ip_test.go
+++ b/digitalocean/resource_digitalocean_floating_ip_test.go
@@ -11,6 +11,36 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func init() {
+	resource.AddTestSweepers("digitalocean_floating_ip", &resource.Sweeper{
+		Name: "digitalocean_floating_ip",
+		F:    testSweepFloatingIps,
+	})
+
+}
+
+func testSweepFloatingIps(region string) error {
+	meta, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client := meta.(*godo.Client)
+
+	ips, _, err := client.FloatingIPs.List(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+
+	for _, ip := range ips {
+		if _, err := client.FloatingIPs.Delete(context.Background(), ip.IP); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func TestAccDigitalOceanFloatingIP_Region(t *testing.T) {
 	var floatingIP godo.FloatingIP
 

--- a/digitalocean/sweeper_test.go
+++ b/digitalocean/sweeper_test.go
@@ -1,0 +1,31 @@
+package digitalocean
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func sharedConfigForRegion(region string) (interface{}, error) {
+	if os.Getenv("DIGITALOCEAN_TOKEN") == "" {
+		return nil, fmt.Errorf("empty DIGITALOCEAN_TOKEN")
+	}
+
+	config := Config{
+		Token: os.Getenv("DIGITALOCEAN_TOKEN"),
+	}
+
+	// configures a default client for the region, using the above env vars
+	client, err := config.Client()
+	if err != nil {
+		return nil, fmt.Errorf("error getting DigitalOcean client")
+	}
+
+	return client, nil
+}


### PR DESCRIPTION
```
% go test ./digitalocean -v -sweep=do-region
2017/07/05 16:07:22 [DEBUG] Running Sweepers for region (do-region):
2017/07/05 16:07:22 [INFO] DigitalOcean Client configured for URL: https://api.digitalocean.com/
2017/07/05 16:07:23 [INFO] DigitalOcean Client configured for URL: https://api.digitalocean.com/
2017/07/05 16:07:24 [INFO] DigitalOcean Client configured for URL: https://api.digitalocean.com/
2017/07/05 16:07:25 [INFO] DigitalOcean Client configured for URL: https://api.digitalocean.com/
2017/07/05 16:07:27 Sweeper Tests ran:
	- digitalocean_loadbalancer
	- digitalocean_volume
	- digitalocean_droplet
	- digitalocean_floating_ip
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	5.338s
```