### PR TITLE
Add HTTP2 protocol to load balancer docs

### DIFF
--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -115,9 +115,9 @@ the backend service. Default value is `false`.
 
 `forwarding_rule` supports the following:
 
-* `entry_protocol` - (Required) The protocol used for traffic to the Load Balancer. The possible values are: `http`, `https`, or `tcp`.
+* `entry_protocol` - (Required) The protocol used for traffic to the Load Balancer. The possible values are: `http`, `https`, `http2` or `tcp`.
 * `entry_port` - (Required) An integer representing the port on which the Load Balancer instance will listen.
-* `target_protocol` - (Required) The protocol used for traffic from the Load Balancer to the backend Droplets. The possible values are: `http`, `https`, or `tcp`.
+* `target_protocol` - (Required) The protocol used for traffic from the Load Balancer to the backend Droplets. The possible values are: `http`, `https`, `http2` or `tcp`.
 * `target_port` - (Required) An integer representing the port on the backend Droplets to which the Load Balancer will send traffic.
 * `certificate_id` - (Optional) The ID of the TLS certificate to be used for SSL termination.
 * `tls_passthrough` - (Optional) A boolean value indicating whether SSL encrypted traffic will be passed through to the backend Droplets. The default value is `false`.


### PR DESCRIPTION
DigitalOcean’s API supports HTTP2 in load balancers (see [docs](https://developers.digitalocean.com/documentation/v2/#load-balancers)).