### PR TITLE
Consistently protect against nil response in error handling (Fixes: #272).

### DIFF
--- a/digitalocean/datasource_digitalocean_domain.go
+++ b/digitalocean/datasource_digitalocean_domain.go
@@ -46,7 +46,7 @@ func dataSourceDigitalOceanDomainRead(d *schema.ResourceData, meta interface{}) 
 
 	domain, resp, err := client.Domains.Get(context.Background(), name)
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			return fmt.Errorf("domain not found: %s", err)
 		}
 		return fmt.Errorf("Error retrieving domain: %s", err)

--- a/digitalocean/datasource_digitalocean_floating_ip.go
+++ b/digitalocean/datasource_digitalocean_floating_ip.go
@@ -46,7 +46,7 @@ func dataSourceDigitalOceanFloatingIpRead(d *schema.ResourceData, meta interface
 
 	floatingIp, resp, err := client.FloatingIPs.Get(context.Background(), ipAddress)
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			return fmt.Errorf("floating ip not found: %s", err)
 		}
 		return fmt.Errorf("Error retrieving floating ip: %s", err)

--- a/digitalocean/datasource_digitalocean_image.go
+++ b/digitalocean/datasource_digitalocean_image.go
@@ -121,7 +121,7 @@ func dataSourceDigitalOceanImageRead(d *schema.ResourceData, meta interface{}) e
 
 		image, resp, err = client.Images.GetBySlug(context.Background(), slug.(string))
 		if err != nil {
-			if resp.StatusCode == 404 {
+			if resp != nil && resp.StatusCode == 404 {
 				return fmt.Errorf("image not found: %s", err)
 			}
 			return fmt.Errorf("Error retrieving image: %s", err)

--- a/digitalocean/datasource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/datasource_digitalocean_kubernetes_cluster.go
@@ -108,7 +108,7 @@ func dataSourceDigitalOceanKubernetesClusterRead(d *schema.ResourceData, meta in
 
 	clusters, resp, err := client.Kubernetes.List(context.Background(), &godo.ListOptions{})
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			return fmt.Errorf("No clusters found")
 		}
 

--- a/digitalocean/datasource_digitalocean_record.go
+++ b/digitalocean/datasource_digitalocean_record.go
@@ -81,7 +81,7 @@ func dataSourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) 
 
 	records, resp, err := client.Domains.Records(context.Background(), domain, opts)
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			return fmt.Errorf("domain not found: %s", err)
 		}
 		return fmt.Errorf("Error retrieving domain: %s", err)

--- a/digitalocean/datasource_digitalocean_tag.go
+++ b/digitalocean/datasource_digitalocean_tag.go
@@ -29,7 +29,7 @@ func dataSourceDigitalOceanTagRead(d *schema.ResourceData, meta interface{}) err
 
 	tag, resp, err := client.Tags.Get(context.Background(), name)
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			return fmt.Errorf("tag not found: %s", err)
 		}
 		return fmt.Errorf("Error retrieving tag: %s", err)

--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -154,7 +154,7 @@ func resourceDigitalOceanDatabaseClusterCreate(d *schema.ResourceData, meta inte
 		if err != nil {
 			// If the database is somehow already destroyed, mark as
 			// successfully gone
-			if resp.StatusCode == 404 {
+			if resp != nil && resp.StatusCode == 404 {
 				d.SetId("")
 				return nil
 			}
@@ -179,7 +179,7 @@ func resourceDigitalOceanDatabaseClusterUpdate(d *schema.ResourceData, meta inte
 		if err != nil {
 			// If the database is somehow already destroyed, mark as
 			// successfully gone
-			if resp.StatusCode == 404 {
+			if resp != nil && resp.StatusCode == 404 {
 				d.SetId("")
 				return nil
 			}
@@ -202,7 +202,7 @@ func resourceDigitalOceanDatabaseClusterUpdate(d *schema.ResourceData, meta inte
 		if err != nil {
 			// If the database is somehow already destroyed, mark as
 			// successfully gone
-			if resp.StatusCode == 404 {
+			if resp != nil && resp.StatusCode == 404 {
 				d.SetId("")
 				return nil
 			}
@@ -223,7 +223,7 @@ func resourceDigitalOceanDatabaseClusterUpdate(d *schema.ResourceData, meta inte
 		if err != nil {
 			// If the database is somehow already destroyed, mark as
 			// successfully gone
-			if resp.StatusCode == 404 {
+			if resp != nil && resp.StatusCode == 404 {
 				d.SetId("")
 				return nil
 			}
@@ -242,7 +242,7 @@ func resourceDigitalOceanDatabaseClusterRead(d *schema.ResourceData, meta interf
 	if err != nil {
 		// If the database is somehow already destroyed, mark as
 		// successfully gone
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/digitalocean/resource_digitalocean_domain.go
+++ b/digitalocean/resource_digitalocean_domain.go
@@ -72,7 +72,7 @@ func resourceDigitalOceanDomainRead(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		// If the domain is somehow already destroyed, mark as
 		// successfully gone
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/digitalocean/resource_digitalocean_droplet_snapshot.go
+++ b/digitalocean/resource_digitalocean_droplet_snapshot.go
@@ -92,7 +92,7 @@ func resourceDigitalOceanDropletSnapshotRead(d *schema.ResourceData, meta interf
 	if err != nil {
 		// If the snapshot is somehow already destroyed, mark as
 		// successfully gone
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -178,7 +178,7 @@ func resourceDigitalOceanKubernetesClusterRead(d *schema.ResourceData, meta inte
 
 	cluster, resp, err := client.Kubernetes.Get(context.Background(), d.Id())
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -217,7 +217,7 @@ func digitaloceanKubernetesClusterRead(client *godo.Client, cluster *godo.Kubern
 	// fetch the K8s config  and update the resource
 	config, resp, err := client.Kubernetes.GetKubeConfig(context.Background(), cluster.ID)
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			return fmt.Errorf("Unable to fetch Kubernetes config: %s", err)
 		}
 	}
@@ -239,7 +239,7 @@ func resourceDigitalOceanKubernetesClusterUpdate(d *schema.ResourceData, meta in
 
 		_, resp, err := client.Kubernetes.Update(context.Background(), d.Id(), opts)
 		if err != nil {
-			if resp.StatusCode == 404 {
+			if resp != nil && resp.StatusCode == 404 {
 				d.SetId("")
 				return nil
 			}
@@ -271,7 +271,7 @@ func resourceDigitalOceanKubernetesClusterDelete(d *schema.ResourceData, meta in
 
 	resp, err := client.Kubernetes.Delete(context.Background(), d.Id())
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool.go
@@ -137,7 +137,7 @@ func resourceDigitalOceanKubernetesNodePoolRead(d *schema.ResourceData, meta int
 
 	pool, resp, err := client.Kubernetes.GetNodePool(context.Background(), d.Get("cluster_id").(string), d.Id())
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
@@ -215,7 +215,7 @@ func digitaloceanKubernetesNodePoolUpdate(client *godo.Client, pool map[string]i
 	})
 
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			return nil, nil
 		}
 

--- a/digitalocean/resource_digitalocean_record.go
+++ b/digitalocean/resource_digitalocean_record.go
@@ -185,16 +185,14 @@ func resourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	rec, resp, err := client.Domains.Record(context.Background(), domain, id)
-	if err != nil && resp != nil {
+	if err != nil {
 		// If the record is somehow already destroyed, mark as
 		// successfully gone
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
 
-		return err
-	} else if err != nil {
 		return err
 	}
 
@@ -275,7 +273,7 @@ func resourceDigitalOceanRecordDelete(d *schema.ResourceData, meta interface{}) 
 	if delErr != nil {
 		// If the record is somehow already destroyed, mark as
 		// successfully gone
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			return nil
 		}
 

--- a/digitalocean/resource_digitalocean_volume.go
+++ b/digitalocean/resource_digitalocean_volume.go
@@ -189,7 +189,7 @@ func resourceDigitalOceanVolumeRead(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		// If the volume is somehow already destroyed, mark as
 		// successfully gone
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/digitalocean/resource_digitalocean_volume_attachment.go
+++ b/digitalocean/resource_digitalocean_volume_attachment.go
@@ -92,7 +92,7 @@ func resourceDigitalOceanVolumeAttachmentRead(d *schema.ResourceData, meta inter
 	if err != nil {
 		// If the volume is already destroyed, mark as
 		// successfully removed
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/digitalocean/resource_digitalocean_volume_snapshot.go
+++ b/digitalocean/resource_digitalocean_volume_snapshot.go
@@ -85,7 +85,7 @@ func resourceDigitalOceanVolumeSnapshotRead(d *schema.ResourceData, meta interfa
 	if err != nil {
 		// If the snapshot is somehow already destroyed, mark as
 		// successfully gone
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
In many cases we handle 404s different than other errors. Though if an error contains no response at all, we panic. (See: #272) Some resources already protect against this, but not all of them.