### PR TITLE
Set resize_disk to the default value on import.

### DIFF
--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -21,7 +21,7 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 		Update: resourceDigitalOceanDropletUpdate,
 		Delete: resourceDigitalOceanDropletDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceDigitalOceanDropletImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -328,6 +328,21 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("tags", droplet.Tags)
 
 	return nil
+}
+
+func resourceDigitalOceanDropletImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// This is a non API attribute. So set to the default setting in the schema.
+	d.Set("resize_disk", true)
+
+	err := resourceDigitalOceanDropletRead(d, meta)
+	if err != nil {
+		return nil, fmt.Errorf("invalid droplet id: %v", err)
+	}
+
+	results := make([]*schema.ResourceData, 1)
+	results[0] = d
+
+	return results, nil
 }
 
 func findIPv6AddrByType(d *godo.Droplet, addrType string) string {


### PR DESCRIPTION
This implements a new `resourceDigitalOceanDropletImport` function
so that we can handle some things differently while importing
than when using `resourceDigitalOceanDropletRead`.

In particular, this is needed here as `resize_disk` defaults to
`true`, but importing results in an empty value as it is a non-API
attribute. So when running `terraform apply` changes are found
regardless of the value in the tf file.

See: https://github.com/terraform-providers/terraform-provider-digitalocean/issues/76

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDroplet_importBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDroplet_importBasic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDroplet_importBasic
--- PASS: TestAccDigitalOceanDroplet_importBasic (36.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	36.913s
```