### PR TITLE
resource/droplet: Removing the IPv6 private parameter

### DIFF
--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -131,6 +131,7 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 			"ipv6_address_private": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Removed:  "DigitalOcean does not provide private IPv6 networking",
 			},
 
 			"private_networking": {
@@ -324,7 +325,6 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("ipv4_address", findIPv4AddrByType(droplet, "public"))
 	d.Set("ipv4_address_private", findIPv4AddrByType(droplet, "private"))
 	d.Set("ipv6_address", findIPv6AddrByType(droplet, "public"))
-	d.Set("ipv6_address_private", findIPv6AddrByType(droplet, "private"))
 
 	if features := droplet.Features; features != nil {
 		d.Set("backups", containsDigitalOceanDropletFeature(features, "backups"))


### PR DESCRIPTION
Fixes: #181

DigitalOcean doesn't support IPv6 private networking. Therefore,
having a parameter in the schema for this isn't correct. It has
been marked as `removed` with an appropriate error message