### PR TITLE
Various resource import improvements (Fixes: #231).

### DIFF
--- a/digitalocean/import_digitalocean_droplet_test.go
+++ b/digitalocean/import_digitalocean_droplet_test.go
@@ -3,6 +3,7 @@ package digitalocean
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/digitalocean/godo"
@@ -30,6 +31,14 @@ func TestAccDigitalOceanDroplet_importBasic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"ssh_keys", "user_data", "resize_disk"}, //we ignore the ssh_keys, resize_disk and user_data as we do not set to state
+			},
+			// Test importing non-existent resource provides expected error.
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "123",
+				ExpectError:       regexp.MustCompile(`(Please verify the ID is correct|Cannot import non-existent remote object)`),
 			},
 		},
 	})

--- a/digitalocean/import_digitalocean_record_test.go
+++ b/digitalocean/import_digitalocean_record_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -28,6 +29,14 @@ func TestAccDigitalOceanRecord_importBasic(t *testing.T) {
 				ImportStateVerify: true,
 				// Requires passing both the ID and domain
 				ImportStateIdPrefix: fmt.Sprintf("%s,", domainName),
+			},
+			// Test importing non-existent resource provides expected error.
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   false,
+				ImportStateIdPrefix: fmt.Sprintf("%s,", "nonexistent.com"),
+				ExpectError:         regexp.MustCompile(`(Please verify the ID is correct|Cannot import non-existent remote object)`),
 			},
 		},
 	})

--- a/digitalocean/import_digitalocean_spaces_bucket_test.go
+++ b/digitalocean/import_digitalocean_spaces_bucket_test.go
@@ -2,6 +2,7 @@ package digitalocean
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -25,8 +26,16 @@ func TestAccDigitalOceanBucket_importBasic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateIdPrefix:     fmt.Sprintf("%s,", "nyc3"),
+				ImportStateIdPrefix:     fmt.Sprintf("%s,", "sfo2"),
 				ImportStateVerifyIgnore: []string{"acl", "force_destroy"},
+			},
+			// Test importing non-existent resource provides expected error.
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "sfo2,nonexistent-bucket",
+				ExpectError:       regexp.MustCompile(`(Please verify the ID is correct|Cannot import non-existent remote object)`),
 			},
 		},
 	})

--- a/digitalocean/import_digitalocean_volume_test.go
+++ b/digitalocean/import_digitalocean_volume_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -26,6 +27,14 @@ func TestAccDigitalOceanVolume_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			// Test importing non-existent resource provides expected error.
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "123abc",
+				ExpectError:       regexp.MustCompile(`(Please verify the ID is correct|Cannot import non-existent remote object)`),
 			},
 		},
 	})

--- a/digitalocean/resource_digitalocean_record.go
+++ b/digitalocean/resource_digitalocean_record.go
@@ -234,15 +234,7 @@ func resourceDigitalOceanRecordImport(d *schema.ResourceData, meta interface{}) 
 		d.Set("domain", s[0])
 	}
 
-	err := resourceDigitalOceanRecordRead(d, meta)
-	if err != nil {
-		return nil, fmt.Errorf("unable to import record: %v", err)
-	}
-
-	results := make([]*schema.ResourceData, 0)
-	results = append(results, d)
-
-	return results, nil
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceDigitalOceanRecordUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/digitalocean/resource_digitalocean_spaces_bucket.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket.go
@@ -295,15 +295,7 @@ func resourceDigitalOceanBucketImport(d *schema.ResourceData, meta interface{}) 
 		d.Set("region", s[0])
 	}
 
-	err := resourceDigitalOceanBucketRead(d, meta)
-	if err != nil {
-		return nil, fmt.Errorf("unable to import bucket: %v", err)
-	}
-
-	results := make([]*schema.ResourceData, 0)
-	results = append(results, d)
-
-	return results, nil
+	return []*schema.ResourceData{d}, nil
 }
 
 func bucketDomainName(bucket string, region string) string {

--- a/digitalocean/resource_digitalocean_spaces_bucket_test.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket_test.go
@@ -276,7 +276,8 @@ resource "digitalocean_spaces_bucket" "bucket" {
 func testAccDigitalOceanBucketConfigImport(randInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_spaces_bucket" "bucket" {
-	name = "tf-test-bucket-%d"
+	name   = "tf-test-bucket-%d"
+	region = "sfo2"
 }
 `, randInt)
 }


### PR DESCRIPTION
This PR brings in a number of improvements around resource importing. Specifically:

- For Volumes, it removes the need for a custom function altogether by just using `ImportStatePassthrough`
- For resources that really do require a custom import function (Droplet, Domain Records, and Spaces buckets), it removes unnecessary calls to the resource read functions. The only thing that is required in the import function is to set the specific attributes.
- For all of the changed resources, an additional test has been added to ensure that a proper error message is provided when the resource being imported does not exist (e.g. the ID was wrong).
- For the Droplet resource, it adds some additional error checking to the custom import function.

```
asb@asb-do:~/projects/go/src/github.com/terraform-providers/terraform-provider-digitalocean$ make testacc TESTARGS='-run=TestAccDigitalOceanDroplet_importBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDroplet_importBasic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDroplet_importBasic
--- PASS: TestAccDigitalOceanDroplet_importBasic (31.76s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	31.771s
asb@asb-do:~/projects/go/src/github.com/terraform-providers/terraform-provider-digitalocean$ make testacc TESTARGS='-run=TestAccDigitalOceanRecord_importBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanRecord_importBasic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanRecord_importBasic
--- PASS: TestAccDigitalOceanRecord_importBasic (2.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	2.929s
asb@asb-do:~/projects/go/src/github.com/terraform-providers/terraform-provider-digitalocean$ make testacc TESTARGS='-run=TestAccDigitalOceanBucket_importBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanBucket_importBasic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanBucket_importBasic
--- PASS: TestAccDigitalOceanBucket_importBasic (4.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	(cached)
asb@asb-do:~/projects/go/src/github.com/terraform-providers/terraform-provider-digitalocean$ make testacc TESTARGS='-run=TestAccDigitalOceanVolume_importBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanVolume_importBasic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanVolume_importBasic
--- PASS: TestAccDigitalOceanVolume_importBasic (2.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	2.972s
```

Closes #231 