### PR TITLE
Issue/152 - Avoid Droplet to create new resource when slug changes to different image

### DIFF
--- a/digitalocean/import_digitalocean_droplet_snapshot_test.go
+++ b/digitalocean/import_digitalocean_droplet_snapshot_test.go
@@ -26,6 +26,9 @@ func TestAccDigitalOceanDropletSnapshot_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				// image_id oposite than image isnt store if no slug
+				ImportStateVerifyIgnore: []string{
+					"image_id"},
 			},
 		},
 	})

--- a/digitalocean/import_digitalocean_droplet_test.go
+++ b/digitalocean/import_digitalocean_droplet_test.go
@@ -28,8 +28,9 @@ func TestAccDigitalOceanDroplet_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				//we ignore the ssh_keys, resize_disk and user_data as we do not set to state and image_id (without slug image_id = image)
 				ImportStateVerifyIgnore: []string{
-					"ssh_keys", "user_data", "resize_disk"}, //we ignore the ssh_keys, resize_disk and user_data as we do not set to state
+					"ssh_keys", "user_data", "resize_disk", "image_id"},
 			},
 		},
 	})
@@ -59,8 +60,9 @@ func TestAccDigitalOceanDroplet_ImportWithNoImageSlug(t *testing.T) {
 				ResourceName:      "digitalocean_droplet.from-snapshot",
 				ImportState:       true,
 				ImportStateVerify: true,
+				//we ignore the ssh_keys, resize_disk and user_data as we do not set to state and image_id (without slug image_id = image)
 				ImportStateVerifyIgnore: []string{
-					"ssh_keys", "user_data", "resize_disk"}, //we ignore the ssh_keys, resize_disk and user_data as we do not set to state
+					"ssh_keys", "user_data", "resize_disk", "image_id", "slug"},
 			},
 			{
 				Config: " ",

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -44,8 +44,14 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 					if d.IsNewResource() {
 						return true
 					}
-					// No idea of change as we dont have state
+					// No information store as there is not slug in the image
 					if imageID == 0 && slug == "" {
+						_, err := strconv.Atoi(new)
+						// do previous information, the new image has change to a id, and there is not
+						// slug so compare base on the ids
+						if err == nil {
+							return old == new
+						}
 						return true
 					}
 					return new == slug || new == godo.Stringify(imageID)

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -36,7 +36,14 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				// Ensure that when the API change slug to image after upgrade
 				// the change is not duplicated
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return new == d.Get("slug") || new == godo.Stringify(d.Get("image_id"))
+					slug := d.Get("slug")
+					imageID := d.Get("image_id")
+					log.Printf("[DEBUG] slug %s, imageid %s", slug, imageID)
+					// No idea of a change
+					if imageID == 0 && slug == "" {
+						return true
+					}
+					return new == slug || new == godo.Stringify(imageID)
 				},
 			},
 

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -36,9 +36,10 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				// Ensure that when the API change slug to image after upgrade
 				// the change is not duplicated
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					changeFromSlug, newID := changeFromSlugToID(old, new)
+					log.Printf("[INFO] Slug diff suppress: Old: %s, New: %s", old, new)
+					changeFromSlug, oldID := changeFromSlugToID(old, new)
 					return ((changeFromSlug && d.Get("image_id") == 0) ||
-						(changeFromSlug && d.Get("image_id") == newID))
+						(changeFromSlug && d.Get("image_id") == oldID))
 				},
 			},
 
@@ -772,7 +773,7 @@ func flattenDigitalOceanDropletVolumeIds(volumeids []string) *schema.Set {
 }
 
 func changeFromSlugToID(old, new string) (bool, int) {
-	_, oldErr := strconv.Atoi(old)
-	newID, newErr := strconv.Atoi(new)
-	return newErr == nil && oldErr != nil, newID
+	oldId, oldErr := strconv.Atoi(old)
+	_, newErr := strconv.Atoi(new)
+	return newErr != nil && oldErr == nil, oldId
 }

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -39,7 +39,12 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 					slug := d.Get("slug")
 					imageID := d.Get("image_id")
 					log.Printf("[DEBUG] slug %s, imageid %s", slug, imageID)
-					// No idea of a change
+
+					// Dont suppress changes for new resources
+					if d.IsNewResource() {
+						return true
+					}
+					// No idea of change as we dont have state
 					if imageID == 0 && slug == "" {
 						return true
 					}

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -38,19 +38,20 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					slug := d.Get("slug")
 					imageID := d.Get("image_id")
+
 					log.Printf("[DEBUG] slug %s, imageid %s", slug, imageID)
 
 					// Dont suppress changes for new resources
-					if d.IsNewResource() {
-						return true
+					if d.Id() == "" {
+						return false
 					}
 					// No information store as there is not slug in the image
 					if imageID == 0 && slug == "" {
 						_, err := strconv.Atoi(new)
-						// do previous information, the new image has change to a id, and there is not
+						// no previous information, the new image has change to a id, and there is not
 						// slug so compare base on the ids
 						if err == nil {
-							return old == new
+							return old != new
 						}
 						return true
 					}

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -38,8 +38,7 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					slug := d.Get("slug")
 					imageID := d.Get("image_id")
-
-					log.Printf("[DEBUG] slug %s, imageid %s", slug, imageID)
+					log.Printf("[DEBUG] slug %s, image_id %s", slug, imageID)
 
 					// Dont suppress changes for new resources
 					if d.Id() == "" {

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -36,7 +36,7 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				// Ensure that when the API change slug to image after upgrade
 				// the change is not duplicated
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					log.Printf("[INFO] Slug diff suppress: Old: %s, New: %s", old, new)
+					log.Printf("[DEBUG] Slug diff suppress: Old: %s, New: %s", old, new)
 					changeFromSlug, oldID := changeFromSlugToID(old, new)
 					return ((changeFromSlug && d.Get("image_id") == 0) ||
 						(changeFromSlug && d.Get("image_id") == oldID))

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -333,6 +333,11 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("image", godo.Stringify(droplet.Image.ID))
 	} else {
 		d.Set("image", droplet.Image.Slug)
+
+		// the user have define a slug and we have a slug and imageid
+		// we can update the status
+		d.Set("slug", droplet.Image.Slug)
+		d.Set("image_id", godo.Stringify(droplet.Image.ID))
 	}
 
 	d.Set("name", droplet.Name)

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -220,8 +220,8 @@ func TestChangeFromSlugToID(t *testing.T) {
 		new      string
 		expected bool
 	}{
-		{"120007", "ubuntu_17_04", false},
-		{"ubuntu_17_04", "120007", true},
+		{"120007", "ubuntu_17_04", true},
+		{"ubuntu_17_04", "120007", false},
 		{"ubuntu_17_04", "ubuntu_17_04", false},
 		{"120007", "120007", false},
 	}
@@ -233,7 +233,6 @@ func TestChangeFromSlugToID(t *testing.T) {
 			t.Fail()
 		}
 	}
-
 }
 
 func TestAccDigitalOceanDroplet_ResizeSmaller(t *testing.T) {

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -75,6 +75,8 @@ func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "image", "centos-7-x64"),
 					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "slug", "centos-7-x64"),
+					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "region", "nyc3"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "user_data", HashString("foobar")),

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -214,27 +214,6 @@ func TestAccDigitalOceanDroplet_ResizeWithOutDisk(t *testing.T) {
 	})
 }
 
-func TestChangeFromSlugToID(t *testing.T) {
-	parameters := []struct {
-		old      string
-		new      string
-		expected bool
-	}{
-		{"120007", "ubuntu_17_04", true},
-		{"ubuntu_17_04", "120007", false},
-		{"ubuntu_17_04", "ubuntu_17_04", false},
-		{"120007", "120007", false},
-	}
-
-	for i := range parameters {
-		actual, _ := changeFromSlugToID(parameters[i].old, parameters[i].new)
-		if actual != parameters[i].expected {
-			t.Logf("old: %s, new: %s => expected:%t , actual:%t", parameters[i].old, parameters[i].new, parameters[i].expected, actual)
-			t.Fail()
-		}
-	}
-}
-
 func TestAccDigitalOceanDroplet_ResizeSmaller(t *testing.T) {
 	var droplet godo.Droplet
 	rInt := acctest.RandInt()

--- a/digitalocean/resource_digitalocean_droplet_test.go
+++ b/digitalocean/resource_digitalocean_droplet_test.go
@@ -214,6 +214,28 @@ func TestAccDigitalOceanDroplet_ResizeWithOutDisk(t *testing.T) {
 	})
 }
 
+func TestChangeFromSlugToID(t *testing.T) {
+	parameters := []struct {
+		old      string
+		new      string
+		expected bool
+	}{
+		{"120007", "ubuntu_17_04", false},
+		{"ubuntu_17_04", "120007", true},
+		{"ubuntu_17_04", "ubuntu_17_04", false},
+		{"120007", "120007", false},
+	}
+
+	for i := range parameters {
+		actual, _ := changeFromSlugToID(parameters[i].old, parameters[i].new)
+		if actual != parameters[i].expected {
+			t.Logf("old: %s, new: %s => expected:%t , actual:%t", parameters[i].old, parameters[i].new, parameters[i].expected, actual)
+			t.Fail()
+		}
+	}
+
+}
+
 func TestAccDigitalOceanDroplet_ResizeSmaller(t *testing.T) {
 	var droplet godo.Droplet
 	rInt := acctest.RandInt()

--- a/website/docs/r/droplet.html.markdown
+++ b/website/docs/r/droplet.html.markdown
@@ -77,6 +77,7 @@ The following attributes are exported:
 * `status` - The status of the Droplet
 * `tags` - The tags associated with the Droplet
 * `volume_ids` - A list of the attached block storage volumes
+* `image_id` - The ID of the image used by the Droplet ( equal to `image` when the image do not have an slug)
 
 ## Import
 

--- a/website/docs/r/droplet.html.markdown
+++ b/website/docs/r/droplet.html.markdown
@@ -77,7 +77,9 @@ The following attributes are exported:
 * `status` - The status of the Droplet
 * `tags` - The tags associated with the Droplet
 * `volume_ids` - A list of the attached block storage volumes
-* `image_id` - The ID of the image used by the Droplet ( equal to `image` when the image do not have an slug)
+* `image_id` - The ID of the image used by the Droplet ( equal to `image` when the image do not
+have an slug)
+* `slug` - The slug if present for the image during the creation of the Droplet
 
 ## Import
 


### PR DESCRIPTION
Fixes #152 

1. This PR has been tested tampering with the data provided by the API for different applications. It suppresses changes base on comparing the image to image_id and slug. So if the slug is not present during the API response but the image is returned, then is suppressed as it matches the image id.

2. In the case that there is no information about slug and image_id in the state, and the image contains a slug the information is updated locally.

3. If the API and image are and there is no information available, 
   -  Suppress change when the target value is slung and we have an image id. ( case of the users affected during migration)
   - Do not suppress change if the API returns a slug and the service return an image id.

Test cases:


|  HCL        | Droplet API (Read) |                      State                        | Suppressed         |
|:---------:|:------------------:|:-------------------------------------------------:|--------------------|
| ubuntu_19 |      ubuntu_19     | image: ubuntu_19                                  | No Invoked         |
| ubuntu_19 |        10000       | image: ubuntu_19                                  | True  (issue_case) |
|   10000   |      ubuntu_19     | image: 10000                                      | False              |
|   10000   |        10000       | image: 10000                                      | No Invoked         |
| centos_7 |       10000         | image: 10000                                      | 👎  This case, conflicts with the bug,  we have update the state,  no  information on slug, if the schema change to slug, we dont know if the images have previously the slug, suppressing the change |
| ubuntu_19 |        centos_7    | image ubuntu_19 (state_will_update)               | False              |
|   10000   |        10000       | image: 10000, image_id: 10000                     | No Invoked         |
|   10000   |      ubuntu_19     | image: 10000, image_id: 10000                     | False              |
| ubuntu_19 |       ubuntu_19    | image: ubuntu_19, image_id: 10000,slug: ubuntu_19 | No Invoked         |
| ubuntu_19 |        10000       | image: ubuntu_19, image_id: 10000,slug: ubuntu_19 | True               |
| ubuntu_19 |        10001       | image: ubuntu_19, image_id: 10000,slug: ubuntu_19 | False              |
|   10000   |      ubuntu_19     | image: ubuntu_19, image_id: 10000,slug: ubuntu_19 | True  (same image) |
|   10000   |        10000       | image: ubuntu_19, image_id: 10000,slug: ubuntu_19 | No Invoked         |
|  centos_7 |      ubuntu_19     | image: ubuntu_19, image_id: 10000,slug: ubuntu_19 | False              |

