### PR TITLE
Acceptance test sweeper improvements

### DIFF
--- a/digitalocean/datasource_digitalocean_droplet_snapshot_test.go
+++ b/digitalocean/datasource_digitalocean_droplet_snapshot_test.go
@@ -128,7 +128,7 @@ data "digitalocean_droplet_snapshot" "foobar" {
 const testAccCheckDataSourceDigitalOceanDropletSnapshot_regex = `
 resource "digitalocean_droplet" "foo" {
   region      = "nyc1"
-  name        = "droplet-%d"
+  name        = "foo-%d"
   size        = "512mb"
   image  			= "centos-7-x64"
   ipv6   			= true
@@ -147,7 +147,7 @@ data "digitalocean_droplet_snapshot" "foobar" {
 const testAccCheckDataSourceDigitalOceanDropletSnapshot_region = `
 resource "digitalocean_droplet" "foo" {
   region      = "nyc1"
-  name        = "droplet-nyc-%d"
+  name        = "foo-nyc-%d"
   size        = "512mb"
   image  			= "centos-7-x64"
   ipv6   			= true
@@ -155,7 +155,7 @@ resource "digitalocean_droplet" "foo" {
 
 resource "digitalocean_droplet" "bar" {
   region      = "lon1"
-  name        = "droplet-lon-%d"
+  name        = "bar-lon-%d"
   size        = "512mb"
   image  			= "centos-7-x64"
   ipv6   			= true

--- a/digitalocean/datasource_digitalocean_droplet_snapshot_test.go
+++ b/digitalocean/datasource_digitalocean_droplet_snapshot_test.go
@@ -108,7 +108,7 @@ func testAccCheckDataSourceDigitalOceanDropletSnapshotExists(n string, snapshot 
 
 const testAccCheckDataSourceDigitalOceanDropletSnapshot_basic = `
 resource "digitalocean_droplet" "foo" {
-  name   = "%d"
+  name   = "foo-%d"
   size   = "512mb"
   image  = "centos-7-x64"
   region = "nyc3"

--- a/digitalocean/datasource_digitalocean_droplet_test.go
+++ b/digitalocean/datasource_digitalocean_droplet_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccDataSourceDigitalOceanDroplet_Basic(t *testing.T) {
 	var droplet godo.Droplet
-	name := fmt.Sprintf("droplet-%s", acctest.RandString(10))
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/digitalocean/datasource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer_test.go
@@ -90,7 +90,7 @@ resource "digitalocean_tag" "foo" {
 resource "digitalocean_droplet" "foo" {
   count              = 2
   image              = "ubuntu-18-04-x64"
-  name               = "droplet-%d-${count.index}"
+  name               = "foo-%d-${count.index}"
   region             = "nyc3"
   size               = "512mb"
   private_networking = true

--- a/digitalocean/datasource_digitalocean_record_test.go
+++ b/digitalocean/datasource_digitalocean_record_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccDataSourceDigitalOceanRecord_Basic(t *testing.T) {
 	var record godo.DomainRecord
 	recordName := fmt.Sprintf("foo-%s", acctest.RandString(10))
-	recordDomain := fmt.Sprintf("bar-test-terraform-%s.com", acctest.RandString(10))
+	recordDomain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
 	recordType := "A"
 
 	resource.Test(t, resource.TestCase{

--- a/digitalocean/resource_digitalocean_certificate_test.go
+++ b/digitalocean/resource_digitalocean_certificate_test.go
@@ -35,7 +35,7 @@ func testSweepCertificate(region string) error {
 		return err
 	}
 
-	client := meta.(*godo.Client)
+	client := meta.(*CombinedConfig).godoClient()
 
 	opt := &godo.ListOptions{PerPage: 200}
 	certs, _, err := client.Certificates.List(context.Background(), opt)

--- a/digitalocean/resource_digitalocean_domain_test.go
+++ b/digitalocean/resource_digitalocean_domain_test.go
@@ -27,7 +27,7 @@ func testSweepDomain(region string) error {
 		return err
 	}
 
-	client := meta.(*godo.Client)
+	client := meta.(*CombinedConfig).godoClient()
 
 	opt := &godo.ListOptions{PerPage: 200}
 	domains, _, err := client.Domains.List(context.Background(), opt)

--- a/digitalocean/resource_digitalocean_droplet_snapshot_test.go
+++ b/digitalocean/resource_digitalocean_droplet_snapshot_test.go
@@ -35,7 +35,7 @@ func testSweepDropletSnapshots(region string) error {
 	}
 
 	for _, s := range snapshots {
-		if strings.HasPrefix(s.Name, "snapshot-") {
+		if strings.HasPrefix(s.Name, "snapshot-") || strings.HasPrefix(s.Name, "snap-") {
 			log.Printf("Destroying Droplet Snapshot %s", s.Name)
 
 			if _, err := client.Snapshots.Delete(context.Background(), s.ID); err != nil {
@@ -62,7 +62,7 @@ func TestAccDigitalOceanDropletSnapshot_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletSnapshotExists("digitalocean_droplet_snapshot.foobar", &snapshot),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet_snapshot.foobar", "name", fmt.Sprintf("snapshotone-%d", rInt2)),
+						"digitalocean_droplet_snapshot.foobar", "name", fmt.Sprintf("snapshot-one-%d", rInt2)),
 				),
 			},
 		},
@@ -127,6 +127,6 @@ resource "digitalocean_droplet" "foo" {
   }
   resource "digitalocean_droplet_snapshot" "foobar" {
 	droplet_id = "${digitalocean_droplet.foo.id}"
-	name = "snapshotone-%d"
+	name = "snapshot-one-%d"
   }
   `

--- a/digitalocean/resource_digitalocean_droplet_snapshot_test.go
+++ b/digitalocean/resource_digitalocean_droplet_snapshot_test.go
@@ -29,7 +29,8 @@ func testSweepDropletSnapshots(region string) error {
 
 	client := meta.(*CombinedConfig).godoClient()
 
-	snapshots, _, err := client.Snapshots.ListDroplet(context.Background(), nil)
+	opt := &godo.ListOptions{PerPage: 200}
+	snapshots, _, err := client.Snapshots.ListDroplet(context.Background(), opt)
 	if err != nil {
 		return err
 	}

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -111,6 +111,10 @@ func TestAccDigitalOceanDroplet_WithID(t *testing.T) {
 func TestAccDigitalOceanDroplet_withSSH(t *testing.T) {
 	var droplet godo.Droplet
 	rInt := acctest.RandInt()
+	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("digitalocean@ssh-acceptance-test")
+	if err != nil {
+		t.Fatalf("Cannot generate test SSH key pair: %s", err)
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -118,7 +122,7 @@ func TestAccDigitalOceanDroplet_withSSH(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_withSSH(rInt),
+				Config: testAccCheckDigitalOceanDropletConfig_withSSH(rInt, publicKeyMaterial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes(&droplet),
@@ -668,7 +672,7 @@ resource "digitalocean_droplet" "foobar" {
 }`, slug, rInt)
 }
 
-func testAccCheckDigitalOceanDropletConfig_withSSH(rInt int) string {
+func testAccCheckDigitalOceanDropletConfig_withSSH(rInt int, testAccValidPublicKey string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_ssh_key" "foobar" {
   name       = "foobar-%d"
@@ -802,5 +806,3 @@ resource "digitalocean_droplet" "foobar" {
 }
 `, rInt, rInt, rInt)
 }
-
-var testAccValidPublicKey = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR`

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -37,7 +37,7 @@ func testSweepDroplets(region string) error {
 	log.Printf("[DEBUG] Found %d droplets to sweep", len(droplets))
 
 	for _, d := range droplets {
-		if strings.HasPrefix(d.Name, "foo-") || strings.HasPrefix(d.Name, "bar-") || strings.HasPrefix(d.Name, "baz-") {
+		if strings.HasPrefix(d.Name, "foo-") || strings.HasPrefix(d.Name, "bar-") || strings.HasPrefix(d.Name, "baz-") || strings.HasPrefix(d.Name, "tf-acc-test-") || strings.HasPrefix(d.Name, "foobar-") {
 			log.Printf("Destroying Droplet %s", d.Name)
 
 			if _, err := client.Droplets.Delete(context.Background(), d.ID); err != nil {

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -30,7 +30,8 @@ func testSweepDroplets(region string) error {
 
 	client := meta.(*CombinedConfig).godoClient()
 
-	droplets, _, err := client.Droplets.List(context.Background(), nil)
+	opt := &godo.ListOptions{PerPage: 200}
+	droplets, _, err := client.Droplets.List(context.Background(), opt)
 	if err != nil {
 		return err
 	}

--- a/digitalocean/resource_digitalocean_firewall_test.go
+++ b/digitalocean/resource_digitalocean_firewall_test.go
@@ -27,7 +27,7 @@ func testSweepFirewall(region string) error {
 		return err
 	}
 
-	client := meta.(*godo.Client)
+	client := meta.(*CombinedConfig).godoClient()
 
 	opt := &godo.ListOptions{PerPage: 200}
 	fws, _, err := client.Firewalls.List(context.Background(), opt)

--- a/digitalocean/resource_digitalocean_firewall_test.go
+++ b/digitalocean/resource_digitalocean_firewall_test.go
@@ -3,6 +3,8 @@ package digitalocean
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
 	"testing"
 
 	"github.com/digitalocean/godo"
@@ -10,6 +12,41 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("digitalocean_firewall", &resource.Sweeper{
+		Name: "digitalocean_firewall",
+		F:    testSweepFirewall,
+	})
+
+}
+
+func testSweepFirewall(region string) error {
+	meta, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client := meta.(*godo.Client)
+
+	opt := &godo.ListOptions{PerPage: 200}
+	fws, _, err := client.Firewalls.List(context.Background(), opt)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range fws {
+		if strings.HasPrefix(f.Name, "foobar-") {
+			log.Printf("Destroying firewall %s", f.Name)
+
+			if _, err := client.Firewalls.Delete(context.Background(), f.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
 
 func TestAccDigitalOceanFirewall_AllowOnlyInbound(t *testing.T) {
 	rName := acctest.RandString(10)
@@ -180,7 +217,7 @@ func TestAccDigitalOceanFirewall_ImportMultipleRules(t *testing.T) {
 func testAccDigitalOceanFirewallConfig_OnlyInbound(rName string) string {
 	return fmt.Sprintf(`
 	resource "digitalocean_firewall" "foobar" {
-				name          = "%s"
+				name          = "foobar-%s"
 				inbound_rule {
 					protocol         = "tcp"
 					port_range       = "22"
@@ -194,7 +231,7 @@ func testAccDigitalOceanFirewallConfig_OnlyInbound(rName string) string {
 func testAccDigitalOceanFirewallConfig_OnlyOutbound(rName string) string {
 	return fmt.Sprintf(`
 	resource "digitalocean_firewall" "foobar" {
-				name          = "%s"
+				name          = "foobar-%s"
 				outbound_rule {
 					protocol              = "tcp"
 					port_range            = "22"
@@ -208,7 +245,7 @@ func testAccDigitalOceanFirewallConfig_OnlyOutbound(rName string) string {
 func testAccDigitalOceanFirewallConfig_OnlyMultipleInbound(rName string) string {
 	return fmt.Sprintf(`
 	resource "digitalocean_firewall" "foobar" {
-				name          = "%s"
+				name          = "foobar-%s"
 				inbound_rule {
 					protocol         = "tcp"
 					port_range       = "22"
@@ -227,7 +264,7 @@ func testAccDigitalOceanFirewallConfig_OnlyMultipleInbound(rName string) string 
 func testAccDigitalOceanFirewallConfig_OnlyMultipleOutbound(rName string) string {
 	return fmt.Sprintf(`
 	resource "digitalocean_firewall" "foobar" {
-				name          = "%s"
+				name          = "foobar-%s"
 				outbound_rule {
 					protocol              = "tcp"
 					port_range            = "22"
@@ -250,7 +287,7 @@ func testAccDigitalOceanFirewallConfig_MultipleInboundAndOutbound(tagName string
 	}
 
 	resource "digitalocean_firewall" "foobar" {
-				name          = "%s"
+				name          = "foobar-%s"
 				inbound_rule {
 					protocol         = "tcp"
 					port_range       = "22"
@@ -281,7 +318,7 @@ func testAccDigitalOceanFirewallConfig_MultipleInboundAndOutbound(tagName string
 func testAccDigitalOceanFirewallConfig_fullPortRange(rName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_firewall" "foobar" {
-	name          = "%s"
+	name          = "foobar-%s"
 	inbound_rule {
 		protocol         = "tcp"
 		port_range       = "all"
@@ -299,7 +336,7 @@ resource "digitalocean_firewall" "foobar" {
 func testAccDigitalOceanFirewallConfig_icmp(rName string) string {
 	return fmt.Sprintf(`
 resource "digitalocean_firewall" "foobar" {
-	name          = "%s"
+	name          = "foobar-%s"
 	inbound_rule {
 		protocol         = "icmp"
 		source_addresses = ["192.168.1.1/32"]

--- a/digitalocean/resource_digitalocean_floating_ip_assignment_test.go
+++ b/digitalocean/resource_digitalocean_floating_ip_assignment_test.go
@@ -175,7 +175,7 @@ resource "digitalocean_droplet" "foobar" {
 var testAccCheckDigitalOceanFloatingIPAssignmentConfig_createBeforeDestroy = `
 resource "digitalocean_droplet" "foobar" {
   image = "centos-7-x64"
-  name = "foobar"
+  name = "foo-bar"
   region = "nyc3"
   size = "s-1vcpu-1gb"
   private_networking = false

--- a/digitalocean/resource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/resource_digitalocean_loadbalancer_test.go
@@ -30,7 +30,8 @@ func testSweepLoadbalancer(region string) error {
 
 	client := meta.(*CombinedConfig).godoClient()
 
-	lbs, _, err := client.LoadBalancers.List(context.Background(), nil)
+	opt := &godo.ListOptions{PerPage: 200}
+	lbs, _, err := client.LoadBalancers.List(context.Background(), opt)
 	if err != nil {
 		return err
 	}

--- a/digitalocean/resource_digitalocean_volume_snapshot_test.go
+++ b/digitalocean/resource_digitalocean_volume_snapshot_test.go
@@ -30,7 +30,8 @@ func testSweepVolumeSnapshots(region string) error {
 
 	client := meta.(*CombinedConfig).godoClient()
 
-	snapshots, _, err := client.Snapshots.ListVolume(context.Background(), nil)
+	opt := &godo.ListOptions{PerPage: 200}
+	snapshots, _, err := client.Snapshots.ListVolume(context.Background(), opt)
 	if err != nil {
 		return err
 	}

--- a/digitalocean/resource_digitalocean_volume_test.go
+++ b/digitalocean/resource_digitalocean_volume_test.go
@@ -39,7 +39,7 @@ func testSweepVolumes(region string) error {
 	}
 
 	for _, v := range volumes {
-		if strings.HasPrefix(v.Name, "volume-") {
+		if strings.HasPrefix(v.Name, "volume-") || strings.HasPrefix(v.Name, "tf-acc-test-") {
 
 			if len(v.DropletIDs) > 0 {
 				log.Printf("Detaching volume %v from Droplet %v", v.ID, v.DropletIDs[0])

--- a/digitalocean/resource_digitalocean_volume_test.go
+++ b/digitalocean/resource_digitalocean_volume_test.go
@@ -37,6 +37,21 @@ func testSweepVolumes(region string) error {
 
 	for _, v := range volumes {
 		if strings.HasPrefix(v.Name, "volume-") {
+
+			if len(v.DropletIDs) > 0 {
+				log.Printf("Detaching volume %v from Droplet %v", v.ID, v.DropletIDs[0])
+
+				action, _, err := client.StorageActions.DetachByDropletID(context.Background(), v.ID, v.DropletIDs[0])
+				if err != nil {
+					return fmt.Errorf("Error resizing volume (%s): %s", v.ID, err)
+				}
+
+				if err = waitForAction(client, action); err != nil {
+					return fmt.Errorf(
+						"Error waiting for volume (%s): %s", v.ID, err)
+				}
+			}
+
 			log.Printf("Destroying Volume %s", v.Name)
 
 			if _, err := client.Storage.DeleteVolume(context.Background(), v.ID); err != nil {

--- a/digitalocean/resource_digitalocean_volume_test.go
+++ b/digitalocean/resource_digitalocean_volume_test.go
@@ -30,7 +30,10 @@ func testSweepVolumes(region string) error {
 
 	client := meta.(*CombinedConfig).godoClient()
 
-	volumes, _, err := client.Storage.ListVolumes(context.Background(), nil)
+	opt := &godo.ListVolumeParams{
+		ListOptions: &godo.ListOptions{PerPage: 200},
+	}
+	volumes, _, err := client.Storage.ListVolumes(context.Background(), opt)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR contains a number of fixes and improvements to the sweeper that is used to destroy dangling resources left behind by HashiCorp's CI in the case of failures:

- Ensures resources are created with the correct prefixes to be found by the sweeper
- Adds new sweepers for domains, certificates, and firewalls
- Uses larger page sizes when looking for resources
- Uses a random public key in resource_digitalocean_droplet_test instead of hardcoding one

There should be no user facing changes.