### PR TITLE
Suppress diff for dns names on custom certificate resources (Fixes: #146)

### DIFF
--- a/digitalocean/resource_digitalocean_certificate.go
+++ b/digitalocean/resource_digitalocean_certificate.go
@@ -60,6 +60,7 @@ func resourceDigitalOceanCertificate() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"private_key", "leaf_certificate", "certificate_chain"},
+				// The domains attribute is computed for custom certs and should be ignored in diffs.
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return d.Get("type") == "custom"
 				},

--- a/digitalocean/resource_digitalocean_certificate.go
+++ b/digitalocean/resource_digitalocean_certificate.go
@@ -60,6 +60,9 @@ func resourceDigitalOceanCertificate() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"private_key", "leaf_certificate", "certificate_chain"},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return d.Get("type") == "custom"
+				},
 			},
 
 			"type": {

--- a/digitalocean/resource_digitalocean_certificate_test.go
+++ b/digitalocean/resource_digitalocean_certificate_test.go
@@ -1,10 +1,18 @@
 package digitalocean
 
 import (
+	"bytes"
 	"context"
+	crand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -90,17 +98,74 @@ func testAccCheckDigitalOceanCertificateExists(n string, cert *godo.Certificate)
 }
 
 func generateTestCertMaterial(t *testing.T) (string, string, string) {
-	leafCertMaterial, privateKeyMaterial, err := acctest.RandTLSCert("Acme Co")
+	leafCertMaterial, privateKeyMaterial, err := randTLSCert("Acme Co", "example.com")
 	if err != nil {
 		t.Fatalf("Cannot generate test TLS certificate: %s", err)
 	}
-	rootCertMaterial, _, err := acctest.RandTLSCert("Acme Go")
+	rootCertMaterial, _, err := randTLSCert("Acme Go", "example.com")
 	if err != nil {
 		t.Fatalf("Cannot generate test TLS certificate: %s", err)
 	}
 	certChainMaterial := fmt.Sprintf("%s\n%s", strings.TrimSpace(rootCertMaterial), leafCertMaterial)
 
 	return privateKeyMaterial, leafCertMaterial, certChainMaterial
+}
+
+// Based on Terraform's acctest.RandTLSCert, but allows for passing DNS name.
+func randTLSCert(orgName string, dnsName string) (string, string, error) {
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(int64(acctest.RandInt())),
+		Subject: pkix.Name{
+			Organization: []string{orgName},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{dnsName},
+	}
+
+	privateKey, privateKeyPEM, err := genPrivateKey()
+	if err != nil {
+		return "", "", err
+	}
+
+	cert, err := x509.CreateCertificate(crand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return "", "", err
+	}
+
+	certPEM, err := pemEncode(cert, "CERTIFICATE")
+	if err != nil {
+		return "", "", err
+	}
+
+	return certPEM, privateKeyPEM, nil
+}
+
+func genPrivateKey() (*rsa.PrivateKey, string, error) {
+	privateKey, err := rsa.GenerateKey(crand.Reader, 1024)
+	if err != nil {
+		return nil, "", err
+	}
+
+	privateKeyPEM, err := pemEncode(x509.MarshalPKCS1PrivateKey(privateKey), "RSA PRIVATE KEY")
+	if err != nil {
+		return nil, "", err
+	}
+
+	return privateKey, privateKeyPEM, nil
+}
+
+func pemEncode(b []byte, block string) (string, error) {
+	var buf bytes.Buffer
+	pb := &pem.Block{Type: block, Bytes: b}
+	if err := pem.Encode(&buf, pb); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
 }
 
 func testAccCheckDigitalOceanCertificateConfig_basic(rInt int, privateKeyMaterial, leafCert, certChain string) string {


### PR DESCRIPTION
When creating a custom certificate, the DigitalOcean API does not accept the `domains` attribute. This is only used when creating a Let's Encrypt certificate. Though the API does return this attribute when reading an existing custom certificate as the information is inferred from the provided certificate. This leads to the situation seen in #146. This PR resolves this issue by suppressing the diff for the `domains` attribute when the `type` is `custom`.

Most of the code added here is in the test. Our previous test did not catch this issue as it used Terraform's `acctest.RandTLSCert` to generate the test data. This function does not set the DNS names for the certificate. The new code is based on it, but allows for passing DNS name.