### PR TITLE
Use an apex domain as the example name

### DIFF
--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -15,7 +15,7 @@ Provides a DigitalOcean domain resource.
 ```hcl
 # Create a new domain
 resource "digitalocean_domain" "default" {
-  name       = "www.example.com"
+  name       = "example.com"
   ip_address = "${digitalocean_droplet.foo.ipv4_address}"
 }
 ```


### PR DESCRIPTION
The problem with adding a domain like www.example.com is, when you create DNS records (such as one named 'blog') inside that zone, it ends up as a DNS record for blog.www.example.com. By adding the apex domain instead, DNS records will be created and work as expected, avoiding some occasional user confusion.