### PR TITLE
Verify Droplet is destroyed before removing from state (Fixes: #283).

### DIFF
--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -626,18 +626,36 @@ func resourceDigitalOceanDropletDelete(d *schema.ResourceData, meta interface{})
 	log.Printf("[INFO] Deleting droplet: %s", d.Id())
 
 	// Destroy the droplet
-	_, err = client.Droplets.Delete(context.Background(), id)
+	resp, err := client.Droplets.Delete(context.Background(), id)
 
-	// Handle remotely destroyed droplets
-	if err != nil && strings.Contains(err.Error(), "404 Not Found") {
+	// Handle already destroyed droplets
+	if err != nil && resp.StatusCode == 404 {
 		return nil
 	}
 
-	if err != nil {
+	_, err = waitForDropletDestroy(d, meta)
+	if err != nil && strings.Contains(err.Error(), "404") {
+		return nil
+	} else if err != nil {
 		return fmt.Errorf("Error deleting droplet: %s", err)
 	}
 
 	return nil
+}
+
+func waitForDropletDestroy(d *schema.ResourceData, meta interface{}) (interface{}, error) {
+	log.Printf("[INFO] Waiting for droplet (%s) to be destroyed", d.Id())
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"active"},
+		Target:     []string{"archived"},
+		Refresh:    newDropletStateRefreshFunc(d, "status", meta),
+		Timeout:    60 * time.Second,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	return stateConf.WaitForState()
 }
 
 func waitForDropletAttribute(


### PR DESCRIPTION
This polls a Droplet after a delete request and waits for it to 404 before removing it from state in order to prevent issues like #283 where an unexpected error on the DigitalOcean side left the Droplet active but removed from state. We don't reuse `waitForDropletAttribute` here as we want a much quicker timeout.