### PR TITLE
Add support for enabling PROXY Protocol on Load Balancers.

### DIFF
--- a/digitalocean/datasource_digitalocean_loadbalancer.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer.go
@@ -167,6 +167,11 @@ func dataSourceDigitalOceanLoadbalancer() *schema.Resource {
 				Computed:    true,
 				Description: "whether http requests will be redirected to https",
 			},
+			"enable_proxy_protocol": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "whether PROXY Protocol should be used to pass information from connecting client requests to the backend service",
+			},
 		},
 	}
 }
@@ -220,6 +225,7 @@ func dataSourceDigitalOceanLoadbalancerRead(d *schema.ResourceData, meta interfa
 	d.Set("status", loadbalancer.Status)
 	d.Set("droplet_tag", loadbalancer.Tag)
 	d.Set("redirect_http_to_https", loadbalancer.RedirectHttpToHttps)
+	d.Set("enable_proxy_protocol", loadbalancer.EnableProxyProtocol)
 
 	if err := d.Set("droplet_ids", flattenDropletIds(loadbalancer.DropletIDs)); err != nil {
 		return fmt.Errorf("[DEBUG] Error setting Load Balancer droplet_ids - error: %#v", err)

--- a/digitalocean/resource_digitalocean_loadbalancer.go
+++ b/digitalocean/resource_digitalocean_loadbalancer.go
@@ -199,6 +199,12 @@ func resourceDigitalOceanLoadbalancer() *schema.Resource {
 				Default:  false,
 			},
 
+			"enable_proxy_protocol": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"ip": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -259,6 +265,7 @@ func buildLoadBalancerRequest(d *schema.ResourceData) (*godo.LoadBalancerRequest
 		Region:              d.Get("region").(string),
 		Algorithm:           d.Get("algorithm").(string),
 		RedirectHttpToHttps: d.Get("redirect_http_to_https").(bool),
+		EnableProxyProtocol: d.Get("enable_proxy_protocol").(bool),
 		ForwardingRules:     expandForwardingRules(d.Get("forwarding_rule").([]interface{})),
 	}
 
@@ -337,6 +344,7 @@ func resourceDigitalOceanLoadbalancerRead(d *schema.ResourceData, meta interface
 	d.Set("algorithm", loadbalancer.Algorithm)
 	d.Set("region", loadbalancer.Region.Slug)
 	d.Set("redirect_http_to_https", loadbalancer.RedirectHttpToHttps)
+	d.Set("enable_proxy_protocol", loadbalancer.EnableProxyProtocol)
 	d.Set("droplet_tag", loadbalancer.Tag)
 
 	if err := d.Set("droplet_ids", flattenDropletIds(loadbalancer.DropletIDs)); err != nil {

--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -107,6 +107,9 @@ Load Balancer. The `sticky_sessions` block is documented below. Only 1 sticky_se
 * `redirect_http_to_https` - (Optional) A boolean value indicating whether
 HTTP requests to the Load Balancer on port 80 will be redirected to HTTPS on port 443.
 Default value is `false`.
+* `enable_proxy_protocol` - (Optional) A boolean value indicating whether PROXY
+Protocol should be used to pass information from connecting client requests to
+the backend service. Default value is `false`.
 * `droplet_ids` (Optional) - A list of the IDs of each droplet to be attached to the Load Balancer.
 * `droplet_tag` (Optional) - The name of a Droplet tag corresponding to Droplets to be assigned to the Load Balancer.
 


### PR DESCRIPTION
```
$ make testacc TESTARGS='-run=TestAccDigitalOceanLoadbalancer_sslTermination'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanLoadbalancer_sslTermination -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanLoadbalancer_sslTermination
--- PASS: TestAccDigitalOceanLoadbalancer_sslTermination (79.61s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	79.623s
```