### PR TITLE
r/droplet: Avoid crash on conditional volumes

### DIFF
--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -192,8 +192,16 @@ func resourceDigitalOceanDropletCreate(d *schema.ResourceData, meta interface{})
 
 	if attr, ok := d.GetOk("volume_ids"); ok {
 		for _, id := range attr.([]interface{}) {
+			if id == nil {
+				continue
+			}
+			volumeId := id.(string)
+			if volumeId == "" {
+				continue
+			}
+
 			opts.Volumes = append(opts.Volumes, godo.DropletCreateVolume{
-				ID: id.(string),
+				ID: volumeId,
 			})
 		}
 	}


### PR DESCRIPTION
Fixes #11 

### Test results

```
TF_ACC=1 go test ./digitalocean -v -run=TestAccDigitalOceanDroplet_ -timeout 120m
=== RUN   TestAccDigitalOceanDroplet_importBasic
--- PASS: TestAccDigitalOceanDroplet_importBasic (39.55s)
=== RUN   TestAccDigitalOceanDroplet_Basic
--- PASS: TestAccDigitalOceanDroplet_Basic (50.31s)
=== RUN   TestAccDigitalOceanDroplet_WithID
--- FAIL: TestAccDigitalOceanDroplet_WithID (0.77s)
	testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:

		* digitalocean_droplet.foobar: 1 error(s) occurred:

		* digitalocean_droplet.foobar: Error creating droplet: POST https://api.digitalocean.com/v2/droplets: 422 You specified an invalid image for Droplet creation.
=== RUN   TestAccDigitalOceanDroplet_withSSH
--- PASS: TestAccDigitalOceanDroplet_withSSH (55.49s)
=== RUN   TestAccDigitalOceanDroplet_Update
--- PASS: TestAccDigitalOceanDroplet_Update (90.11s)
=== RUN   TestAccDigitalOceanDroplet_ResizeWithOutDisk
--- PASS: TestAccDigitalOceanDroplet_ResizeWithOutDisk (251.60s)
=== RUN   TestAccDigitalOceanDroplet_ResizeOnlyDisk
--- PASS: TestAccDigitalOceanDroplet_ResizeOnlyDisk (191.92s)
=== RUN   TestAccDigitalOceanDroplet_UpdateUserData
--- PASS: TestAccDigitalOceanDroplet_UpdateUserData (80.26s)
=== RUN   TestAccDigitalOceanDroplet_UpdateTags
--- PASS: TestAccDigitalOceanDroplet_UpdateTags (47.62s)
=== RUN   TestAccDigitalOceanDroplet_PrivateNetworkingIpv6
--- PASS: TestAccDigitalOceanDroplet_PrivateNetworkingIpv6 (62.98s)
=== RUN   TestAccDigitalOceanDroplet_Monitoring
--- PASS: TestAccDigitalOceanDroplet_Monitoring (50.38s)
=== RUN   TestAccDigitalOceanDroplet_conditionalVolumes
--- PASS: TestAccDigitalOceanDroplet_conditionalVolumes (77.11s)
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	998.107s
make: *** [testacc] Error 1
```

`TestAccDigitalOceanDroplet_WithID` was failing for a long while - that's worth a separate PR, unrelated to this one.