### PR TITLE
Update digitalocean_kubernetes_cluster version

### DIFF
--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -27,7 +27,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "region", "lon1"),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", "1.14.2-do.0"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", "1.14.4-do.0"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "ipv4_address"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "cluster_subnet"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "service_subnet"),
@@ -183,7 +183,7 @@ func testAccDigitalOceanKubernetesConfigBasic(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.14.2-do.0"
+	version = "1.14.4-do.0"
 	tags    = ["foo","bar", "one"]
 
 	node_pool {
@@ -201,7 +201,7 @@ func testAccDigitalOceanKubernetesConfigBasic2(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.14.2-do.0"
+	version = "1.14.4-do.0"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -219,7 +219,7 @@ func testAccDigitalOceanKubernetesConfigBasic3(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.14.2-do.0"
+	version = "1.14.4-do.0"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -237,7 +237,7 @@ func testAccDigitalOceanKubernetesConfigBasic4(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.14.2-do.0"
+	version = "1.14.4-do.0"
 	tags    = ["one","two"]
 
 	node_pool {
@@ -255,7 +255,7 @@ func testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(rNam
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.14.2-do.0"
+	version = "1.14.4-do.0"
 
 	node_pool {
 	  name = "default"

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -16,7 +16,7 @@ Provides a DigitalOcean Kubernetes cluster resource. This can be used to create,
 resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
-  version = "1.14.2-do.0"
+  version = "1.14.4-do.0"
 
   node_pool {
     name       = "worker-pool"
@@ -32,7 +32,7 @@ The cluster's kubeconfig is exported as an attribute allowing you to use it with
 resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
-  version = "1.14.2-do.0"
+  version = "1.14.4-do.0"
   tags    = ["staging"]
 
   node_pool {


### PR DESCRIPTION
DigitalOcean has deprecated version `1.14.2-do.0` in favor of version `1.14.4-do.0` for the `digitalocean_kubernetes_cluster` resource. 


Error when using version `1.14.2-do.0`:

> Error: Error creating Kubernetes cluster: POST https://api.digitalocean.com/v2/kubernetes/clusters: 422 rpc error: code = InvalidArgument desc = validation error: invalid version slug