### PR TITLE
Put correct build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
-$ make bin
+$ make build
 ...
 $ $GOPATH/bin/terraform-provider-$PROVIDER_NAME
 ...


### PR DESCRIPTION
The README displays 'make bin' as build command, but it's 'make build'.