### PR TITLE
Feature/introduce urn attribute to loadbalancer

### DIFF
--- a/digitalocean/datasource_digitalocean_loadbalancer.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer.go
@@ -21,6 +21,11 @@ func dataSourceDigitalOceanLoadbalancer() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			// computed attributes
+			"urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "the uniform resource name for the load balancer",
+			},
 			"region": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -219,6 +224,7 @@ func dataSourceDigitalOceanLoadbalancerRead(d *schema.ResourceData, meta interfa
 
 	d.SetId(loadbalancer.ID)
 	d.Set("name", loadbalancer.Name)
+	d.Set("urn", loadbalancer.URN())
 	d.Set("region", loadbalancer.Region.Slug)
 	d.Set("ip", loadbalancer.IP)
 	d.Set("algorithm", loadbalancer.Algorithm)

--- a/digitalocean/datasource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer_test.go
@@ -23,8 +23,11 @@ func TestAccDataSourceDigitalOceanLoadBalancer_Basic(t *testing.T) {
 				Config: testAccCheckDataSourceDigitalOceanLoadBalancerConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceDigitalOceanLoadBalancerExists("data.digitalocean_loadbalancer.foobar", &loadbalancer),
+					testAccCheckDataSourceDigitalOceanLoadBalancerAttributes(&loadbalancer),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "urn", fmt.Sprintf("do:loadbalancer:%s", loadbalancer.ID)),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
@@ -49,6 +52,19 @@ func TestAccDataSourceDigitalOceanLoadBalancer_Basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckDataSourceDigitalOceanLoadBalancerAttributes(loadbalancer *godo.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		expectURN := fmt.Sprintf("do:loadbalancer:%s", loadbalancer.ID)
+
+		if loadbalancer.URN() != expectURN {
+			return fmt.Errorf("URN: Expected %s, but actual was %s", expectURN, loadbalancer.URN())
+		}
+
+		return nil
+	}
 }
 
 func testAccCheckDataSourceDigitalOceanLoadBalancerExists(n string, loadbalancer *godo.LoadBalancer) resource.TestCheckFunc {

--- a/digitalocean/resource_digitalocean_loadbalancer.go
+++ b/digitalocean/resource_digitalocean_loadbalancer.go
@@ -34,7 +34,11 @@ func resourceDigitalOceanLoadbalancer() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
-
+			"urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "the uniform resource name for the load balancer",
+			},
 			"algorithm": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -339,6 +343,7 @@ func resourceDigitalOceanLoadbalancerRead(d *schema.ResourceData, meta interface
 	}
 
 	d.Set("name", loadbalancer.Name)
+	d.Set("urn", loadbalancer.URN())
 	d.Set("ip", loadbalancer.IP)
 	d.Set("status", loadbalancer.Status)
 	d.Set("algorithm", loadbalancer.Algorithm)

--- a/digitalocean/resource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/resource_digitalocean_loadbalancer_test.go
@@ -62,6 +62,7 @@ func TestAccDigitalOceanLoadbalancer_Basic(t *testing.T) {
 				Config: testAccCheckDigitalOceanLoadbalancerConfig_basic(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
+					testAccCheckDigitalOceanLoadBalancerAttributes(&loadbalancer),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "name", fmt.Sprintf("loadbalancer-%d", rInt)),
 					resource.TestCheckResourceAttr(
@@ -88,6 +89,19 @@ func TestAccDigitalOceanLoadbalancer_Basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckDigitalOceanLoadBalancerAttributes(loadbalancer *godo.LoadBalancer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		expectURN := fmt.Sprintf("do:loadbalancer:%s", loadbalancer.ID)
+
+		if loadbalancer.URN() != expectURN {
+			return fmt.Errorf("URN: Expected %s, but actual was %s", expectURN, loadbalancer.URN())
+		}
+
+		return nil
+	}
 }
 
 func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {

--- a/website/docs/d/loadbalancer.html.md
+++ b/website/docs/d/loadbalancer.html.md
@@ -30,6 +30,7 @@ data "digitalocean_loadbalancer" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The name of load balancer.
+* `urn` - The uniform resource name for the Load Balancer
 
 ## Attributes Reference
 

--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -146,6 +146,7 @@ The following attributes are exported:
 
 * `id` - The ID of the Load Balancer
 * `ip`- The ip of the Load Balancer
+* `urn` - The uniform resource name for the Load Balancer
 
 ## Import
 


### PR DESCRIPTION
This PR introduces the URN attribute for the load balancer resource.  This covers the datasource and the resource.  Alterations also include the website to document the new attribute.