### PR TITLE
K8s: Do not filter out node pool tags also applied to the cluster (Fixes: #184).

### DIFF
--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -380,13 +380,3 @@ func filterTags(tags []string) []string {
 
 	return filteredTags
 }
-
-func tagsContain(tags []string, tag string) bool {
-	for _, t := range tags {
-		if t == tag {
-			return true
-		}
-	}
-
-	return false
-}

--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -367,13 +367,13 @@ func flattenKubeConfig(config *godo.KubernetesClusterConfig) []interface{} {
 }
 
 // we need to filter tags to remove any automatically added to avoid state problems,
-// these are tags starting with "k8s:", named "k8s" or duplicates of the cluster tags
-func filterTags(tags []string, parentTags ...string) []string {
+// these are tags starting with "k8s:" or named "k8s"
+func filterTags(tags []string) []string {
 	filteredTags := make([]string, 0)
 	for _, t := range tags {
 		if !strings.HasPrefix(t, "k8s:") &&
 			!strings.HasPrefix(t, "terraform:") &&
-			t != "k8s" && !tagsContain(parentTags, t) {
+			t != "k8s" {
 			filteredTags = append(filteredTags, t)
 		}
 	}

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -31,7 +31,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "cluster_subnet"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "service_subnet"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "endpoint"),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "tags.#", "2"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "tags.#", "3"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "tags.2356372769", "foo"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "tags.1996459178", "bar"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "status"),
@@ -183,7 +183,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
 	version = "1.14.2-do.0"
-	tags    = ["foo","bar"]
+	tags    = ["foo","bar", "one"]
 
 	node_pool {
 	  name = "default"

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -3,6 +3,7 @@ package digitalocean
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/digitalocean/godo"
@@ -334,5 +335,36 @@ func testAccCheckDigitalOceanKubernetesClusterExists(n string, cluster *godo.Kub
 		*cluster = *foundCluster
 
 		return nil
+	}
+}
+
+func Test_filterTags(t *testing.T) {
+	tests := []struct {
+		have []string
+		want []string
+	}{
+		{
+			have: []string{"k8s", "foo"},
+			want: []string{"foo"},
+		},
+		{
+			have: []string{"k8s", "k8s:looks-like-a-uuid", "bar"},
+			want: []string{"bar"},
+		},
+		{
+			have: []string{"k8s", "k8s:looks-like-a-uuid", "bar", "k8s-this-is-ok"},
+			want: []string{"bar", "k8s-this-is-ok"},
+		},
+		{
+			have: []string{"k8s", "k8s:looks-like-a-uuid", "terraform:default-node-pool", "baz"},
+			want: []string{"baz"},
+		},
+	}
+
+	for _, tt := range tests {
+		filteredTags := filterTags(tt.have)
+		if !reflect.DeepEqual(filteredTags, tt.want) {
+			t.Errorf("filterTags returned %+v, expected %+v", filteredTags, tt.want)
+		}
 	}
 }

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool.go
@@ -145,20 +145,10 @@ func resourceDigitalOceanKubernetesNodePoolRead(d *schema.ResourceData, meta int
 		return fmt.Errorf("Error retrieving Kubernetes node pool: %s", err)
 	}
 
-	cluster, resp, err := client.Kubernetes.Get(context.Background(), d.Get("cluster_id").(string))
-	if err != nil {
-		if resp.StatusCode == 404 {
-			d.SetId("")
-			return nil
-		}
-
-		return fmt.Errorf("Error retrieving Kubernetes cluster: %s", err)
-	}
-
 	d.Set("name", pool.Name)
 	d.Set("size", pool.Size)
 	d.Set("node_count", pool.Count)
-	d.Set("tags", flattenTags(filterTags(pool.Tags, cluster.Tags...)))
+	d.Set("tags", flattenTags(filterTags(pool.Tags)))
 
 	if pool.Nodes != nil {
 		d.Set("nodes", flattenNodes(pool.Nodes))
@@ -363,7 +353,7 @@ func flattenNodePool(pool *godo.KubernetesNodePool, parentTags ...string) []inte
 	}
 
 	if pool.Tags != nil {
-		rawPool["tags"] = flattenTags(filterTags(pool.Tags, parentTags...))
+		rawPool["tags"] = flattenTags(filterTags(pool.Tags))
 	}
 
 	if pool.Nodes != nil {


### PR DESCRIPTION
While still in beta, the DigitalOcean Kubernetes API automatically applied tags
from the cluster to the node pools. The provider's `filterTags` function
accounted for this by not manually applying tags found on the parent cluster
to the children node pools:
```
// we need to filter tags to remove any automatically added to avoid state problems,
// these are tags starting with "k8s:", named "k8s" or duplicates of the cluster tags
```

This does not match the current behavior of the API. See:

#184

The updated test fails without the additional changes:
```
$ make testacc TESTARGS='-run=TestAccDigitalOceanKubernetesCluster_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanKubernetesCluster_Basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanKubernetesCluster_Basic
--- FAIL: TestAccDigitalOceanKubernetesCluster_Basic (211.95s)
    testing.go:538: Step 0 error: Check failed: 3 errors occurred:
        	* Check 9/30 error: digitalocean_kubernetes_cluster.foobar: Attribute 'tags.#' expected "2", got "3"
        	* Check 18/30 error: digitalocean_kubernetes_cluster.foobar: Attribute 'node_pool.0.tags.#' expected "2", got "1"
        	* Check 19/30 error: digitalocean_kubernetes_cluster.foobar: Attribute 'node_pool.0.tags.2053932785' not found

FAIL
FAIL	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	211.957s
GNUmakefile:18: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

And passes with them:
```
$ make testacc TESTARGS='-run=TestAccDigitalOceanKubernetesCluster_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanKubernetesCluster_Basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanKubernetesCluster_Basic
--- PASS: TestAccDigitalOceanKubernetesCluster_Basic (242.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	242.736s
```