### PR TITLE
Adding digitalocean_domain data source

### DIFF
--- a/digitalocean/datasource_digitalocean_domain.go
+++ b/digitalocean/datasource_digitalocean_domain.go
@@ -16,18 +16,18 @@ func dataSourceDigitalOceanDomain() *schema.Resource {
 			"name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "name of the image",
+				Description: "name of the domain",
 			},
 			// computed attributes
 			"ttl": &schema.Schema{
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "slug or id of the image",
+				Description: "ttl of the domain",
 			},
 			"zone_file": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "minimum disk size required by the image",
+				Description: "zone file of the domain",
 			},
 		},
 	}

--- a/digitalocean/datasource_digitalocean_domain_test.go
+++ b/digitalocean/datasource_digitalocean_domain_test.go
@@ -1,0 +1,79 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceDigitalOceanDomain_Basic(t *testing.T) {
+	var domain godo.Domain
+	domainName := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDataSourceDigitalOceanDomainConfig_basic, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceDigitalOceanDomainExists("digitalocean_domain.foobar", &domain),
+					testAccCheckDataSourceDigitalOceanDomainAttributes(&domain, domainName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_domain.foobar", "name", domainName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDataSourceDigitalOceanDomainAttributes(domain *godo.Domain, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if domain.Name != name {
+			return fmt.Errorf("Bad name: %s", domain.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDataSourceDigitalOceanDomainExists(n string, domain *godo.Domain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*godo.Client)
+
+		foundDomain, _, err := client.Domains.Get(context.Background(), rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if foundDomain.Name != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		*domain = *foundDomain
+
+		return nil
+	}
+}
+
+const testAccCheckDataSourceDigitalOceanDomainConfig_basic = `
+data "digitalocean_domain" "foobar" {
+	name       = "%s"
+}`

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -18,7 +18,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"digitalocean_image": dataSourceDigitalOceanImage(),
+			"digitalocean_image":  dataSourceDigitalOceanImage(),
+			"digitalocean_domain": dataSourceDigitalOceanDomain(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -17,6 +17,11 @@
           <a href="/docs/providers/do/d/image.html">digitalocean_image</a>
                     </li>
                 </ul>
+                <ul class="nav nav-visible">
+                  <li<%= sidebar_current("docs-do-datasource-domain") %>>
+                    <a href="/docs/providers/do/d/domain.html">digitalocean_domain</a>
+                  </li>
+                </ul>
         </li>
 
         <li<%= sidebar_current("docs-do-resource") %>>

--- a/website/docs/d/domain.html.md
+++ b/website/docs/d/domain.html.md
@@ -1,0 +1,65 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_domain"
+sidebar_current: "docs-do-datasource-domain"
+description: |-
+  Get information on a domain.
+---
+
+# digitalocean_domain
+
+Get information on a domain. This data source provides the name, TTL, and zone
+file as configured on your Digital Ocean account. This is useful if the domain
+name in question is not managed by Terraform or you need to utilize TTL or zone
+file data.
+
+An error is triggered if the provided domain name is not managed with your
+Digital Ocean account.
+
+## Example Usage
+
+Get the zone file for a domain:
+
+```hcl
+data "digitalocean_domain" "example" {
+  name = "example.com"
+}
+
+output "domain_output" {
+  value = "${data.digitalocean_domain.example.zone_file}"
+}
+```
+
+```
+  $ terraform apply
+  
+data.digitalocean_domain.example: Refreshing state...
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+domain_output = $ORIGIN example.com.
+$TTL 1800
+example.com. IN SOA ns1.digitalocean.com. hostmaster.example.com. 1516944700 10800 3600 604800 1800
+example.com. 1800 IN NS ns1.digitalocean.com.
+example.com. 1800 IN NS ns2.digitalocean.com.
+example.com. 1800 IN NS ns3.digitalocean.com.
+www.example.com. 3600 IN A 176.107.155.137
+db.example.com. 3600 IN A 179.189.166.115
+jira.example.com. 3600 IN A 207.189.228.15
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - The name of the domain.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name`: See Argument Reference above.
+* `ttl`: The TTL of the domain.
+* `zone_file`: The zone file of the domain.


### PR DESCRIPTION
Hello,  not sure if others would find this useful but I've cobbled together a data source for domain names managed by a Digital Ocean account.  It seems to work well for me and I've done my best to bring it up to a point where it could be shared with others.  I'm no go programmer so any feedback would be much appreciated.  I ended up using both the `digitalocean_image` data source and the `digitalocean_domain` resource types as inspiration.  Thanks in advance.