### PR TITLE
Feature/introduce projects resource

### DIFF
--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -63,6 +63,7 @@ func Provider() terraform.ResourceProvider {
 			"digitalocean_kubernetes_cluster":     resourceDigitalOceanKubernetesCluster(),
 			"digitalocean_kubernetes_node_pool":   resourceDigitalOceanKubernetesNodePool(),
 			"digitalocean_loadbalancer":           resourceDigitalOceanLoadbalancer(),
+			"digitalocean_project":                resourceDigitalOceanProject(),
 			"digitalocean_record":                 resourceDigitalOceanRecord(),
 			"digitalocean_spaces_bucket":          resourceDigitalOceanBucket(),
 			"digitalocean_ssh_key":                resourceDigitalOceanSSHKey(),

--- a/digitalocean/resource_digitalocean_project.go
+++ b/digitalocean/resource_digitalocean_project.go
@@ -1,0 +1,56 @@
+package digitalocean
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceDigitalOceanProject() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDigitalOceanProjectCreate,
+		Read:   resourceDigitalOceanProjectRead,
+		Update: resourceDigitalOceanProjectUpdate,
+		Delete: resourceDigitalOceanProjectDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"purpose": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+		},
+	}
+}
+
+func resourceDigitalOceanProjectCreate(d *schema.ResourceData, meta interface{}) error {
+	//client := meta.(*CombinedConfig).godoClient()
+
+	return resourceDigitalOceanCertificateRead(d, meta)
+}
+
+func resourceDigitalOceanProjectRead(d *schema.ResourceData, meta interface{}) error {
+	//client := meta.(*CombinedConfig).godoClient()
+
+	return nil
+}
+
+func resourceDigitalOceanProjectUpdate(d *schema.ResourceData, meta interface{}) error {
+	//client := meta.(*CombinedConfig).godoClient()
+
+	return resourceDigitalOceanCertificateRead(d, meta)
+}
+
+func resourceDigitalOceanProjectDelete(d *schema.ResourceData, meta interface{}) error {
+	//client := meta.(*CombinedConfig).godoClient()
+
+	return nil
+}

--- a/digitalocean/resource_digitalocean_project.go
+++ b/digitalocean/resource_digitalocean_project.go
@@ -1,8 +1,13 @@
 package digitalocean
 
 import (
+	"context"
+	"fmt"
+	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
+	"log"
+	"strings"
 )
 
 func resourceDigitalOceanProject() *schema.Resource {
@@ -17,40 +22,148 @@ func resourceDigitalOceanProject() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "the human-readable name for the project",
+				ValidateFunc: validation.All(
+					validation.NoZeroValues,
+					validation.StringLenBetween(1, 175),
+				),
+			},
+			"description": {
 				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.NoZeroValues,
+				Optional:     true,
+				Default:      "",
+				Description:  "the descirption of the project",
+				ValidateFunc: validation.StringLenBetween(0, 255),
 			},
 			"purpose": {
 				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.NoZeroValues,
+				Optional:     true,
+				Default:      "Web Application",
+				Description:  "the purpose of the project",
+				ValidateFunc: validation.StringLenBetween(0, 255),
+			},
+			"environment": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "Development",
+				Description:  "the environment of the project's resources",
+				ValidateFunc: validation.StringInSlice([]string{"development", "staging", "production"}, true),
+			},
+			"owner_uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "the unique universal identifier of the project owner.",
+			},
+			"owner_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "the id of the project owner.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "the date and time when the project was created, (ISO8601)",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "the date and time when the project was last updated, (ISO8601)",
 			},
 		},
 	}
 }
 
 func resourceDigitalOceanProjectCreate(d *schema.ResourceData, meta interface{}) error {
-	//client := meta.(*CombinedConfig).godoClient()
+	client := meta.(*CombinedConfig).godoClient()
 
-	return resourceDigitalOceanCertificateRead(d, meta)
+	projectRequest := &godo.CreateProjectRequest{
+		Name:    d.Get("name").(string),
+		Purpose: d.Get("purpose").(string),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		projectRequest.Description = v.(string)
+	}
+
+	if v, ok := d.GetOk("environment"); ok {
+		projectRequest.Environment = v.(string)
+	}
+
+	log.Printf("[DEBUG] Project create request: %#v", projectRequest)
+	project, _, err := client.Projects.Create(context.Background(), projectRequest)
+
+	if err != nil {
+		return fmt.Errorf("Error creating Project: %s", err)
+	}
+
+	d.SetId(project.ID)
+	log.Printf("[INFO] Project created, ID: %s", d.Id())
+
+	return resourceDigitalOceanProjectRead(d, meta)
 }
 
 func resourceDigitalOceanProjectRead(d *schema.ResourceData, meta interface{}) error {
-	//client := meta.(*CombinedConfig).godoClient()
+	client := meta.(*CombinedConfig).godoClient()
 
-	return nil
+	project, resp, err := client.Projects.Get(context.Background(), d.Id())
+
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Printf("[DEBUG] Project  (%s) was not found - removing from state", d.Id())
+			d.SetId("")
+		}
+
+		return fmt.Errorf("Error reading Project: %s", err)
+	}
+
+	d.Set("id", project.ID)
+	d.Set("name", project.Name)
+	d.Set("purpose", strings.TrimPrefix(project.Purpose, "Other: "))
+	d.Set("description", project.Description)
+	d.Set("environment", project.Environment)
+	d.Set("is_default", project.IsDefault)
+	d.Set("owner_uuid", project.OwnerUUID)
+	d.Set("owner_id", project.OwnerID)
+	d.Set("created_at", project.CreatedAt)
+	d.Set("updated_at", project.UpdatedAt)
+
+	return err
 }
 
 func resourceDigitalOceanProjectUpdate(d *schema.ResourceData, meta interface{}) error {
-	//client := meta.(*CombinedConfig).godoClient()
+	client := meta.(*CombinedConfig).godoClient()
 
-	return resourceDigitalOceanCertificateRead(d, meta)
+	projectRequest := &godo.UpdateProjectRequest{
+		Name:        d.Get("name"),
+		Description: d.Get("description"),
+		Purpose:     d.Get("purpose"),
+		Environment: d.Get("environment"),
+		IsDefault:   d.Get("is_default"),
+	}
+
+	_, _, err := client.Projects.Update(context.Background(), d.Id(), projectRequest)
+	if err != nil {
+		return fmt.Errorf("Error updating Project: %s", err)
+	}
+
+	log.Printf("[INFO] Updated Project")
+
+	return resourceDigitalOceanProjectRead(d, meta)
 }
 
 func resourceDigitalOceanProjectDelete(d *schema.ResourceData, meta interface{}) error {
-	//client := meta.(*CombinedConfig).godoClient()
+	client := meta.(*CombinedConfig).godoClient()
+	resourceId := d.Id()
+
+	_, err := client.Projects.Delete(context.Background(), resourceId)
+	if err != nil {
+		return fmt.Errorf("Error deleteing Project %s", err)
+	}
+
+	d.SetId("")
+	log.Printf("[INFO] Project deleted, ID: %s", resourceId)
 
 	return nil
 }

--- a/digitalocean/resource_digitalocean_project.go
+++ b/digitalocean/resource_digitalocean_project.go
@@ -71,6 +71,12 @@ func resourceDigitalOceanProject() *schema.Resource {
 				Computed:    true,
 				Description: "the date and time when the project was last updated, (ISO8601)",
 			},
+			"resources": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "the resources associated with the project",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -96,6 +102,16 @@ func resourceDigitalOceanProjectCreate(d *schema.ResourceData, meta interface{})
 
 	if err != nil {
 		return fmt.Errorf("Error creating Project: %s", err)
+	}
+
+	if v, ok := d.GetOk("resources"); ok {
+
+		resources, err := assignResourcesToProject(client, project.ID, v.(*schema.Set))
+		if err != nil {
+			return fmt.Errorf("Error creating project: %s", err)
+		}
+
+		d.Set("resources", resources)
 	}
 
 	d.SetId(project.ID)
@@ -129,11 +145,21 @@ func resourceDigitalOceanProjectRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("created_at", project.CreatedAt)
 	d.Set("updated_at", project.UpdatedAt)
 
+	urns, err := loadResourceURNs(client, project.ID)
+	if err != nil {
+		return fmt.Errorf("Error reading Project: %s", err)
+	}
+
+	d.Set("resources", urns)
+
 	return err
 }
 
 func resourceDigitalOceanProjectUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
+	projectId := d.Id()
+
+	d.Partial(true)
 
 	projectRequest := &godo.UpdateProjectRequest{
 		Name:        d.Get("name"),
@@ -143,27 +169,122 @@ func resourceDigitalOceanProjectUpdate(d *schema.ResourceData, meta interface{})
 		IsDefault:   d.Get("is_default"),
 	}
 
-	_, _, err := client.Projects.Update(context.Background(), d.Id(), projectRequest)
+	_, _, err := client.Projects.Update(context.Background(), projectId, projectRequest)
 	if err != nil {
 		return fmt.Errorf("Error updating Project: %s", err)
 	}
 
-	log.Printf("[INFO] Updated Project")
+	d.SetPartial("project_updated")
+
+	// The API requires project resources to be reassigned to another project if the association needs to be deleted.
+	// a diff of the resource could be implemented instead of removing all, (bulk) and adding the back again.
+	if d.HasChange("resources") {
+		oldURNs, newURNs := d.GetChange("resources")
+
+		assignResourcesToDefaultProject(client, oldURNs.(*schema.Set))
+
+		var urns *[]interface{}
+
+		if newURNs.(*schema.Set).Len() != 0 {
+			urns, err = assignResourcesToProject(client, projectId, newURNs.(*schema.Set))
+			if err != nil {
+				return fmt.Errorf("Error Updating project: %s", err)
+			}
+		}
+
+		d.Set("resources", urns)
+		d.SetPartial("project_resources_updated")
+	}
+
+	log.Printf("[INFO] Updated Project, ID: ")
+	d.Partial(false)
 
 	return resourceDigitalOceanProjectRead(d, meta)
 }
 
 func resourceDigitalOceanProjectDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
-	resourceId := d.Id()
 
-	_, err := client.Projects.Delete(context.Background(), resourceId)
+	defaultProject, _, defaultProjErr := client.Projects.GetDefault(context.Background())
+	if defaultProjErr != nil {
+		return fmt.Errorf("Error locating default project %s", defaultProjErr)
+	}
+
+	projectId := d.Id()
+	defaultProjectId := defaultProject.ID
+
+	log.Printf("[DEBUG] Default project located, ID: %s", defaultProjectId)
+
+	if v, ok := d.GetOk("resources"); ok {
+
+		_, err := assignResourcesToProject(client, defaultProjectId, v.(*schema.Set))
+		if err != nil {
+			return fmt.Errorf("Error assigning resource to default project: %s", err)
+		}
+
+		d.Set("resources", nil)
+		log.Printf("[DEBUG] Resources assigned to default project: %s", defaultProjectId)
+	}
+
+	_, err := client.Projects.Delete(context.Background(), projectId)
 	if err != nil {
-		return fmt.Errorf("Error deleteing Project %s", err)
+		return fmt.Errorf("Error deleteing project %s", err)
 	}
 
 	d.SetId("")
-	log.Printf("[INFO] Project deleted, ID: %s", resourceId)
+	log.Printf("[INFO] Project deleted, ID: %s", projectId)
 
 	return nil
+}
+
+func assignResourcesToDefaultProject(client *godo.Client, resources *schema.Set) (*[]interface{}, error) {
+
+	defaultProject, _, defaultProjErr := client.Projects.GetDefault(context.Background())
+	if defaultProjErr != nil {
+		return nil, fmt.Errorf("Error locating default project %s", defaultProjErr)
+	}
+
+	return assignResourcesToProject(client, defaultProject.ID, resources)
+}
+
+func assignResourcesToProject(client *godo.Client, projectId string, resources *schema.Set) (*[]interface{}, error) {
+
+	var urns []interface{}
+
+	for _, resource := range resources.List() {
+
+		if resource == nil {
+			continue
+		}
+
+		if resource == "" {
+			continue
+		}
+
+		urns = append(urns, resource.(string))
+	}
+
+	_, _, err := client.Projects.AssignResources(context.Background(), projectId, urns...)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error assigning resources: %s", err)
+	}
+
+	return &urns, nil
+}
+
+func loadResourceURNs(client *godo.Client, projectId string) (*[]interface{}, error) {
+
+	resources, _, err := client.Projects.ListResources(context.Background(), projectId, nil)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error loading resources %s", err)
+	}
+
+	var urns []interface{}
+	for _, rsrc := range resources {
+		urns = append(urns, rsrc.URN)
+	}
+
+	return &urns, nil
 }

--- a/digitalocean/resource_digitalocean_project_test.go
+++ b/digitalocean/resource_digitalocean_project_test.go
@@ -1,11 +1,202 @@
 package digitalocean
 
 import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 	"testing"
 )
 
-func TestAccDigitalOceanProject_Basic(t *testing.T) {
+func TestAccDigitalOceanProject_CreateWithDefaults(t *testing.T) {
 
+	expectedName := generateProjectName()
+	createConfig := fixtureCreateWithDefaults(expectedName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: createConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanProjectExists("digitalocean_project.myproj"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "name", expectedName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "description", ""),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "purpose", "Web Application"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "environment", "Development"),
+					resource.TestCheckResourceAttrSet("digitalocean_project.myproj", "id"),
+					resource.TestCheckResourceAttrSet("digitalocean_project.myproj", "owner_uuid"),
+					resource.TestCheckResourceAttrSet("digitalocean_project.myproj", "owner_id"),
+					resource.TestCheckResourceAttrSet("digitalocean_project.myproj", "created_at"),
+					resource.TestCheckResourceAttrSet("digitalocean_project.myproj", "updated_at"),
+				),
+			},
+		},
+	})
 }
 
-const testAccCheckDigitalOceanProjectConfig_basic = ``
+func TestAccDigitalOceanProject_CreateWithInitialValues(t *testing.T) {
+
+	expectedName := generateProjectName()
+	expectedDescription := "A simple project for a web app."
+	expectedPurpose := "My Basic Web App"
+	expectedEnvironment := "Production"
+
+	createConfig := fixtureCreateWithInitialValues(expectedName, expectedDescription,
+		expectedPurpose, expectedEnvironment)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: createConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanProjectExists("digitalocean_project.myproj"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "name", expectedName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "description", expectedDescription),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "purpose", expectedPurpose),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "environment", expectedEnvironment),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanProject_UpdateWithInitialValues(t *testing.T) {
+
+	expectedName := generateProjectName()
+	expectedDesc := "A simple project for a web app."
+	expectedPurpose := "My Basic Web App"
+	expectedEnv := "Production"
+
+	createConfig := fixtureCreateWithInitialValues(expectedName, expectedDesc,
+		expectedPurpose, expectedEnv)
+
+	expectedUpdateName := generateProjectName()
+	expectedUpdateDesc := "A simple project for Beta testing."
+	expectedUpdatePurpose := "MyWeb App, (Beta)"
+	expectedUpdateEnv := "Staging"
+
+	updateConfig := fixtureUpdateWithValues(expectedUpdateName, expectedUpdateDesc,
+		expectedUpdatePurpose, expectedUpdateEnv)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: createConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanProjectExists("digitalocean_project.myproj"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "name", expectedName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "description", expectedDesc),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "purpose", expectedPurpose),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "environment", expectedEnv),
+				),
+			},
+			{
+				Config: updateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanProjectExists("digitalocean_project.myproj"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "name", expectedUpdateName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "description", expectedUpdateDesc),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "purpose", expectedUpdatePurpose),
+					resource.TestCheckResourceAttr(
+						"digitalocean_project.myproj", "environment", expectedUpdateEnv),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDigitalOceanProjectDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*CombinedConfig).godoClient()
+
+	for _, rs := range s.RootModule().Resources {
+
+		if rs.Type != "digitalocean_project" {
+			continue
+		}
+
+		_, _, err := client.Projects.Get(context.Background(), rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Project resource still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDigitalOceanProjectExists(resource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*CombinedConfig).godoClient()
+
+		rs, ok := s.RootModule().Resources[resource]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", resource)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID set for resource: %s", resource)
+		}
+
+		foundProject, _, err := client.Projects.Get(context.Background(), rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if foundProject.ID != rs.Primary.ID {
+			return fmt.Errorf("Resource not found: %s : %s", resource, rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func generateProjectName() string {
+	return fmt.Sprintf("tf-proj-test-%d", acctest.RandInt())
+}
+
+func fixtureCreateWithDefaults(name string) string {
+	return fmt.Sprintf(`
+		resource "digitalocean_project" "myproj" {
+			name = "%s"
+		}`, name)
+}
+
+func fixtureUpdateWithValues(name, description, purpose, environment string) string {
+	return fixtureCreateWithInitialValues(name, description, purpose, environment)
+}
+
+func fixtureCreateWithInitialValues(name, description, purpose, environment string) string {
+	return fmt.Sprintf(`
+		resource "digitalocean_project" "myproj" {
+			name = "%s"
+			description = "%s"
+			purpose = "%s"
+			environment = "%s"
+		}`, name, description, purpose, environment)
+}

--- a/digitalocean/resource_digitalocean_project_test.go
+++ b/digitalocean/resource_digitalocean_project_test.go
@@ -1,0 +1,11 @@
+package digitalocean
+
+import (
+	"testing"
+)
+
+func TestAccDigitalOceanProject_Basic(t *testing.T) {
+
+}
+
+const testAccCheckDigitalOceanProjectConfig_basic = ``

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_project"
+sidebar_current: "docs-do-resource-project"
+description: |-
+  Provides a DigitalOcean Project resource.
+---
+
+# digitalocean\_project
+
+Provides a DigitalOcean Project resource. 
+
+## Example Usage
+
+```
+TODO:  Expand with project based example
+TODO:  second example with a refernece to another resource.
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Project
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The id of the project
+* `name` - The name of the project
+
+
+## Import
+

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -8,13 +8,48 @@ description: |-
 
 # digitalocean\_project
 
-Provides a DigitalOcean Project resource. 
+Provides a DigitalOcean Project resource.
+
+Projects allow you to organize your resources into groups that fit the way you work. 
+You can group resources (like Droplets, Spaces, Load Balancers, domains, and Floating IPs) 
+in ways that align with the applications you host on DigitalOcean. 
+
+A terrafrom managed project cannot be set as a default project.  
+This will reduce the amount of drift associated with the project.
+
 
 ## Example Usage
 
+The following example demonstrates the creation of an empty project.
+
 ```
-TODO:  Expand with project based example
-TODO:  second example with a refernece to another resource.
+resource "digitalocean_project" "playground" {
+    name = "playground"
+    description = "A project to represent development resources."
+    purpose = "Web Application"
+    environment = "Development"
+}
+```
+
+The following example demonstrates the creation of a project with droplet resource.
+
+```
+resource "digitalocean_droplet" "foobar" {
+      name      = "example"
+      size      = "512mb"
+      image     = "centos-7-x64"
+      region    = "nyc3"
+      user_data = "foobar"
+}
+
+resource "digitalocean_project" "playground" {
+    name = "playground"
+    description = "A project to represent development resources."
+    purpose = "Web Application"
+    environment = "Development"
+    resources = ["${digitalocean_droplet.foobar.urn}"]
+}
+
 ```
 
 ## Argument Reference
@@ -22,14 +57,27 @@ TODO:  second example with a refernece to another resource.
 The following arguments are supported:
 
 * `name` - (Required) The name of the Project
+* `description` - (Optional) the descirption of the project
+* `purpose` - (Optional) the purpose of the project, (Default "Web Application")
+* `environment` - (Optional) the environment of the project's resources.  The possible values are: `development`, `Staging`, `Production`)
+* `resources` - the resources associated with the project
+
+The following resources can be associated with a project
+
+* Droplet
+* Load Balancer
+* Domain
+* Volume
+* Floating IP
+* Spaces Bucket
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The id of the project
-* `name` - The name of the project
-
-
-## Import
+* `owner_uuid` - the unique universal identifier of the project owner.
+* `owner_id` - the id of the project owner.
+* `created_at` - the date and time when the project was created, (ISO8601)
+* `updated_at` - the date and time when the project was last updated, (ISO8601)
 


### PR DESCRIPTION
This PR introduces the DigitalOcean Project resource and supportive documentation/tests. The first tests cover the creation and updating of the basic fields in the project. Later tests add and update/remove the other resource associations with the project.

Notes:
To remove the resources from the project, the old resources are linked to the current default project and then the new resources are linked back to the managed project. The new list may include resources from the old list if they are still linked to the project.

The tests use the droplet and spaces resources, but there are other resources. The main requirement is the availability of the URN attribute on the resource and this was before this PR.