### PR TITLE
Enable setting a dns' record weight to 0 (updated godo SDK)

### DIFF
--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [v1.4.2] - 2018-08-30
+
+- #178 Allowing creating domain records with weight of 0 - @TFaga
+- #177 Adding `VolumeLimit` to account - @lxfontes
+
 ## [v1.4.1] - 2018-08-23
 
 - #176 Fix cdn flush cache API endpoint - @sunny-b

--- a/vendor/github.com/digitalocean/godo/account.go
+++ b/vendor/github.com/digitalocean/godo/account.go
@@ -24,6 +24,7 @@ var _ AccountService = &AccountServiceOp{}
 type Account struct {
 	DropletLimit    int    `json:"droplet_limit,omitempty"`
 	FloatingIPLimit int    `json:"floating_ip_limit,omitempty"`
+	VolumeLimit     int    `json:"volume_limit,omitempty"`
 	Email           string `json:"email,omitempty"`
 	UUID            string `json:"uuid,omitempty"`
 	EmailVerified   bool   `json:"email_verified,omitempty"`

--- a/vendor/github.com/digitalocean/godo/domains.go
+++ b/vendor/github.com/digitalocean/godo/domains.go
@@ -75,7 +75,7 @@ type DomainRecord struct {
 	Priority int    `json:"priority"`
 	Port     int    `json:"port,omitempty"`
 	TTL      int    `json:"ttl,omitempty"`
-	Weight   int    `json:"weight,omitempty"`
+	Weight   int    `json:"weight"`
 	Flags    int    `json:"flags"`
 	Tag      string `json:"tag,omitempty"`
 }
@@ -88,7 +88,7 @@ type DomainRecordEditRequest struct {
 	Priority int    `json:"priority"`
 	Port     int    `json:"port,omitempty"`
 	TTL      int    `json:"ttl,omitempty"`
-	Weight   int    `json:"weight,omitempty"`
+	Weight   int    `json:"weight"`
 	Flags    int    `json:"flags"`
 	Tag      string `json:"tag,omitempty"`
 }

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.4.1"
+	libraryVersion = "1.4.2"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -251,13 +251,13 @@
 			"revisionTime": "2016-10-29T20:57:26Z"
 		},
 		{
-			"checksumSHA1": "YkfXtYXa+nInWIOfBeHVCXWvXQs=",
+			"checksumSHA1": "aiCBBVRj3GySoe6VRkpitpVQYdU=",
 			"comment": "v0.9.0-20-gf75d769",
 			"path": "github.com/digitalocean/godo",
-			"revision": "ddc940d8ef8b736b5cdfc47f24cdf95b9a4b73f6",
-			"revisionTime": "2018-08-23T18:38:25Z",
-			"version": "v1.4.1",
-			"versionExact": "v1.4.1"
+			"revision": "6a6ce62154ba780ecbb97bbbb13a4e9e0b157070",
+			"revisionTime": "2018-08-30T17:48:58Z",
+			"version": "v1.4.2",
+			"versionExact": "v1.4.2"
 		},
 		{
 			"checksumSHA1": "HbOJxa+FsQ1TTsF+BkHAvzqqZv4=",


### PR DESCRIPTION
This PR includes the new version of the godo SDK (v1.4.2), that includes support for setting the weight of a dns record to zero.