### PR TITLE
Add an override for the DigitalOcean API URL

### DIFF
--- a/digitalocean/config.go
+++ b/digitalocean/config.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"strings"
 	"time"
 
@@ -20,9 +21,10 @@ import (
 )
 
 type Config struct {
-	Token     string
-	AccessID  string
-	SecretKey string
+	Token       string
+	APIEndpoint string
+	AccessID    string
+	SecretKey   string
 }
 
 type CombinedConfig struct {
@@ -64,6 +66,12 @@ func (c *Config) Client() (*CombinedConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	apiURL, err := url.Parse(c.APIEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	client.BaseURL = apiURL
 
 	if logging.IsDebugOrHigher() {
 		do.OnRequestCompleted(logRequestAndResponse)

--- a/digitalocean/config.go
+++ b/digitalocean/config.go
@@ -62,7 +62,7 @@ func (c *Config) Client() (*CombinedConfig, error) {
 
 	userAgent := fmt.Sprintf("Terraform/%s", terraform.VersionString())
 
-	do, err := godo.New(oauth2.NewClient(oauth2.NoContext, tokenSrc), godo.SetUserAgent(userAgent))
+	godoClient, err := godo.New(oauth2.NewClient(oauth2.NoContext, tokenSrc), godo.SetUserAgent(userAgent))
 	if err != nil {
 		return nil, err
 	}
@@ -71,16 +71,16 @@ func (c *Config) Client() (*CombinedConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	client.BaseURL = apiURL
+	godoClient.BaseURL = apiURL
 
 	if logging.IsDebugOrHigher() {
-		do.OnRequestCompleted(logRequestAndResponse)
+		godoClient.OnRequestCompleted(logRequestAndResponse)
 	}
 
-	log.Printf("[INFO] DigitalOcean Client configured for URL: %s", do.BaseURL.String())
+	log.Printf("[INFO] DigitalOcean Client configured for URL: %s", godoClient.BaseURL.String())
 
 	return &CombinedConfig{
-		client:    do,
+		client:    godoClient,
 		accessID:  c.AccessID,
 		secretKey: c.SecretKey,
 	}, nil

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -15,6 +15,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("DIGITALOCEAN_TOKEN", nil),
 				Description: "The token key for API operations.",
 			},
+			"api_endpoint": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("DIGITALOCEAN_API_URL", "https://api.digitalocean.com"),
+				Description: "The URL to use for the DigitalOcean API.",
+			},
 			"spaces_access_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -71,9 +77,10 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		Token:     d.Get("token").(string),
-		AccessID:  d.Get("spaces_access_id").(string),
-		SecretKey: d.Get("spaces_secret_key").(string),
+		Token:       d.Get("token").(string),
+		APIEndpoint: d.Get("api_endpoint").(string),
+		AccessID:    d.Get("spaces_access_id").(string),
+		SecretKey:   d.Get("spaces_secret_key").(string),
 	}
 
 	return config.Client()

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -44,3 +44,6 @@ The following arguments are supported:
 * `spaces_secret_key` - (Optional) The secret access key used for Spaces API
   operations (Defaults to the value of the `SPACES_SECRET_ACCESS_KEY`
   environment variable).
+* `api_endpoint` - (Optional) This can be used to override the base URL for
+  DigitalOcean API requests (Defaults to the value of the `DIGITALOCEAN_API_URL`
+  environment variable or `https://api.digitalocean.com if unset).


### PR DESCRIPTION
This allows you to change the default URL for accessing the DigitalOcean
API. It's similar to what you would do when overriding an endpoint in
the AWS provider, only with the DO API it's an all or nothing change.