### PR TITLE
add support for import of digitalocean_kubernetes_cluster resources

### DIFF
--- a/digitalocean/import_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_cluster_test.go
@@ -1,0 +1,30 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDigitalOceanKubernetesCluster_importBasic(t *testing.T) {
+	resourceName := "digitalocean_kubernetes_cluster.foobar"
+	rName := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDigitalOceanKubernetesConfigBasic(rName),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"kube_config"},
+			},
+		},
+	})
+}

--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -15,10 +15,13 @@ import (
 
 func resourceDigitalOceanKubernetesCluster() *schema.Resource {
 	return &schema.Resource{
-		Create:        resourceDigitalOceanKubernetesClusterCreate,
-		Read:          resourceDigitalOceanKubernetesClusterRead,
-		Update:        resourceDigitalOceanKubernetesClusterUpdate,
-		Delete:        resourceDigitalOceanKubernetesClusterDelete,
+		Create: resourceDigitalOceanKubernetesClusterCreate,
+		Read:   resourceDigitalOceanKubernetesClusterRead,
+		Update: resourceDigitalOceanKubernetesClusterUpdate,
+		Delete: resourceDigitalOceanKubernetesClusterDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDigitalOceanKubernetesClusterImport,
+		},
 		SchemaVersion: 1,
 
 		Schema: map[string]*schema.Schema{
@@ -310,6 +313,17 @@ func waitForKubernetesClusterCreate(client *godo.Client, id string) (*godo.Kuber
 	}
 
 	return nil, fmt.Errorf("Timeout waiting to create cluster")
+}
+
+func resourceDigitalOceanKubernetesClusterImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	err := resourceDigitalOceanKubernetesClusterRead(d, meta)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cluster id: %v", err)
+	}
+
+	results := make([]*schema.ResourceData, 1)
+	results[0] = d
+	return results, nil
 }
 
 type kubernetesConfig struct {

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -96,4 +96,8 @@ In addition to the arguments listed above, the following additional attributes a
 
 ## Import
 
-Kubernetes clusters can not be imported at this time.
+Kubernetes clusters can be imported using the cluster `id`, e.g.
+
+```
+terraform import digitalocean_kubernetes_cluster.mycluster b8ecd2ab-2267-4a5e-8692-cbf1d32583e3
+```


### PR DESCRIPTION
Adds support for importing `digitalocean_kubernetes_cluster` resources and associated acceptance test and documentation update.

acceptance test (`TestAccDigitalOceanKubernetesCluster_importBasic`) run:
> $ make testacc TESTARGS='-run=TestAccDigitalOceanKubernetesCluster_importBasic'
> ==> Checking that code complies with gofmt requirements...
> TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanKubernetesCluster_importBasic -timeout 120m
> === RUN   TestAccDigitalOceanKubernetesCluster_importBasic
> --- PASS: TestAccDigitalOceanKubernetesCluster_importBasic (157.52s)
> PASS
> ok      github.com/terraform-providers/terraform-provider-digitalocean/digitalocean     157.546s
> 