### PR TITLE
Validate tag name when creating

### DIFF
--- a/digitalocean/resource_digitalocean_tag.go
+++ b/digitalocean/resource_digitalocean_tag.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -20,12 +21,23 @@ func resourceDigitalOceanTag() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateTagName,
 			},
 		},
 	}
+}
+
+var tagNameRe = regexp.MustCompile("^[a-z0-9:-_]{1,255}$")
+
+func validateTagName(value interface{}, key string) ([]string, []error) {
+	if !tagNameRe.MatchString(value.(string)) {
+		return nil, []error{fmt.Errorf("tags may contain letters, numbers, colons, dashes, and underscores; there is a limit of 255 characters per tag")}
+	}
+
+	return nil, nil
 }
 
 func resourceDigitalOceanTagCreate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
DigitalOcean only allows letters, numbers, colons, dashes and underscores as valid characters in a tag name. This commit validates that the assigned name is valid before calling DO's API.

Fixes #78