### PR TITLE
Adding digitalocean_record data source

### DIFF
--- a/digitalocean/datasource_digitalocean_record.go
+++ b/digitalocean/datasource_digitalocean_record.go
@@ -1,0 +1,120 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceDigitalOceanRecord() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDigitalOceanRecordRead,
+		Schema: map[string]*schema.Schema{
+
+			"domain": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "domain of the name record",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "name of the record",
+			},
+			// computed attributes
+			"type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "type of the name record",
+			},
+			"id": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "id of the name record",
+			},
+			"data": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "name record data",
+			},
+			"priority": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "priority of the name record",
+			},
+			"port": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "port of the name record",
+			},
+			"ttl": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "ttl of the name record",
+			},
+			"weight": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "weight of the name record",
+			},
+			"flags": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "flags of the name record",
+			},
+			"tag": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "tag of the name record",
+			},
+		},
+	}
+}
+
+func dataSourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*godo.Client)
+	domain := d.Get("domain").(string)
+
+	opts := &godo.ListOptions{}
+
+	records, _, err := client.Domains.Records(context.Background(), domain, opts)
+	if err != nil {
+		d.SetId("")
+		return err
+	}
+	record, err := findRecordByName(records, d.Get("name").(string))
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(record.Name)
+	d.Set("id", record.ID)
+	d.Set("type", record.Type)
+	d.Set("name", record.Name)
+	d.Set("data", record.Data)
+	d.Set("priority", record.Priority)
+	d.Set("port", record.Port)
+	d.Set("ttl", record.TTL)
+	d.Set("weight", record.Weight)
+
+	return nil
+}
+
+func findRecordByName(records []godo.DomainRecord, name string) (*godo.DomainRecord, error) {
+	results := make([]godo.DomainRecord, 0)
+	for _, v := range records {
+		if v.Name == name {
+			results = append(results, v)
+		}
+	}
+	if len(results) == 1 {
+		return &results[0], nil
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no records found with name %s", name)
+	}
+	return nil, fmt.Errorf("too many records found (found %d, expected 1)", len(results))
+}

--- a/digitalocean/datasource_digitalocean_record_test.go
+++ b/digitalocean/datasource_digitalocean_record_test.go
@@ -1,0 +1,93 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceDigitalOceanRecord_Basic(t *testing.T) {
+	var record godo.DomainRecord
+	recordName := fmt.Sprintf("foo-%s", acctest.RandString(10))
+	recordDomain := fmt.Sprintf("bar-test-terraform-%s.com", acctest.RandString(10))
+	recordType := "A"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDataSourceDigitalOceanRecordConfig_basic, recordName, recordDomain, recordType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceDigitalOceanRecordExists("digitalocean_record.foobar", &record),
+					testAccCheckDataSourceDigitalOceanRecordAttributes(&record, recordName, recordType),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "name", recordName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "type", recordType),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDataSourceDigitalOceanRecordAttributes(record *godo.DomainRecord, name string, r_type string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if record.Name != name {
+			return fmt.Errorf("Bad name: %s", record.Name)
+		}
+
+		if record.Type != r_type {
+			return fmt.Errorf("Bad type: %s", record.Type)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDataSourceDigitalOceanRecordExists(n string, record *godo.DomainRecord) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*godo.Client)
+
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		domain := rs.Primary.Attributes["domain"]
+		id, err := strconv.Atoi(rs.Primary.ID)
+
+		foundRecord, _, err := client.Domains.Record(context.Background(), domain, id)
+
+		if err != nil {
+			return err
+		}
+
+		if foundRecord.Name != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		*record = *foundRecord
+
+		return nil
+	}
+}
+
+const testAccCheckDataSourceDigitalOceanRecordConfig_basic = `
+data "digitalocean_record" "foobar" {
+	name      = "%s"
+	domain    = "%s"
+	type			= "%s"
+}`

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -19,6 +19,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"digitalocean_image": dataSourceDigitalOceanImage(),
+			"digitalocean_record": dataSourceDigitalOceanRecord(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -18,7 +18,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"digitalocean_image": dataSourceDigitalOceanImage(),
+			"digitalocean_image":  dataSourceDigitalOceanImage(),
 			"digitalocean_record": dataSourceDigitalOceanRecord(),
 		},
 

--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -17,6 +17,11 @@
           <a href="/docs/providers/do/d/image.html">digitalocean_image</a>
                     </li>
                 </ul>
+                <ul class="nav nav-visible">
+                    <li<%= sidebar_current("docs-do-datasource-record") %>>
+                      <a href="/docs/providers/do/d/record.html">digitalocean_record</a>
+                    </li>
+                </ul>
         </li>
 
         <li<%= sidebar_current("docs-do-resource") %>>

--- a/website/docs/d/record.html.md
+++ b/website/docs/d/record.html.md
@@ -1,0 +1,69 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_record"
+sidebar_current: "docs-do-datasource-record"
+description: |-
+  Get information on a DNS record.
+---
+
+# digitalocean_record
+
+Get information on a DNS record. This data source provides the name, TTL, and zone
+file as configured on your Digital Ocean account. This is useful if the record
+in question is not managed by Terraform.
+
+An error is triggered if the provided domain name or record are not managed with
+your Digital Ocean account.
+
+## Example Usage
+
+Get data from a DNS record:
+
+```hcl
+data "digitalocean_record" "example" {
+  domain  = "example.com"
+  name    = "test"
+}
+
+output "record_type" {
+  value = "${data.digitalocean_record.example.type}"
+}
+output "record_ttl" {
+  value = "${data.digitalocean_record.example.ttl}"
+}
+```
+
+```
+  $ terraform apply
+
+data.digitalocean_record.example: Refreshing state...
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+record_ttl = 3600
+record_type = A
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - The name of the record.
+* `domain` - The domain name of the record.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name`: See Argument Reference above.
+* `type`:	The type of the DNS record. For example: A, CNAME, TXT, ...
+* `id`:	The host name, alias, or service being defined by the record.
+* `data`:	Variable data depending on record type. For example, the "data" value for an A record would be the IPv4 address to which the domain will be mapped. For a CAA record, it would contain the domain name of the CA being granted permission to issue certificates.
+* `priority`:	The priority for SRV and MX records.
+* `port`:	The port for SRV records.
+* `ttl`: This value is the time to live for the record, in seconds. This defines the time frame that clients can cache queried information before a refresh should be requested.
+* `weight`:	The weight for SRV records.
+* `flags`: An unsigned integer between 0-255 used for CAA records.
+* `tag`: The parameter tag for CAA records. Valid values are "issue", "wildissue", or "iodef"


### PR DESCRIPTION
Similar to #63,  I've cobbled together another data source for DNS records managed by a Digital Ocean account. It also seems to work well for me. I'm no go programmer so any feedback would be much appreciated. I ended up using both the digitalocean_image data source and the digitalocean_record resource types as inspiration. Thanks in advance.