### PR TITLE
Fixed an issue with force recreating droplets when using an older terraform state

### DIFF
--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -24,6 +24,8 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceDigitalOceanDropletImport,
 		},
+		MigrateState:  resourceDigitalOceanDropletMigrateState,
+		SchemaVersion: 1,
 
 		Schema: map[string]*schema.Schema{
 			"image": {
@@ -97,10 +99,9 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 			},
 
 			"backups": {
-				Type:             schema.TypeBool,
-				Optional:         true,
-				Default:          false,
-				DiffSuppressFunc: suppressDropletUnsetBool,
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
 			},
 
 			"ipv6": {
@@ -174,11 +175,10 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 			},
 
 			"monitoring": {
-				Type:             schema.TypeBool,
-				Optional:         true,
-				ForceNew:         true,
-				Default:          false,
-				DiffSuppressFunc: suppressDropletUnsetBool,
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
 			},
 
 			"tags": tagsSchema(),
@@ -727,10 +727,6 @@ func detachVolumeIDOnDroplet(d *schema.ResourceData, volumeID string, meta inter
 	}
 
 	return nil
-}
-
-func suppressDropletUnsetBool(k, old, new string, d *schema.ResourceData) bool {
-	return old == "" && new == "false"
 }
 
 func expandSshKeys(sshKeys []interface{}) ([]godo.DropletCreateSSHKey, error) {

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -97,9 +97,10 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 			},
 
 			"backups": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Default:          false,
+				DiffSuppressFunc: suppressDropletUnsetBool,
 			},
 
 			"ipv6": {
@@ -173,10 +174,11 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 			},
 
 			"monitoring": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  false,
+				Type:             schema.TypeBool,
+				Optional:         true,
+				ForceNew:         true,
+				Default:          false,
+				DiffSuppressFunc: suppressDropletUnsetBool,
 			},
 
 			"tags": tagsSchema(),
@@ -357,8 +359,6 @@ func resourceDigitalOceanDropletImport(d *schema.ResourceData, meta interface{})
 	// This is a non API attribute. So set to the default setting in the schema.
 	d.Set("resize_disk", true)
 	d.Set("backups", false)
-	d.Set("ipv6", false)
-	d.Set("private_networking", false)
 	d.Set("monitoring", false)
 
 	err := resourceDigitalOceanDropletRead(d, meta)
@@ -727,6 +727,10 @@ func detachVolumeIDOnDroplet(d *schema.ResourceData, volumeID string, meta inter
 	}
 
 	return nil
+}
+
+func suppressDropletUnsetBool(k, old, new string, d *schema.ResourceData) bool {
+	return old == "" && new == "false"
 }
 
 func expandSshKeys(sshKeys []interface{}) ([]godo.DropletCreateSSHKey, error) {

--- a/digitalocean/resource_digitalocean_droplet_migrate.go
+++ b/digitalocean/resource_digitalocean_droplet_migrate.go
@@ -1,0 +1,39 @@
+package digitalocean
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceDigitalOceanDropletMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+
+	switch v {
+	case 0:
+		log.Println("[INFO] Found DigitalOcean Droplet State v0; migrating to v1")
+		return migrateDigitalOceanDropletStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateDigitalOceanDropletStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] DigitalOcean Droplet Attributes before Migration: %#v", is.Attributes)
+
+	if _, ok := is.Attributes["backups"]; !ok {
+		is.Attributes["backups"] = "false"
+	}
+	if _, ok := is.Attributes["monitoring"]; !ok {
+		is.Attributes["monitoring"] = "false"
+	}
+
+	log.Printf("[DEBUG] DigitalOcean Droplet Attributes after State Migration: %#v", is.Attributes)
+
+	return is, nil
+}

--- a/digitalocean/resource_digitalocean_droplet_migrate_test.go
+++ b/digitalocean/resource_digitalocean_droplet_migrate_test.go
@@ -1,0 +1,55 @@
+package digitalocean
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestDigitalOceanDropletMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		ID           string
+		Attributes   map[string]string
+		Expected     map[string]string
+	}{
+		"v0_1_with_values": {
+			StateVersion: 0,
+			ID:           "id",
+			Attributes: map[string]string{
+				"backups":    "true",
+				"monitoring": "false",
+			},
+			Expected: map[string]string{
+				"backups":    "true",
+				"monitoring": "false",
+			},
+		},
+		"v0_1_without_values": {
+			StateVersion: 0,
+			ID:           "id",
+			Attributes:   map[string]string{},
+			Expected: map[string]string{
+				"backups":    "false",
+				"monitoring": "false",
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceDigitalOceanDropletMigrateState(tc.StateVersion, is, nil)
+
+		if err != nil {
+			t.Fatalf("bad: %q, err: %#v", tn, err)
+		}
+
+		if !reflect.DeepEqual(tc.Expected, is.Attributes) {
+			t.Fatalf("Bad Droplet Migrate\n\n. Got: %+v\n\n expected: %+v", is.Attributes, tc.Expected)
+		}
+	}
+}


### PR DESCRIPTION
Fixes a force recreate of a droplet If you have a state file from an older version of the terraform provider and didn't specify the `monitoring` or `backups` property in the resource.