### PR TITLE
Refactored support for setting the volumes filesystem type and label

### DIFF
--- a/digitalocean/resource_digitalocean_volume_test.go
+++ b/digitalocean/resource_digitalocean_volume_test.go
@@ -176,6 +176,47 @@ resource "digitalocean_droplet" "foobar" {
 }`, vName, rInt)
 }
 
+func TestAccDigitalOceanVolume_LegacyFilesystemType(t *testing.T) {
+	name := fmt.Sprintf("volume-%s", acctest.RandString(10))
+
+	volume := godo.Volume{
+		Name: name,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanVolumeConfig_legacy_filesystem_type, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &volume),
+					resource.TestCheckResourceAttr(
+						"digitalocean_volume.foobar", "name", name),
+					resource.TestCheckResourceAttr(
+						"digitalocean_volume.foobar", "size", "100"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_volume.foobar", "region", "nyc1"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_volume.foobar", "description", "peace makes plenty"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_volume.foobar", "filesystem_type", "xfs"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckDigitalOceanVolumeConfig_legacy_filesystem_type = `
+resource "digitalocean_volume" "foobar" {
+	region      = "nyc1"
+	name        = "%s"
+	size        = 100
+	description = "peace makes plenty"
+	filesystem_type = "xfs"
+}`
+
 func TestAccDigitalOceanVolume_FilesystemType(t *testing.T) {
 	name := fmt.Sprintf("volume-%s", acctest.RandString(10))
 
@@ -201,7 +242,13 @@ func TestAccDigitalOceanVolume_FilesystemType(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_volume.foobar", "description", "peace makes plenty"),
 					resource.TestCheckResourceAttr(
+						"digitalocean_volume.foobar", "initial_filesystem_type", "xfs"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_volume.foobar", "initial_filesystem_label", "label"),
+					resource.TestCheckResourceAttr(
 						"digitalocean_volume.foobar", "filesystem_type", "xfs"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_volume.foobar", "filesystem_label", "label"),
 				),
 			},
 		},
@@ -214,7 +261,8 @@ resource "digitalocean_volume" "foobar" {
 	name        = "%s"
 	size        = 100
 	description = "peace makes plenty"
-	filesystem_type = "xfs"
+	initial_filesystem_type = "xfs"
+	initial_filesystem_label = "label"
 }`
 
 func TestAccDigitalOceanVolume_Resize(t *testing.T) {

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -51,7 +51,7 @@ The following attributes are exported:
 * `id` - The unique identifier for the block storage volume.
 * `filesystem_type` - Filesystem type (`xfs` or `ext4`) for the block storage volume.
 * `filesystem_label` - Filesystem label for the block storage volume.
-* `droplet_ids` - A list of associated droplet ids
+* `droplet_ids` - A list of associated droplet ids.
 
 
 ## Import
@@ -59,5 +59,5 @@ The following attributes are exported:
 Volumes can be imported using the `volume id`, e.g.
 
 ```
-terraform import digitalocean_volume.volumea 506f78a4-e098-11e5-ad9f-000f53306ae1
+terraform import digitalocean_volume.volume 506f78a4-e098-11e5-ad9f-000f53306ae1
 ```

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -25,7 +25,11 @@ resource "digitalocean_droplet" "foobar" {
   size       = "s-1vcpu-1gb"
   image      = "coreos-stable"
   region     = "nyc1"
-  volume_ids = ["${digitalocean_volume.foobar.id}"]
+}
+
+resource "digitalocean_volume_attachment" "foobar" {
+  droplet_id = "${digitalocean_droplet.foobar.id}"
+  volume_id = "${digitalocean_volume.foobar.id}"
 }
 ```
 
@@ -37,14 +41,17 @@ The following arguments are supported:
 * `name` - (Required) A name for the block storage volume. Must be lowercase and be composed only of numbers, letters and "-", up to a limit of 64 characters.
 * `size` - (Required) The size of the block storage volume in GiB. If updated, can only be expanded.
 * `description` - (Optional) A free-form text field up to a limit of 1024 bytes to describe a block storage volume.
-* `filesystem_type` - (Optional) Filesystem type (`xfs` or `ext4`) for the block storage volume.
-* `droplet_ids` - (Computed) A list of associated droplet ids
+* `initial_filesystem_type` - (Optional) Initial filesystem type (`xfs` or `ext4`) for the block storage volume.
+* `initial_filesystem_label` - (Optional) Initial filesystem label for the block storage volume.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The unique identifier for the block storage volume.
+* `filesystem_type` - Filesystem type (`xfs` or `ext4`) for the block storage volume.
+* `filesystem_label` - Filesystem label for the block storage volume.
+* `droplet_ids` - A list of associated droplet ids
 
 
 ## Import


### PR DESCRIPTION
The PR splits out the volume properties for the filesystem type/label that the volume is initially created with and the volumes current filesystem type/label. The reason behind the change is because the filesystem can not be changed through the API after the fact. However if the filesystem is changed by the droplet, the changes will be reflected in the API and consequentially the terraform state file on refresh.

The changes should be fully backward compatibly with a deprecation message for using the old property.