### PR TITLE
r/firewall: Suppress diff for 'all' port range

### DIFF
--- a/digitalocean/resource_digitalocean_firewall.go
+++ b/digitalocean/resource_digitalocean_firewall.go
@@ -85,6 +85,12 @@ func resourceDigitalOceanFirewall() *schema.Resource {
 						"port_range": {
 							Type:     schema.TypeString,
 							Optional: true,
+							DiffSuppressFunc: func(k, oldV, newV string, d *schema.ResourceData) bool {
+								if oldV == "0" && newV == "all" {
+									return true
+								}
+								return (oldV == newV)
+							},
 						},
 						"source_addresses": {
 							Type:     schema.TypeList,
@@ -122,6 +128,12 @@ func resourceDigitalOceanFirewall() *schema.Resource {
 						"port_range": {
 							Type:     schema.TypeString,
 							Optional: true,
+							DiffSuppressFunc: func(k, oldV, newV string, d *schema.ResourceData) bool {
+								if oldV == "0" && newV == "all" {
+									return true
+								}
+								return (oldV == newV)
+							},
 						},
 						"destination_addresses": {
 							Type:     schema.TypeList,


### PR DESCRIPTION
Fixes a bug mentioned in https://github.com/terraform-providers/terraform-provider-digitalocean/pull/39#issue-255538002

## Test results

```
TF_ACC=1 go test ./digitalocean -v -run=TestAccDigitalOceanFirewall_ -timeout 120m
=== RUN   TestAccDigitalOceanFirewall_AllowOnlyInbound
--- PASS: TestAccDigitalOceanFirewall_AllowOnlyInbound (8.38s)
=== RUN   TestAccDigitalOceanFirewall_AllowMultipleInbound
--- PASS: TestAccDigitalOceanFirewall_AllowMultipleInbound (10.12s)
=== RUN   TestAccDigitalOceanFirewall_AllowOnlyOutbound
--- PASS: TestAccDigitalOceanFirewall_AllowOnlyOutbound (9.54s)
=== RUN   TestAccDigitalOceanFirewall_AllowMultipleOutbound
--- PASS: TestAccDigitalOceanFirewall_AllowMultipleOutbound (8.71s)
=== RUN   TestAccDigitalOceanFirewall_MultipleInboundAndOutbound
--- PASS: TestAccDigitalOceanFirewall_MultipleInboundAndOutbound (8.90s)
=== RUN   TestAccDigitalOceanFirewall_fullPortRange
--- PASS: TestAccDigitalOceanFirewall_fullPortRange (8.87s)
=== RUN   TestAccDigitalOceanFirewall_ImportMultipleRules
--- PASS: TestAccDigitalOceanFirewall_ImportMultipleRules (8.85s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	63.391s
```