### PR TITLE
Certificates: Move attribute validation from CustomizeDiff to Create (Fixes: #163).

### DIFF
--- a/digitalocean/resource_digitalocean_certificate.go
+++ b/digitalocean/resource_digitalocean_certificate.go
@@ -92,27 +92,6 @@ func resourceDigitalOceanCertificate() *schema.Resource {
 				Computed: true,
 			},
 		},
-
-		CustomizeDiff: func(diff *schema.ResourceDiff, v interface{}) error {
-
-			certificateType := diff.Get("type").(string)
-			if certificateType == "custom" {
-				if _, ok := diff.GetOk("private_key"); !ok {
-					return fmt.Errorf("`private_key` is required for when type is `custom` or empty")
-				}
-
-				if _, ok := diff.GetOk("leaf_certificate"); !ok {
-					return fmt.Errorf("`leaf_certificate` is required for when type is `custom` or empty")
-				}
-			} else if certificateType == "lets_encrypt" {
-
-				if _, ok := diff.GetOk("domains"); !ok {
-					return fmt.Errorf("`domains` is required for when type is `lets_encrypt`")
-				}
-			}
-
-			return nil
-		},
 	}
 }
 
@@ -141,6 +120,22 @@ func buildCertificateRequest(d *schema.ResourceData) (*godo.CertificateRequest, 
 
 func resourceDigitalOceanCertificateCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
+
+	certificateType := d.Get("type").(string)
+	if certificateType == "custom" {
+		if _, ok := d.GetOk("private_key"); !ok {
+			return fmt.Errorf("`private_key` is required for when type is `custom` or empty")
+		}
+
+		if _, ok := d.GetOk("leaf_certificate"); !ok {
+			return fmt.Errorf("`leaf_certificate` is required for when type is `custom` or empty")
+		}
+	} else if certificateType == "lets_encrypt" {
+
+		if _, ok := d.GetOk("domains"); !ok {
+			return fmt.Errorf("`domains` is required for when type is `lets_encrypt`")
+		}
+	}
 
 	log.Printf("[INFO] Create a Certificate Request")
 


### PR DESCRIPTION
When CustomizeDiff is run for a new resource, it does not have access to the
current state. In the digitalocean_certificate resource, we are using a
CustomizeDiff function to validate that certain attributes are used together
depending on the certificate type. When the value for one of those attributes
is interpolated, as in the case of generating a cert using the acme provider,
the validation fails since it depends on reading the value from state. As state
is not present, the value is interpreted as empty.

From the CustomizeDiff doc string:

> // The phases Terraform runs this in, and the state available via functions
> // like Get and GetChange, are as follows:
> //
> //  * New resource: One run with no state

https://godoc.org/github.com/hashicorp/terraform/helper/schema#Resource

This PR moves the validation from the CustomizeDiff function into the
Create function as well as adding acceptance tests:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanCertificate_ExpectedErrors'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanCertificate_ExpectedE$
?       github.com/terraform-providers/terraform-provider-digitalocean  [no test files]
=== RUN   TestAccDigitalOceanCertificate_ExpectedErrors
--- PASS: TestAccDigitalOceanCertificate_ExpectedErrors (0.10s)
PASS
ok      github.com/terraform-providers/terraform-provider-digitalocean/digitalocean     (cached)
```