### PR TITLE
Updates the spaces resource to expose the urn.

### DIFF
--- a/digitalocean/resource_digitalocean_spaces_bucket.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket.go
@@ -29,6 +29,11 @@ func resourceDigitalOceanBucket() *schema.Resource {
 				Required:    true,
 				Description: "Bucket name",
 			},
+			"urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "the uniform resource name for the bucket",
+			},
 			"region": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -173,6 +178,9 @@ func resourceDigitalOceanBucketRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	d.Set("name", d.Get("name").(string))
+
+	urn := fmt.Sprintf("do:space:%s", d.Get("name"))
+	d.Set("urn", urn)
 
 	return nil
 }

--- a/digitalocean/resource_digitalocean_spaces_bucket_test.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket_test.go
@@ -22,6 +22,10 @@ import (
 func TestAccDigitalOceanBucket_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
+	expectedRegion := "ams3"
+	expectedBucketName := testAccBucketName(rInt)
+	expectBucketURN := fmt.Sprintf("do:space:%s", expectedBucketName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		/*
@@ -36,9 +40,10 @@ func TestAccDigitalOceanBucket_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists("digitalocean_spaces_bucket.bucket"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_spaces_bucket.bucket", "region", "nyc3"),
+						"digitalocean_spaces_bucket.bucket", "region", expectedRegion),
 					resource.TestCheckResourceAttr(
-						"digitalocean_spaces_bucket.bucket", "name", testAccBucketName(rInt)),
+						"digitalocean_spaces_bucket.bucket", "name", expectedBucketName),
+					resource.TestCheckResourceAttr("digitalocean_spaces_bucket.bucket", "urn", expectBucketURN),
 				),
 			},
 		},
@@ -245,6 +250,7 @@ func testAccDigitalOceanBucketConfig(randInt int) string {
 resource "digitalocean_spaces_bucket" "bucket" {
 	name = "tf-test-bucket-%d"
 	acl = "public-read"
+	region = "ams3"
 }
 `, randInt)
 }

--- a/website/docs/r/spaces_bucket.html.markdown
+++ b/website/docs/r/spaces_bucket.html.markdown
@@ -61,6 +61,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `name` - The name of the bucket
+* `urn` - The uniform resource name for the bucket
 * `region` - The name of the region
 * `bucket_domain_name` - The FQDN of the bucket (e.g. bucket-name.nyc3.digitaloceanspaces.com)
 


### PR DESCRIPTION
This PR Introduces the URN attribute into the spaces/bucket resource.  Unlike the other resources that use the structs from the godo client, the spaces resource does not do this in the read function.  As a result the URN is created in the read function.

**NOTE:**  DigitialOcean API is not allowing the use of nyc3 for spaces/bucket creation and so the use of ams3 as a region has been used to allow the tests to execute.