### PR TITLE
digitalocean_database_cluster: version should not be required

### DIFF
--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -38,10 +38,9 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 			},
 
 			"version": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.NoZeroValues,
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 
 			"size": {

--- a/digitalocean/resource_digitalocean_database_cluster_test.go
+++ b/digitalocean/resource_digitalocean_database_cluster_test.go
@@ -131,6 +131,40 @@ func TestAccDigitalOceanDatabaseCluster_WithMaintWindow(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanDatabaseCluster_RedisNoVersion(t *testing.T) {
+	var database godo.Database
+	databaseName := fmt.Sprintf("foobar-test-terraform-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDatabaseClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterRedisNoVersion, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
+					testAccCheckDigitalOceanDatabaseClusterAttributes(&database, databaseName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "name", databaseName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "engine", "redis"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_cluster.foobar", "host"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_cluster.foobar", "port"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_cluster.foobar", "user"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_cluster.foobar", "password"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_cluster.foobar", "urn"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDigitalOceanDatabaseClusterDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*CombinedConfig).godoClient()
 
@@ -229,9 +263,18 @@ resource "digitalocean_database_cluster" "foobar" {
 	size       = "db-s-1vcpu-1gb"
 	region     = "nyc1"
 	node_count = 1
-	
+
 	maintenance_window {
         day  = "friday"
         hour = "13:00:00"
 	}
+}`
+
+const testAccCheckDigitalOceanDatabaseClusterRedisNoVersion = `
+resource "digitalocean_database_cluster" "foobar" {
+	name       = "%s"
+	engine     = "redis"
+	size       = "db-s-1vcpu-1gb"
+	region     = "nyc1"
+    node_count = 1
 }`

--- a/website/docs/r/database_cluster.html.markdown
+++ b/website/docs/r/database_cluster.html.markdown
@@ -12,12 +12,34 @@ Provides a DigitalOcean database cluster resource.
 
 ## Example Usage
 
+### Create a new PostgreSQL database cluster
 ```hcl
-# Create a new database cluster
-resource "digitalocean_database_cluster" "example" {
-  name       = "example-cluster"
+resource "digitalocean_database_cluster" "postgres-example" {
+  name       = "example-postgres-cluster"
   engine     = "pg"
   version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+```
+
+### Create a new MySQL database cluster
+```hcl
+resource "digitalocean_database_cluster" "mysql-example" {
+  name       = "example-mysql-cluster"
+  engine     = "mysql"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+```
+
+### Create a new Redis database cluster
+```hcl
+resource "digitalocean_database_cluster" "redis-example" {
+  name       = "example-redis-cluster"
+  engine     = "redis"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1
@@ -29,11 +51,11 @@ resource "digitalocean_database_cluster" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the database cluster.
-* `engine` - (Required) Database engine used by the cluster (ex. `pg` for PostreSQL).
-* `version` - (Required) Engine version used by the cluster (ex. `11` for PostgreSQL 11).
+* `engine` - (Required) Database engine used by the cluster (ex. `pg` for PostreSQL, `mysql` for MySQL, or `redis` for Redis).
 * `size` - (Required) Database droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`).
 * `region` - (Required) DigitalOcean region where the cluster will reside.
 * `node_count` - (Required) Number of nodes that will be included in the cluster.
+* `version` - (Optional) Engine version used by the cluster (ex. `11` for PostgreSQL 11).
 * `maintenance_window` - (Optional) Defines when the automatic maintenance should be performed for the database cluster.
 
 `maintenance_window` supports the following:


### PR DESCRIPTION
This relaxes the version constraint. As per #285, this is not actually required by the API, and as described in #287 is currently causing issue with Redis and MySQL.

New test failing before the change:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDatabaseCluster_RedisNoVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDatabaseCluster_RedisNoVersion -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDatabaseCluster_RedisNoVersion
--- FAIL: TestAccDigitalOceanDatabaseCluster_RedisNoVersion (0.05s)
    testing.go:568: Step 0 error: config is invalid: Missing required argument: The argument "version" is required, but no definition was found.
FAIL
FAIL	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	0.115s
GNUmakefile:18: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

New test passing post change: 

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDatabaseCluster_RedisNoVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDatabaseCluster_RedisNoVersion -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDatabaseCluster_RedisNoVersion
--- PASS: TestAccDigitalOceanDatabaseCluster_RedisNoVersion (388.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	388.028s
```