### PR TITLE
Fix typo in node pool name

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -21,7 +21,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   version = "1.12.1-do.2"
 
   node_pool {
-    name       = "woker-pool"
+    name       = "worker-pool"
     size       = "s-2vcpu-2gb"
     node_count = 3
   }


### PR DESCRIPTION
Just a tiny fix to change `woker-pool` to `worker-pool`.