### PR TITLE
Rebuild droplet on image change

### DIFF
--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -442,7 +442,7 @@ func resourceDigitalOceanDropletUpdate(d *schema.ResourceData, meta interface{})
 				"Error powering on droplet (%s) after resize: %s", d.Id(), err)
 		}
 
-		// Wait for power off
+		// Wait for power on
 		_, err = waitForDropletAttribute(d, "active", []string{"off"}, "status", meta)
 		if err != nil {
 			return err
@@ -504,7 +504,7 @@ func resourceDigitalOceanDropletUpdate(d *schema.ResourceData, meta interface{})
 				"Error powering on droplet (%s) after rebuild: %s", d.Id(), err)
 		}
 
-		// Wait for power off
+		// Wait for power on
 		_, err = waitForDropletAttribute(d, "active", []string{"off"}, "status", meta)
 		if err != nil {
 			return err

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -803,7 +803,7 @@ resource "digitalocean_droplet" "foobar" {
   size     = "512mb"
   image    = "ubuntu-18-04-x64"
   region   = "nyc3"
-	user_data = "foobar"
+  user_data = "foobar"
 }
 `, rInt)
 }


### PR DESCRIPTION
Hi 👋🏼

This PR makes use of the DigitalOcean rebuild API on changes to a droplet's image attribute.

Currently, when you change an image the entire droplet resource is destroyed in DigitalOcean releasing the droplets IP addresses, volume attachments and other resources that are related to a droplet's ID.

By using the rebuild API a droplet will maintain it's IP addresses and other related resources on image changes.

I welcome any feedback or thoughts and experiences on this.

Thanks,

Tim Birkett. 