### PR TITLE
Update docs to use new size slugs.

### DIFF
--- a/examples/droplet/main.tf
+++ b/examples/droplet/main.tf
@@ -9,7 +9,7 @@ resource "digitalocean_droplet" "mywebserver" {
   ssh_keys           = [12345678]         # Key example
   image              = "${var.ubuntu}"
   region             = "${var.do_ams3}"
-  size               = "512mb"
+  size               = "s-1vcpu-1gb"
   private_networking = true
   backups            = true
   ipv6               = true

--- a/website/docs/d/image.html.md
+++ b/website/docs/d/image.html.md
@@ -33,7 +33,7 @@ resource "digitalocean_droplet" "example1" {
   image  = "${data.digitalocean_image.example1.image}"
   name   = "example-1"
   region = "nyc2"
-  size   = "512mb"
+  size   = "s-1vcpu-1gb"
 }
 ```
 

--- a/website/docs/r/droplet.html.markdown
+++ b/website/docs/r/droplet.html.markdown
@@ -20,7 +20,7 @@ resource "digitalocean_droplet" "web" {
   image  = "ubuntu-14-04-x64"
   name   = "web-1"
   region = "nyc2"
-  size   = "512mb"
+  size   = "s-1vcpu-1gb"
 }
 ```
 

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -16,7 +16,7 @@ modify, and delete Firewalls.
 ```hcl
 resource "digitalocean_droplet" "web" {
   name      = "web-1"
-  size      = "512mb"
+  size      = "s-1vcpu-1gb"
   image     = "centos-7-x64"
   region    = "nyc3"
 }

--- a/website/docs/r/floating_ip.html.markdown
+++ b/website/docs/r/floating_ip.html.markdown
@@ -15,7 +15,7 @@ Provides a DigitalOcean Floating IP to represent a publicly-accessible static IP
 ```hcl
 resource "digitalocean_droplet" "foobar" {
   name               = "baz"
-  size               = "1gb"
+  size               = "s-1vcpu-1gb"
   image              = "centos-5-8-x32"
   region             = "sgp1"
   ipv6               = true

--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -16,7 +16,7 @@ modify, and delete Load Balancers.
 ```hcl
 resource "digitalocean_droplet" "web" {
   name      = "web-1"
-  size      = "512mb"
+  size      = "s-1vcpu-1gb"
   image     = "centos-7-x64"
   region    = "nyc3"
 }

--- a/website/docs/r/tag.html.markdown
+++ b/website/docs/r/tag.html.markdown
@@ -26,7 +26,7 @@ resource "digitalocean_droplet" "web" {
   image  = "ubuntu-16-04-x64"
   name   = "web-1"
   region = "nyc3"
-  size   = "512mb"
+  size   = "s-1vcpu-1gb"
   tags   = ["${digitalocean_tag.foobar.id}"]
 }
 ```

--- a/website/docs/r/volume.markdown
+++ b/website/docs/r/volume.markdown
@@ -22,7 +22,7 @@ resource "digitalocean_volume" "foobar" {
 
 resource "digitalocean_droplet" "foobar" {
   name       = "baz"
-  size       = "1gb"
+  size       = "s-1vcpu-1gb"
   image      = "coreos-stable"
   region     = "nyc1"
   volume_ids = ["${digitalocean_volume.foobar.id}"]


### PR DESCRIPTION
At DO, we recently released new Droplet plans. This updates
the docs to reference the slugs for these plans in preparation
for the old ones to be deprecated. Hopefully this will help
head off confusion like in #74.

See:

https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/