### PR TITLE
provider: Add the ability to set DIGITALOCEAN_ACCESS_TOKEN

### DIFF
--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -10,8 +10,8 @@ func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"token": {
-				Type:        schema.TypeString,
-				Required:    true,
+				Type:     schema.TypeString,
+				Required: true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"DIGITALOCEAN_TOKEN",
 					"DIGITALOCEAN_ACCESS_TOKEN",

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -12,7 +12,10 @@ func Provider() terraform.ResourceProvider {
 			"token": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("DIGITALOCEAN_TOKEN", nil),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"DIGITALOCEAN_TOKEN",
+					"DIGITALOCEAN_ACCESS_TOKEN",
+				}, nil),
 				Description: "The token key for API operations.",
 			},
 			"api_endpoint": {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -36,8 +36,10 @@ resource "digitalocean_droplet" "web" {
 
 The following arguments are supported:
 
-* `token` - (Required) This is the DO API token. This can also be specified
-  with the `DIGITALOCEAN_TOKEN` shell environment variable.
+* `token` - (Required) This is the DO API token. Alternatively, this can also be specified
+  using environment variables ordered by precedence:
+  * `DIGITALOCEAN_TOKEN`
+  * `DIGITALOCEAN_ACCESS_TOKEN`
 * `spaces_access_id` - (Optional) The access key ID used for Spaces API
   operations (Defaults to the value of the `SPACES_ACCESS_KEY_ID` environment
   variable).


### PR DESCRIPTION
Fixes: #260

This follows the same usage as `doctl` so not having to reset env
vars would be a better experience. This DOT NOT remove DIGITALOCEAN_TOKEN,
this just adds the ability to specify one of the two and the
provider will continue to work as expected