### PR TITLE
When IPv6 and/or private networking are not enabled, default their addresses to "".

### DIFF
--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -310,6 +310,9 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("ipv6", true)
 		d.Set("ipv6_address", strings.ToLower(publicIPv6))
 		d.Set("ipv6_address_private", findIPv6AddrByType(droplet, "private"))
+	} else {
+		d.Set("ipv6", false)
+		d.Set("ipv6_address", "")
 	}
 
 	d.Set("ipv4_address", findIPv4AddrByType(droplet, "public"))
@@ -317,6 +320,9 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 	if privateIPv4 := findIPv4AddrByType(droplet, "private"); privateIPv4 != "" {
 		d.Set("private_networking", true)
 		d.Set("ipv4_address_private", privateIPv4)
+	} else {
+		d.Set("private_networking", false)
+		d.Set("ipv4_address_private", "")
 	}
 
 	// Initialize the connection info

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -78,6 +78,10 @@ func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 						"digitalocean_droplet.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "user_data", "foobar"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "ipv4_address_private", ""),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "ipv6_address", ""),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes: #92 

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDroplet_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDroplet_Basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDroplet_Basic
--- PASS: TestAccDigitalOceanDroplet_Basic (30.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	30.102s
```