### PR TITLE
Fixes issue 158 relating to Firewall

### DIFF
--- a/digitalocean/resource_digitalocean_firewall.go
+++ b/digitalocean/resource_digitalocean_firewall.go
@@ -41,7 +41,7 @@ func resourceDigitalOceanFirewall() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"protocol": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"tcp",
 								"udp",
@@ -86,7 +86,7 @@ func resourceDigitalOceanFirewall() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"protocol": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"tcp",
 								"udp",


### PR DESCRIPTION
fixes #158 158
Make protocol optional in both inbound and outbound ports.

This was changed in version 1.0.0 and the bug was reported shortly afterwards.
TBH not entirely sure why this fix works, but I am assuming it is something to do with the way that Go reads interfaces  
