### PR TITLE
Manage CAA domain records

### DIFF
--- a/digitalocean/resource_digitalocean_record.go
+++ b/digitalocean/resource_digitalocean_record.go
@@ -74,6 +74,19 @@ func resourceDigitalOceanRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"flags": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -85,6 +98,7 @@ func resourceDigitalOceanRecordCreate(d *schema.ResourceData, meta interface{}) 
 		Type: d.Get("type").(string),
 		Name: d.Get("name").(string),
 		Data: d.Get("value").(string),
+		Tag:  d.Get("tag").(string),
 	}
 
 	var err error
@@ -110,6 +124,12 @@ func resourceDigitalOceanRecordCreate(d *schema.ResourceData, meta interface{}) 
 		newRecord.Weight, err = strconv.Atoi(weight)
 		if err != nil {
 			return fmt.Errorf("Failed to parse weight as an integer: %v", err)
+		}
+	}
+	if flags := d.Get("flags").(string); flags != "" {
+		newRecord.Flags, err = strconv.Atoi(flags)
+		if err != nil {
+			return fmt.Errorf("Failed to parse flags as an integer: %v", err)
 		}
 	}
 
@@ -145,7 +165,7 @@ func resourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	if t := rec.Type; t == "CNAME" || t == "MX" || t == "NS" || t == "SRV" {
+	if t := rec.Type; t == "CNAME" || t == "MX" || t == "NS" || t == "SRV" || t == "CAA" {
 		if rec.Data == "@" {
 			rec.Data = domain
 		}
@@ -159,6 +179,8 @@ func resourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("priority", strconv.Itoa(rec.Priority))
 	d.Set("port", strconv.Itoa(rec.Port))
 	d.Set("ttl", strconv.Itoa(rec.TTL))
+	d.Set("flags", strconv.Itoa(rec.Flags))
+	d.Set("tag", rec.Tag)
 
 	en := constructFqdn(rec.Name, d.Get("domain").(string))
 	log.Printf("[DEBUG] Constructed FQDN: %s", en)

--- a/digitalocean/resource_digitalocean_record_test.go
+++ b/digitalocean/resource_digitalocean_record_test.go
@@ -169,6 +169,39 @@ func TestAccDigitalOceanRecord_ExternalHostnameValue(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanRecord_FlagsAndTag(t *testing.T) {
+	var record godo.DomainRecord
+	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(
+					testAccCheckDigitalOceanRecordConfig_caa, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanRecordExists("digitalocean_record.foobar", &record),
+					testAccCheckDigitalOceanRecordAttributesHostname("a.foobar-test-terraform.net", &record),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "name", "terraform"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "domain", domain),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "value", "letsencrypt.org."),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "type", "CAA"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "flags", "1"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "tag", "issue"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanRecord_MX(t *testing.T) {
 	var record godo.DomainRecord
 	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
@@ -404,4 +437,20 @@ resource "digitalocean_record" "foobar" {
   name  = "terraform"
   value = "a.foobar-test-terraform.net."
   type  = "CNAME"
+}`
+
+const testAccCheckDigitalOceanRecordConfig_caa = `
+resource "digitalocean_domain" "foobar" {
+  name       = "%s"
+  ip_address = "192.168.0.10"
+}
+
+resource "digitalocean_record" "foobar" {
+  domain = "${digitalocean_domain.foobar.name}"
+
+  name  = "terraform"
+  type  = "CAA"
+  value = "letsencrypt.org."
+  flags = 1
+  tag   = "issue"
 }`

--- a/digitalocean/resource_digitalocean_record_test.go
+++ b/digitalocean/resource_digitalocean_record_test.go
@@ -183,7 +183,7 @@ func TestAccDigitalOceanRecord_FlagsAndTag(t *testing.T) {
 					testAccCheckDigitalOceanRecordConfig_caa, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanRecordExists("digitalocean_record.foobar", &record),
-					testAccCheckDigitalOceanRecordAttributesHostname("a.foobar-test-terraform.net", &record),
+					testAccCheckDigitalOceanRecordAttributesHostname("letsencrypt.org", &record),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "name", "terraform"),
 					resource.TestCheckResourceAttr(

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [v1.1.3] - 2018-03-07
+
+- #156 Handle non-json errors from the API - @aknuds1
+- #158 Update droplet example to use latest instance type - @dan-v
+
+## [v1.1.2] - 2018-03-06
+
+- #157 storage: list volumes should handle only name or only region params - @andrewsykim
+- #154 docs: replace first example with fully-runnable example - @xmudrii
+- #152 Handle flags & tag properties of domain record - @jaymecd
+
 ## [v1.1.1] - 2017-09-29
 
 - #151 Following user agent field recommendations - @joonas

--- a/vendor/github.com/digitalocean/godo/README.md
+++ b/vendor/github.com/digitalocean/godo/README.md
@@ -27,25 +27,37 @@ at the DigitalOcean Control Panel [Applications Page](https://cloud.digitalocean
 You can then use your token to create a new client:
 
 ```go
-import "golang.org/x/oauth2"
+package main
 
-pat := "mytoken"
+import (
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/godo/context"
+	"golang.org/x/oauth2"
+)
+
+const (
+    pat = "mytoken"
+)
+
 type TokenSource struct {
-    AccessToken string
+	AccessToken string
 }
 
 func (t *TokenSource) Token() (*oauth2.Token, error) {
-    token := &oauth2.Token{
-        AccessToken: t.AccessToken,
-    }
-    return token, nil
+	token := &oauth2.Token{
+		AccessToken: t.AccessToken,
+	}
+	return token, nil
 }
 
-tokenSource := &TokenSource{
-    AccessToken: pat,
+func main() {
+	tokenSource := &TokenSource{
+		AccessToken: pat,
+	}
+
+	oauthClient := oauth2.NewClient(context.Background(), tokenSource)
+	client := godo.NewClient(oauthClient)
 }
-oauthClient := oauth2.NewClient(context.Background(), tokenSource)
-client := godo.NewClient(oauthClient)
 ```
 
 ## Examples
@@ -59,7 +71,7 @@ dropletName := "super-cool-droplet"
 createRequest := &godo.DropletCreateRequest{
     Name:   dropletName,
     Region: "nyc3",
-    Size:   "512mb",
+    Size:   "s-1vcpu-1gb",
     Image: godo.DropletCreateImage{
         Slug: "ubuntu-14-04-x64",
     },

--- a/vendor/github.com/digitalocean/godo/domains.go
+++ b/vendor/github.com/digitalocean/godo/domains.go
@@ -77,6 +77,8 @@ type DomainRecord struct {
 	Port     int    `json:"port,omitempty"`
 	TTL      int    `json:"ttl,omitempty"`
 	Weight   int    `json:"weight,omitempty"`
+	Flags    int    `json:"flags"`
+	Tag      string `json:"tag,omitempty"`
 }
 
 // DomainRecordEditRequest represents a request to update a domain record.
@@ -88,6 +90,8 @@ type DomainRecordEditRequest struct {
 	Port     int    `json:"port,omitempty"`
 	TTL      int    `json:"ttl,omitempty"`
 	Weight   int    `json:"weight,omitempty"`
+	Flags    int    `json:"flags"`
+	Tag      string `json:"tag,omitempty"`
 }
 
 func (d Domain) String() string {

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -356,7 +356,7 @@ func CheckResponse(r *http.Response) error {
 	if err == nil && len(data) > 0 {
 		err := json.Unmarshal(data, errorResponse)
 		if err != nil {
-			return err
+			errorResponse.Message = string(data)
 		}
 	}
 

--- a/vendor/github.com/digitalocean/godo/storage.go
+++ b/vendor/github.com/digitalocean/godo/storage.go
@@ -85,6 +85,10 @@ func (svc *StorageServiceOp) ListVolumes(ctx context.Context, params *ListVolume
 	if params != nil {
 		if params.Region != "" && params.Name != "" {
 			path = fmt.Sprintf("%s?name=%s&region=%s", path, params.Name, params.Region)
+		} else if params.Region != "" {
+			path = fmt.Sprintf("%s?region=%s", path, params.Region)
+		} else if params.Name != "" {
+			path = fmt.Sprintf("%s?name=%s", path, params.Name)
 		}
 
 		if params.ListOptions != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -233,13 +233,11 @@
 			"revisionTime": "2016-10-29T20:57:26Z"
 		},
 		{
-			"checksumSHA1": "2dQN7GCITMHVNOVoV8kXPShK04w=",
+			"checksumSHA1": "zFLShJ+lf3Vu3qUgNEhuCCbweRw=",
 			"comment": "v0.9.0-20-gf75d769",
 			"path": "github.com/digitalocean/godo",
-			"revision": "77ea48de76a7b31b234d854f15d003c68bb2fb90",
-			"revisionTime": "2017-09-29T14:45:41Z",
-			"version": "v1.1.1",
-			"versionExact": "v1.1.1"
+			"revision": "801cee9569723107654606a8e00d79b56470072e",
+			"revisionTime": "2017-10-04T19:28:12Z"
 		},
 		{
 			"checksumSHA1": "YpWoCsk+u9H5ctWNKKSVPf4b2as=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -233,19 +233,21 @@
 			"revisionTime": "2016-10-29T20:57:26Z"
 		},
 		{
-			"checksumSHA1": "zFLShJ+lf3Vu3qUgNEhuCCbweRw=",
+			"checksumSHA1": "kugYAXPtqjIfuDzzFmu5xxaMPN0=",
 			"comment": "v0.9.0-20-gf75d769",
 			"path": "github.com/digitalocean/godo",
-			"revision": "801cee9569723107654606a8e00d79b56470072e",
-			"revisionTime": "2017-10-04T19:28:12Z"
+			"revision": "7a32b5ce17203924a21366d5031032fd326d5051",
+			"revisionTime": "2018-03-07T23:05:53Z",
+			"version": "v1.1",
+			"versionExact": "v1.1.3"
 		},
 		{
 			"checksumSHA1": "YpWoCsk+u9H5ctWNKKSVPf4b2as=",
 			"path": "github.com/digitalocean/godo/context",
-			"revision": "77ea48de76a7b31b234d854f15d003c68bb2fb90",
-			"revisionTime": "2017-09-29T14:45:41Z",
-			"version": "v1.1.1",
-			"versionExact": "v1.1.1"
+			"revision": "7a32b5ce17203924a21366d5031032fd326d5051",
+			"revisionTime": "2018-03-07T23:05:53Z",
+			"version": "v1.1.3",
+			"versionExact": "v1.1.3"
 		},
 		{
 			"checksumSHA1": "BCv50o5pDkoSG3vYKOSai1Z8p3w=",

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -41,6 +41,8 @@ The following arguments are supported:
 * `priority` - (Optional) The priority of the record, for MX and SRV
    records.
 * `ttl` - (Optional) The time to live for the record, in seconds.
+* `flags` - (Optional) The flags of the record (integer between 0-255), for CAA records.
+* `tag` - (Optional) Teh tag of the record (one of `issue`, `wildissue`, or `iodef`), for CAA records.
 
 ## Attributes Reference
 

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
    records.
 * `ttl` - (Optional) The time to live for the record, in seconds.
 * `flags` - (Optional) The flags of the record (integer between 0-255), for CAA records.
-* `tag` - (Optional) Teh tag of the record (one of `issue`, `wildissue`, or `iodef`), for CAA records.
+* `tag` - (Optional) The tag of the record (one of `issue`, `wildissue`, or `iodef`), for CAA records.
 
 ## Attributes Reference
 


### PR DESCRIPTION
`terraform` adjustment to manage `CAA` domain records via https://github.com/digitalocean/godo/pull/152 (not yet tagged)

All validation is delegated to the client.

Create a new `CAA` record:
```
resource "digitalocean_record" "example_caa_issue" {
        domain  = "${digitalocean_domain.example.name}"
        type    = "CAA"
        name    = "@"
        value   = "letsencrypt.org."
        ttl     = 1800
        flags   = 0
        tag     = "issue"
}
```

Evaluate execution plan:

```
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

digitalocean_domain.example: Refreshing state... (ID: example.com)
... [CLIPPED] ...

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + digitalocean_record.example_caa_issue
      id:       <computed>
      domain:   "example.com"
      flags:    <computed>
      fqdn:     <computed>
      name:     "@"
      port:     <computed>
      priority: <computed>
      tag:      "issue"
      ttl:      "1800"
      type:     "CAA"
      value:    "letsencrypt.org."
      weight:   <computed>


Plan: 1 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------
```