### PR TITLE
Correctly hand destination_tags in firewall resource. Fixes: #33

### DIFF
--- a/digitalocean/resource_digitalocean_firewall.go
+++ b/digitalocean/resource_digitalocean_firewall.go
@@ -352,7 +352,7 @@ func expandFirewallOutboundRules(d *schema.ResourceData) []godo.OutboundRule {
 
 		destinationTags := rule["destination_tags"].([]interface{})
 		for _, tag := range destinationTags {
-			dest.Addresses = append(dest.Tags, tag.(string))
+			dest.Tags = append(dest.Tags, tag.(string))
 		}
 
 		dropletIds := rule["destination_droplet_ids"].([]interface{})


### PR DESCRIPTION
Closes https://github.com/terraform-providers/terraform-provider-digitalocean/issues/33

Looks like destination tags were inadvertently being added to the destination addresses list. Test case updated to exercise this usecase. Failure demonstrating the bug before the fix:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanFirewall_MultipleInboundAndOutbound'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanFirewall_MultipleInboundAndOutbound -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanFirewall_MultipleInboundAndOutbound
--- FAIL: TestAccDigitalOceanFirewall_MultipleInboundAndOutbound (1.89s)
	testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:
		
		* digitalocean_firewall.foobar: 1 error(s) occurred:
		
		* digitalocean_firewall.foobar: Error creating firewall: POST https://api.digitalocean.com/v2/firewalls: 422 (request "1cf5da03-6967-4052-a778-2eaa1ff3f661") invalid address
FAIL
FAIL	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	1.898s
GNUmakefile:15: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

Success after:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanFirewall_MultipleInboundAndOutbound'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanFirewall_MultipleInboundAndOutbound -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanFirewall_MultipleInboundAndOutbound
--- PASS: TestAccDigitalOceanFirewall_MultipleInboundAndOutbound (9.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	9.896s
```