### PR TITLE
Support enabling and disabling backups on Droplets (Fixes: #266).

### DIFF
--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -483,6 +483,32 @@ func resourceDigitalOceanDropletUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
+	if d.HasChange("backups") {
+		if d.Get("backups").(bool) {
+			// Enable backups on droplet
+			action, _, err := client.DropletActions.EnableBackups(context.Background(), id)
+			if err != nil {
+				return fmt.Errorf(
+					"Error enabling backups on droplet (%s): %s", d.Id(), err)
+			}
+
+			if err := waitForAction(client, action); err != nil {
+				return fmt.Errorf("Error waiting for backups to be enabled for droplet (%s): %s", d.Id(), err)
+			}
+		} else {
+			// Disable backups on droplet
+			action, _, err := client.DropletActions.DisableBackups(context.Background(), id)
+			if err != nil {
+				return fmt.Errorf(
+					"Error disabling backups on droplet (%s): %s", d.Id(), err)
+			}
+
+			if err := waitForAction(client, action); err != nil {
+				return fmt.Errorf("Error waiting for backups to be disabled for droplet (%s): %s", d.Id(), err)
+			}
+		}
+	}
+
 	// As there is no way to disable private networking,
 	// we only check if it needs to be enabled
 	if d.HasChange("private_networking") && d.Get("private_networking").(bool) {


### PR DESCRIPTION
Somehow we never seem to have supported enabling and disabling backups on Droplets. 😯 This fixes that!

New test failing pre-change:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDroplet_EnableAndDisableBackups'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDroplet_EnableAndDisableBackups -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDroplet_EnableAndDisableBackups
--- FAIL: TestAccDigitalOceanDroplet_EnableAndDisableBackups (36.81s)
    testing.go:568: Step 1 error: Check failed: Check 2/2 error: digitalocean_droplet.foobar: Attribute 'backups' expected "true", got "false"
FAIL
FAIL	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	36.835s
GNUmakefile:18: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

New test passing post change:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDroplet_EnableAndDisableBackups'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDroplet_EnableAndDisableBackups -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDroplet_EnableAndDisableBackups
--- PASS: TestAccDigitalOceanDroplet_EnableAndDisableBackups (59.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	59.178s
```