### PR TITLE
Firewall: fix port_range documentation

### DIFF
--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
   This may be one of "tcp", "udp", or "icmp".
 * `port_range` - (Optional) The ports on which traffic will be allowed
   specified as a string containing a single port, a range (e.g. "8000-9000"),
-  or "all" to open all ports for a protocol.
+  or "1-65535" to open all ports for a protocol.
 * `source_addresses` - (Optional) An array of strings containing the IPv4
   addresses, IPv6 addresses, IPv4 CIDRs, and/or IPv6 CIDRs from which the
   inbound traffic will be accepted.
@@ -89,7 +89,7 @@ The following arguments are supported:
   This may be one of "tcp", "udp", or "icmp".
 * `port_range` - (Optional) The ports on which traffic will be allowed
   specified as a string containing a single port, a range (e.g. "8000-9000"),
-  or "all" to open all ports for a protocol.
+  or "1-65535" to open all ports for a protocol.
 * `destination_addresses` - (Optional) An array of strings containing the IPv4
   addresses, IPv6 addresses, IPv4 CIDRs, and/or IPv6 CIDRs to which the
   outbound traffic will be allowed.


### PR DESCRIPTION
Digital Ocean API will throw a 422 error "You must specify a positive value for ports" if you send up “all” (as the documentation used to suggest), or “0”, or "", or anything other than “1-65535” if you want all ports opened.

There is still going to be a bug where if you don't specify the `port_range` parameter at all, the API will give you a 422 error. The documentation suggests the parameter is optional, but it will fail if you don't provide it, since Terraform will send up a `""`, which is also invalid and cause the same 422. I'm not sure what the intended behaviour is if you don't provide the `port_range`, but either way I'm not confident enough with go to fix this myself.