### PR TITLE
Ensure image ID set to state when importing a Droplet (Fixes: #144).

### DIFF
--- a/digitalocean/import_digitalocean_droplet_test.go
+++ b/digitalocean/import_digitalocean_droplet_test.go
@@ -1,10 +1,14 @@
 package digitalocean
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDigitalOceanDroplet_importBasic(t *testing.T) {
@@ -29,4 +33,75 @@ func TestAccDigitalOceanDroplet_importBasic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccDigitalOceanDroplet_ImportWithNoImageSlug(t *testing.T) {
+	rInt := acctest.RandInt()
+	var droplet godo.Droplet
+	var snapshotId []int
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanDropletConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
+					takeDropletSnapshot(rInt, &droplet, &snapshotId),
+				),
+			},
+			{
+				Config: testAccCheckDigitalOceanDropletConfig_fromSnapshot(rInt),
+			},
+			{
+				ResourceName:      "digitalocean_droplet.from-snapshot",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"ssh_keys", "user_data", "resize_disk"}, //we ignore the ssh_keys, resize_disk and user_data as we do not set to state
+			},
+			{
+				Config: " ",
+				Check: resource.ComposeTestCheckFunc(
+					deleteDropletSnapshots(&snapshotId),
+				),
+			},
+		},
+	})
+}
+
+func takeDropletSnapshot(rInt int, droplet *godo.Droplet, snapshotId *[]int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*godo.Client)
+
+		action, _, err := client.DropletActions.Snapshot(context.Background(), (*droplet).ID, fmt.Sprintf("snap-%d", rInt))
+		if err != nil {
+			return err
+		}
+		waitForAction(client, action)
+
+		retrieveDroplet, _, err := client.Droplets.Get(context.Background(), (*droplet).ID)
+		if err != nil {
+			return err
+		}
+		*snapshotId = retrieveDroplet.SnapshotIDs
+		return nil
+	}
+}
+
+func testAccCheckDigitalOceanDropletConfig_fromSnapshot(rInt int) string {
+	return fmt.Sprintf(`
+data "digitalocean_image" "snapshot" {
+  name = "snap-%d"
+}
+
+resource "digitalocean_droplet" "from-snapshot" {
+  name      = "foo-%d"
+  size      = "512mb"
+  image     = "${data.digitalocean_image.snapshot.id}"
+  region    = "nyc3"
+  user_data = "foobar"
+}`, rInt, rInt)
 }

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -304,8 +304,8 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 	_, err = strconv.Atoi(d.Get("image").(string))
 	if err == nil || droplet.Image.Slug == "" {
 		// The image field is provided as an ID (number), or
-		// the image bash no slug. In both cases we store it as an ID.
-		d.Set("image", droplet.Image.ID)
+		// the image has no slug. In both cases we store it as an ID.
+		d.Set("image", godo.Stringify(droplet.Image.ID))
 	} else {
 		d.Set("image", droplet.Image.Slug)
 	}

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -90,6 +90,7 @@ func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 func TestAccDigitalOceanDroplet_WithID(t *testing.T) {
 	var droplet godo.Droplet
 	rInt := acctest.RandInt()
+	slug := "centos-7-x64"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -97,7 +98,7 @@ func TestAccDigitalOceanDroplet_WithID(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_withID(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_withID(rInt, slug),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 				),
@@ -651,10 +652,10 @@ resource "digitalocean_droplet" "foobar" {
 }`, rInt)
 }
 
-func testAccCheckDigitalOceanDropletConfig_withID(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_withID(rInt int, slug string) string {
 	return fmt.Sprintf(`
 data "digitalocean_image" "foobar" {
-  slug = "centos-7-x64"
+  slug = "%s"
 }
 
 resource "digitalocean_droplet" "foobar" {
@@ -663,7 +664,7 @@ resource "digitalocean_droplet" "foobar" {
   image     = "${data.digitalocean_image.foobar.id}"
   region    = "nyc3"
   user_data = "foobar"
-}`, rInt)
+}`, slug, rInt)
 }
 
 func testAccCheckDigitalOceanDropletConfig_withSSH(rInt int) string {


### PR DESCRIPTION
When importing a Droplet based on an image that no longer has a slug (or never had one, e.g. a snapshot), the image ID is not properly being set to state. This had not been an issue in the past as we did not validate that the image value was not an empty string.

This PR ensures the correct value is set.

