### PR TITLE
Feature/introduce urn attribute to domain

### DIFF
--- a/digitalocean/datasource_digitalocean_domain.go
+++ b/digitalocean/datasource_digitalocean_domain.go
@@ -20,6 +20,11 @@ func dataSourceDigitalOceanDomain() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			// computed attributes
+			"urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "the uniform resource name for the domain",
+			},
 			"ttl": {
 				Type:        schema.TypeInt,
 				Computed:    true,
@@ -49,6 +54,7 @@ func dataSourceDigitalOceanDomainRead(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId(domain.Name)
 	d.Set("name", domain.Name)
+	d.Set("urn", domain.URN())
 	d.Set("ttl", domain.TTL)
 	d.Set("zone_file", domain.ZoneFile)
 

--- a/digitalocean/datasource_digitalocean_domain_test.go
+++ b/digitalocean/datasource_digitalocean_domain_test.go
@@ -15,6 +15,8 @@ func TestAccDataSourceDigitalOceanDomain_Basic(t *testing.T) {
 	var domain godo.Domain
 	domainName := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
 
+	expectedURN := fmt.Sprintf("do:domain:%s", domainName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -26,6 +28,8 @@ func TestAccDataSourceDigitalOceanDomain_Basic(t *testing.T) {
 					testAccCheckDataSourceDigitalOceanDomainAttributes(&domain, domainName),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_domain.foobar", "name", domainName),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_domain.foobar", "urn", expectedURN),
 				),
 			},
 		},

--- a/digitalocean/resource_digitalocean_domain.go
+++ b/digitalocean/resource_digitalocean_domain.go
@@ -26,12 +26,15 @@ func resourceDigitalOceanDomain() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
-
 			"ip_address": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
+			},
+			"urn": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -78,6 +81,7 @@ func resourceDigitalOceanDomainRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	d.Set("name", domain.Name)
+	d.Set("urn", domain.URN())
 
 	return nil
 }

--- a/digitalocean/resource_digitalocean_domain_test.go
+++ b/digitalocean/resource_digitalocean_domain_test.go
@@ -52,6 +52,8 @@ func TestAccDigitalOceanDomain_Basic(t *testing.T) {
 	var domain godo.Domain
 	domainName := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
 
+	expectedURN := fmt.Sprintf("do:domain:%s", domainName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -66,6 +68,8 @@ func TestAccDigitalOceanDomain_Basic(t *testing.T) {
 						"digitalocean_domain.foobar", "name", domainName),
 					resource.TestCheckResourceAttr(
 						"digitalocean_domain.foobar", "ip_address", "192.168.0.10"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_domain.foobar", "urn", expectedURN),
 				),
 			},
 		},

--- a/website/docs/d/domain.html.md
+++ b/website/docs/d/domain.html.md
@@ -61,4 +61,5 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `ttl`: The TTL of the domain.
+* `urn` - The uniform resource name of the domain
 * `zone_file`: The zone file of the domain.

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -33,6 +33,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The name of the domain
+* `urn` - The uniform resource name of the domain
 
 ## Import
 


### PR DESCRIPTION
This PR introduces the URN attribute for the domain resource.  This covers the datasource and the resource.  Alterations also include the website to document the new attribute.