### PR TITLE
Don't panic when enabling private_networking or ipv6. (Fixes #67)

### DIFF
--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -450,8 +450,10 @@ func resourceDigitalOceanDropletUpdate(d *schema.ResourceData, meta interface{})
 		_, err = waitForDropletAttribute(
 			d, "true", []string{"", "false"}, "private_networking", meta)
 
-		return fmt.Errorf(
-			"Error waiting for private networking to be enabled on for droplet (%s): %s", d.Id(), err)
+		if err != nil {
+			return fmt.Errorf(
+				"Error waiting for private networking to be enabled on for droplet (%s): %s", d.Id(), err)
+		}
 	}
 
 	// As there is no way to disable IPv6, we only check if it needs to be enabled
@@ -616,7 +618,12 @@ func newDropletStateRefreshFunc(
 				return nil, "", fmt.Errorf("Error retrieving droplet: %s", err)
 			}
 
-			return &droplet, attr.(string), nil
+			switch attr.(type) {
+			case bool:
+				return &droplet, strconv.FormatBool(attr.(bool)), nil
+			default:
+				return &droplet, attr.(string), nil
+			}
 		}
 
 		return nil, "", nil

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -361,6 +361,41 @@ func TestAccDigitalOceanDroplet_PrivateNetworkingIpv6(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanDroplet_UpdatePrivateNetworkingIpv6(t *testing.T) {
+	var afterCreate, afterUpdate godo.Droplet
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterCreate),
+					testAccCheckDigitalOceanDropletAttributes(&afterCreate),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+				),
+			},
+
+			{
+				Config: testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterUpdate),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "private_networking", "true"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "ipv6", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanDroplet_Monitoring(t *testing.T) {
 	var droplet godo.Droplet
 	rInt := acctest.RandInt()
@@ -518,11 +553,11 @@ func testAccCheckDigitalOceanDropletAttributes_PrivateNetworkingIpv6(droplet *go
 			return fmt.Errorf("Bad image_slug: %s", droplet.Image.Slug)
 		}
 
-		if droplet.Size.Slug != "1gb" {
+		if droplet.Size.Slug != "512mb" {
 			return fmt.Errorf("Bad size_slug: %s", droplet.Size.Slug)
 		}
 
-		if droplet.Region.Slug != "sgp1" {
+		if droplet.Region.Slug != "nyc3" {
 			return fmt.Errorf("Bad region_slug: %s", droplet.Region.Slug)
 		}
 
@@ -706,14 +741,13 @@ resource "digitalocean_droplet" "foobar" {
 `, rInt)
 }
 
-// IPV6 only in singapore
 func testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name               = "baz-%d"
-  size               = "1gb"
+  name               = "foo-%d"
+  size               = "512mb"
   image              = "centos-7-x64"
-  region             = "sgp1"
+  region             = "nyc3"
   ipv6               = true
   private_networking = true
 }


### PR DESCRIPTION
This PR resolves issue #67. The panic was caused by `newDropletStateRefreshFunc` attempting to return a bool instead of a string. Additionally, if it had somehow gotten past that, there was no check whether `err` was `nil` or not before returning with the error. A new acceptance test was also added to exercise this functionality.

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDroplet_UpdatePrivateNetworkingIpv6'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDroplet_UpdatePrivateNetworkingIpv6 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDroplet_UpdatePrivateNetworkingIpv6
--- PASS: TestAccDigitalOceanDroplet_UpdatePrivateNetworkingIpv6 (70.61s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	70.614s
```