### PR TITLE
Use both TCP and UDP for DNS in firewall example

### DIFF
--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -44,11 +44,18 @@ resource "digitalocean_firewall" "web" {
     },
   ]
 
-  outbound_rule {
-    protocol                = "udp"
-    port_range              = "53"
-    destination_addresses   = ["0.0.0.0/0", "::/0"]
-  }
+  outbound_rule = [
+    {
+      protocol                = "tcp"
+      port_range              = "53"
+      destination_addresses   = ["0.0.0.0/0", "::/0"]
+    },
+    {
+      protocol                = "udp"
+      port_range              = "53"
+      destination_addresses   = ["0.0.0.0/0", "::/0"]
+    },
+  ]
 }
 ```
 


### PR DESCRIPTION
DNS uses both UDP and TCP. While UDP is usually the default TCP is
needed to handle larger responses. Especially so when the EDNS0
extension isn't available.

Yes, I do realize that this is just an example. Yet, a lot of people
learn from examples, and the misconception that DNS only needs UDP is
already way too common.