### PR TITLE
Updated the state representation of the `user_data` droplet property to a hashed one

### DIFF
--- a/digitalocean/hash.go
+++ b/digitalocean/hash.go
@@ -1,0 +1,11 @@
+package digitalocean
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+)
+
+func HashString(s string) string {
+	hash := sha1.Sum([]byte(s))
+	return hex.EncodeToString(hash[:])
+}

--- a/website/docs/r/droplet.html.markdown
+++ b/website/docs/r/droplet.html.markdown
@@ -29,7 +29,7 @@ resource "digitalocean_droplet" "web" {
 The following arguments are supported:
 
 * `image` - (Required) The Droplet image ID or slug.
-* `name` - (Required) The Droplet name
+* `name` - (Required) The Droplet name.
 * `region` - (Required) The region to start in
 * `size` - (Required) The unique slug that indentifies the type of Droplet. You can find a list of available slugs on [DigitalOcean API documentation](https://developers.digitalocean.com/documentation/v2/#list-all-sizes)
 * `backups` - (Optional) Boolean controlling if backups are made. Defaults to


### PR DESCRIPTION
The `user_data` property of the `digitalocean_droplet` resource was updated to use the hash of the value to save in the state and use for diffs instead of the full value, which can be quite large. This way the actual value won't be shown in the console when doing diffs. This increases visibility and clarity of the output, as well as prevents potential sensitive data from being shown.

Backward compatibility for existing state files with full `user_data` values saved is preserved.

In addition, the PR includes validations for the droplet properties and minor fixes and enhancements to the codebase of the resource.

Resolves #65 