### PR TITLE
sweepers: Add missing droplet name pattern

### DIFF
--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -34,9 +34,10 @@ func testSweepDroplets(region string) error {
 	if err != nil {
 		return err
 	}
+	log.Printf("[DEBUG] Found %d droplets to sweep", len(droplets))
 
 	for _, d := range droplets {
-		if strings.HasPrefix(d.Name, "foo-") || strings.HasPrefix(d.Name, "bar-") {
+		if strings.HasPrefix(d.Name, "foo-") || strings.HasPrefix(d.Name, "bar-") || strings.HasPrefix(d.Name, "baz-") {
 			log.Printf("Destroying Droplet %s", d.Name)
 
 			if _, err := client.Droplets.Delete(context.Background(), d.ID); err != nil {

--- a/digitalocean/resource_digitalocean_volume_test.go
+++ b/digitalocean/resource_digitalocean_volume_test.go
@@ -16,8 +16,9 @@ import (
 
 func init() {
 	resource.AddTestSweepers("digitalocean_volume", &resource.Sweeper{
-		Name: "digitalocean_volume",
-		F:    testSweepVolumes,
+		Name:         "digitalocean_volume",
+		F:            testSweepVolumes,
+		Dependencies: []string{"digitalocean_droplet"},
 	})
 
 }


### PR DESCRIPTION
This is to address a sweeper failure from this morning:

```
2017/08/11 05:09:52 [ERR] error running (digitalocean_volume): DELETE https://api.digitalocean.com/v2/volumes/212bc0da-7d8a-11e7-b204-0242ac112707: 409 A volume that's attached to a Droplet cannot be deleted. Please detach it first before deleting.
```
