### PR TITLE
Correct the logic for resizing a droplet. Fixes 15

### DIFF
--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -361,7 +361,7 @@ func resourceDigitalOceanDropletUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	resizeDisk := d.Get("resize_disk").(bool)
-	if d.HasChange("size") || d.HasChange("resize_disk") && resizeDisk {
+	if resizeDisk && d.HasChange("size") {
 		newSize := d.Get("size")
 
 		_, _, err = client.DropletActions.PowerOff(context.Background(), id)


### PR DESCRIPTION
I'm new to this codebase, and fairly new to golang, so please forgive my ignorance.

This issue https://github.com/terraform-providers/terraform-provider-digitalocean/issues/15 describes a bug. 

The current/old logic says to power off and resize iff `(the size changes OR the resize disk field changes) AND resizeDisk is true`. That's logic does not seem correct to me. Instead we should power off and resize iff `resizeDisk is true AND d.HasChange("size")`.
