### PR TITLE
Feature/introduce urn attribute to droplet

### DIFF
--- a/digitalocean/datasource_digitalocean_droplet.go
+++ b/digitalocean/datasource_digitalocean_droplet.go
@@ -23,6 +23,11 @@ func dataSourceDigitalOceanDroplet() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			// computed attributes
+			"urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "the uniform resource name for the Droplet",
+			},
 			"region": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -168,6 +173,7 @@ func dataSourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{})
 
 	d.SetId(strconv.Itoa(droplet.ID))
 	d.Set("name", droplet.Name)
+	d.Set("urn", droplet.URN())
 	d.Set("region", droplet.Region.Slug)
 	d.Set("size", droplet.Size.Slug)
 	d.Set("price_hourly", droplet.Size.PriceHourly)

--- a/digitalocean/datasource_digitalocean_droplet_test.go
+++ b/digitalocean/datasource_digitalocean_droplet_test.go
@@ -34,6 +34,7 @@ func TestAccDataSourceDigitalOceanDroplet_Basic(t *testing.T) {
 						"data.digitalocean_droplet.foobar", "ipv6", "true"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_droplet.foobar", "private_networking", "false"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_droplet.foobar", "urn"),
 				),
 			},
 		},

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -62,6 +62,11 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 
+			"urn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"disk": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -311,6 +316,7 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("name", droplet.Name)
+	d.Set("urn", droplet.URN())
 	d.Set("region", droplet.Region.Slug)
 	d.Set("size", droplet.Size.Slug)
 	d.Set("price_hourly", droplet.Size.PriceHourly)

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -82,6 +82,7 @@ func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 						"digitalocean_droplet.foobar", "ipv4_address_private", ""),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "ipv6_address", ""),
+					resource.TestCheckResourceAttrSet("digitalocean_droplet.foobar", "urn"),
 				),
 			},
 		},

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -487,6 +487,10 @@ func testAccCheckDigitalOceanDropletDestroy(s *terraform.State) error {
 func testAccCheckDigitalOceanDropletAttributes(droplet *godo.Droplet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
+		if droplet.URN() != fmt.Sprintf("do:droplet:%d", droplet.ID) {
+			return fmt.Errorf("Bad URN: %s", droplet.URN())
+		}
+
 		if droplet.Image.Slug != "centos-7-x64" {
 			return fmt.Errorf("Bad image_slug: %s", droplet.Image.Slug)
 		}

--- a/website/docs/d/droplet.html.md
+++ b/website/docs/d/droplet.html.md
@@ -36,6 +36,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id`: The ID of the Droplet.
+* `urn` - The uniform resource name of the Droplet
 * `region` - The region the Droplet is running in.
 * `image` - The Droplet image ID or slug.
 * `size` - The unique slug that indentifies the type of Droplet.

--- a/website/docs/r/droplet.html.markdown
+++ b/website/docs/r/droplet.html.markdown
@@ -59,6 +59,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the Droplet
+* `urn` - The uniform resource name of the Droplet
 * `name`- The name of the Droplet
 * `region` - The region of the Droplet
 * `image` - The image of the Droplet


### PR DESCRIPTION
This PR introduces the URN attribute for the droplet resource.  This covers the datasource and the resource.  Alterations also include the website to document the new attribute.