### PR TITLE
r/digitalocean_database_cluster: Adding new resource to manage database clusters

### DIFF
--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -53,6 +53,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"digitalocean_certificate":            resourceDigitalOceanCertificate(),
+			"digitalocean_database_cluster":       resourceDigitalOceanDatabaseCluster(),
 			"digitalocean_domain":                 resourceDigitalOceanDomain(),
 			"digitalocean_droplet":                resourceDigitalOceanDroplet(),
 			"digitalocean_droplet_snapshot":       resourceDigitalOceanDropletSnapshot(),

--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -253,8 +253,10 @@ func resourceDigitalOceanDatabaseClusterRead(d *schema.ResourceData, meta interf
 	d.Set("region", database.RegionSlug)
 	d.Set("node_count", database.NumNodes)
 
-	if err := d.Set("maintenance_window", flattenMaintWindowOpts(*database.MaintenanceWindow)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting maintenance_window - error: %#v", err)
+	if _, ok := d.GetOk("maintenance_window"); ok {
+		if err := d.Set("maintenance_window", flattenMaintWindowOpts(*database.MaintenanceWindow)); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting maintenance_window - error: %#v", err)
+		}
 	}
 
 	// Computed values

--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -1,0 +1,196 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceDigitalOceanDatabaseCluster() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDigitalOceanDatabaseClusterCreate,
+		Read:   resourceDigitalOceanDatabaseClusterRead,
+		Update: resourceDigitalOceanDatabaseClusterUpdate,
+		Delete: resourceDigitalOceanDatabaseClusterDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"engine": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"version": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"size": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					// DO API V2 region slug is always lowercase
+					return strings.ToLower(val.(string))
+				},
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"node_count": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+		},
+	}
+}
+
+func resourceDigitalOceanDatabaseClusterCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+
+	opts := &godo.DatabaseCreateRequest{
+		Name:       d.Get("name").(string),
+		EngineSlug: d.Get("engine").(string),
+		Version:    d.Get("version").(string),
+		SizeSlug:   d.Get("size").(string),
+		Region:     d.Get("region").(string),
+		NumNodes:   d.Get("node_count").(int),
+	}
+
+	log.Printf("[DEBUG] DatabaseCluster create configuration: %#v", opts)
+	database, _, err := client.Databases.Create(context.Background(), opts)
+	if err != nil {
+		return fmt.Errorf("Error creating DatabaseCluster: %s", err)
+	}
+
+	database, err = waitForDatabaseCluster(client, database.ID, "online")
+	if err != nil {
+		return fmt.Errorf("Error creating DatabaseCluster: %s", err)
+	}
+
+	d.SetId(database.ID)
+	log.Printf("[INFO] DatabaseCluster Name: %s", database.Name)
+
+	return resourceDigitalOceanDatabaseClusterRead(d, meta)
+}
+
+func resourceDigitalOceanDatabaseClusterUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+
+	if d.HasChange("size") || d.HasChange("node_count") {
+		opts := &godo.DatabaseResizeRequest{
+			SizeSlug: d.Get("size").(string),
+			NumNodes: d.Get("node_count").(int),
+		}
+
+		resp, err := client.Databases.Resize(context.Background(), d.Id(), opts)
+		if err != nil {
+			// If the database is somehow already destroyed, mark as
+			// successfully gone
+			if resp.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+
+			return fmt.Errorf("Error resizing database: %s", err)
+		}
+
+		_, err = waitForDatabaseCluster(client, d.Id(), "online")
+		if err != nil {
+			return fmt.Errorf("Error resizing DatabaseCluster: %s", err)
+		}
+	}
+
+	return resourceDigitalOceanDatabaseClusterRead(d, meta)
+}
+
+func resourceDigitalOceanDatabaseClusterRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+
+	database, resp, err := client.Databases.Get(context.Background(), d.Id())
+	if err != nil {
+		// If the database is somehow already destroyed, mark as
+		// successfully gone
+		if resp.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving database: %s", err)
+	}
+
+	d.Set("name", database.Name)
+	d.Set("engine", database.EngineSlug)
+	d.Set("version", database.VersionSlug)
+	d.Set("size", database.SizeSlug)
+	d.Set("region", database.RegionSlug)
+	d.Set("node_count", database.NumNodes)
+
+	return nil
+}
+
+func resourceDigitalOceanDatabaseClusterDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+
+	log.Printf("[INFO] Deleting DatabaseCluster: %s", d.Id())
+	_, err := client.Databases.Delete(context.Background(), d.Id())
+	if err != nil {
+		return fmt.Errorf("Error deleting DatabaseCluster: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func waitForDatabaseCluster(client *godo.Client, id string, status string) (*godo.Database, error) {
+	ticker := time.NewTicker(15 * time.Second)
+	timeout := 120
+	n := 0
+
+	for range ticker.C {
+		database, _, err := client.Databases.Get(context.Background(), id)
+		if err != nil {
+			ticker.Stop()
+			return nil, fmt.Errorf("Error trying to read database state: %s", err)
+		}
+
+		if database.Status == status {
+			ticker.Stop()
+			return database, nil
+		}
+
+		if n > timeout {
+			ticker.Stop()
+			break
+		}
+
+		n++
+	}
+
+	return nil, fmt.Errorf("Timeout waiting to database to become %s", status)
+}

--- a/digitalocean/resource_digitalocean_database_cluster_test.go
+++ b/digitalocean/resource_digitalocean_database_cluster_test.go
@@ -1,0 +1,147 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDigitalOceanDatabaseCluster_Basic(t *testing.T) {
+	var database godo.Database
+	databaseName := fmt.Sprintf("foobar-test-terraform-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDatabaseClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigBasic, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
+					testAccCheckDigitalOceanDatabaseClusterAttributes(&database, databaseName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "name", databaseName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "engine", "pg"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanDatabaseCluster_WithUpdate(t *testing.T) {
+	var database godo.Database
+	databaseName := fmt.Sprintf("foobar-test-terraform-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDatabaseClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigBasic, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
+					testAccCheckDigitalOceanDatabaseClusterAttributes(&database, databaseName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "size", "db-s-1vcpu-1gb"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigWithUpdate, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
+					testAccCheckDigitalOceanDatabaseClusterAttributes(&database, databaseName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "size", "db-s-1vcpu-2gb"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDigitalOceanDatabaseClusterDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*CombinedConfig).godoClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "digitalocean_database_cluster" {
+			continue
+		}
+
+		// Try to find the database
+		_, _, err := client.Databases.Get(context.Background(), rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("DatabaseCluster still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDigitalOceanDatabaseClusterAttributes(database *godo.Database, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if database.Name != name {
+			return fmt.Errorf("Bad name: %s", database.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDigitalOceanDatabaseClusterExists(n string, database *godo.Database) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DatabaseCluster ID is set")
+		}
+
+		client := testAccProvider.Meta().(*CombinedConfig).godoClient()
+
+		foundDatabaseCluster, _, err := client.Databases.Get(context.Background(), rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if foundDatabaseCluster.ID != rs.Primary.ID {
+			return fmt.Errorf("DatabaseCluster not found")
+		}
+
+		*database = *foundDatabaseCluster
+
+		return nil
+	}
+}
+
+const testAccCheckDigitalOceanDatabaseClusterConfigBasic = `
+resource "digitalocean_database_cluster" "foobar" {
+	name       = "%s"
+	engine     = "pg"
+	version    = "11"
+	size       = "db-s-1vcpu-1gb"
+	region     = "nyc1"
+    node_count = 1
+}`
+
+const testAccCheckDigitalOceanDatabaseClusterConfigWithUpdate = `
+resource "digitalocean_database_cluster" "foobar" {
+	name       = "%s"
+	engine     = "pg"
+	version    = "11"
+	size       = "db-s-1vcpu-2gb"
+	region     = "nyc1"
+    node_count = 1
+}`

--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -16,9 +16,6 @@
             <li<%= sidebar_current("docs-do-datasource-certificate") %>>
               <a href="/docs/providers/do/d/certificate.html">digitalocean_certificate</a>
             </li>
-            <li<%= sidebar_current("docs-do-resource-database-cluster") %>>
-              <a href="/docs/providers/do/r/database_cluster.html">digitalocean_database_cluster</a>
-            </li>
             <li<%= sidebar_current("docs-do-datasource-domain") %>>
               <a href="/docs/providers/do/d/domain.html">digitalocean_domain</a>
             </li>
@@ -63,6 +60,9 @@
             </li>
             <li<%= sidebar_current("docs-do-resource-certificate") %>>
               <a href="/docs/providers/do/r/certificate.html">digitalocean_certificate</a>
+            </li>
+            <li<%= sidebar_current("docs-do-resource-database-cluster") %>>
+              <a href="/docs/providers/do/r/database_cluster.html">digitalocean_database_cluster</a>
             </li>
             <li<%= sidebar_current("docs-do-resource-domain") %>>
               <a href="/docs/providers/do/r/domain.html">digitalocean_domain</a>

--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -16,6 +16,9 @@
             <li<%= sidebar_current("docs-do-datasource-certificate") %>>
               <a href="/docs/providers/do/d/certificate.html">digitalocean_certificate</a>
             </li>
+            <li<%= sidebar_current("docs-do-resource-database-cluster") %>>
+              <a href="/docs/providers/do/r/database_cluster.html">digitalocean_database_cluster</a>
+            </li>
             <li<%= sidebar_current("docs-do-datasource-domain") %>>
               <a href="/docs/providers/do/d/domain.html">digitalocean_domain</a>
             </li>

--- a/website/docs/r/database_cluster.html.markdown
+++ b/website/docs/r/database_cluster.html.markdown
@@ -34,12 +34,24 @@ The following arguments are supported:
 * `size` - (Required) Database droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`).
 * `region` - (Required) DigitalOcean region where the cluster will reside.
 * `node_count` - (Required) Number of nodes that will be included in the cluster.
+* `maintenance_window` - (Optional) Defines when the automatic maintenance should be performed for the database cluster.
+
+`maintenance_window` supports the following:
+
+* `day` - (Required) The day of the week on which to apply maintenance updates.
+* `hour` - (Required) The hour in UTC at which maintenance updates will be applied in 24 hour format.
 
 ## Attributes Reference
 
 In addition to the above arguments, the following attributes are exported:
 
 * `id` - The ID of the database cluster.
+* `host` - Database cluster's hostname.
+* `port` - Network port that the database cluster is listening on.
+* `uri` - The full URI for connecting to the database cluster.
+* `database` - Name of the cluster's default database.
+* `user` - Username for the cluster's default user.
+* `password` - Password for the cluster's default user.
 
 ## Import
 

--- a/website/docs/r/database_cluster.html.markdown
+++ b/website/docs/r/database_cluster.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_database_cluster"
+sidebar_current: "docs-do-resource-database-cluster"
+description: |-
+  Provides a DigitalOcean database cluster resource.
+---
+
+# digitalocean\_database\_cluster
+
+Provides a DigitalOcean database cluster resource.
+
+## Example Usage
+
+```hcl
+# Create a new database cluster
+resource "digitalocean_database_cluster" "example" {
+  name       = "example-cluster"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the database cluster.
+* `engine` - (Required) Database engine used by the cluster (ex. `pg` for PostreSQL).
+* `version` - (Required) Engine version used by the cluster (ex. `11` for PostgreSQL 11).
+* `size` - (Required) Database droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`).
+* `region` - (Required) DigitalOcean region where the cluster will reside.
+* `node_count` - (Required) Number of nodes that will be included in the cluster.
+
+## Attributes Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+* `id` - The ID of the database cluster.
+
+## Import
+
+Database clusters can be imported using the `id` returned from DigitalOcean, e.g.
+
+```
+terraform import digitalocean_database_cluster.mycluster 245bcfd0-7f31-4ce6-a2bc-475a116cca97
+```


### PR DESCRIPTION
```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDatabaseCluster_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDatabaseCluster_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDatabaseCluster_Basic
--- PASS: TestAccDigitalOceanDatabaseCluster_Basic (269.01s)
=== RUN   TestAccDigitalOceanDatabaseCluster_WithUpdate
--- PASS: TestAccDigitalOceanDatabaseCluster_WithUpdate (475.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	744.505s
```