### PR TITLE
Mark the kubernetes_cluster resource's kube_config field as sensitive

### DIFF
--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -100,8 +100,9 @@ func resourceDigitalOceanKubernetesCluster() *schema.Resource {
 
 func kubernetesConfigSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeList,
-		Computed: true,
+		Type:      schema.TypeList,
+		Computed:  true,
+		Sensitive: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"raw_config": {

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -27,7 +27,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "region", "lon1"),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", "1.14.4-do.0"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", "1.15.3-do.1"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "ipv4_address"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "cluster_subnet"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "service_subnet"),
@@ -183,7 +183,7 @@ func testAccDigitalOceanKubernetesConfigBasic(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.14.4-do.0"
+	version = "1.15.3-do.1"
 	tags    = ["foo","bar", "one"]
 
 	node_pool {
@@ -201,7 +201,7 @@ func testAccDigitalOceanKubernetesConfigBasic2(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.14.4-do.0"
+	version = "1.15.3-do.1"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -219,7 +219,7 @@ func testAccDigitalOceanKubernetesConfigBasic3(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.14.4-do.0"
+	version = "1.15.3-do.1"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -237,7 +237,7 @@ func testAccDigitalOceanKubernetesConfigBasic4(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.14.4-do.0"
+	version = "1.15.3-do.1"
 	tags    = ["one","two"]
 
 	node_pool {
@@ -255,7 +255,7 @@ func testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(rNam
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.14.4-do.0"
+	version = "1.15.3-do.1"
 
 	node_pool {
 	  name = "default"


### PR DESCRIPTION
This data includes sensitive information about the cluster, such as its private key. This prevents that data from ending up in, for example, logs on a CI system that does a `terraform plan` as part of its build.

With this applied, a `terraform plan` or `terraform apply` instead shows:

```
...
        ipv4_address   = "1.2.3.4"
        kube_config    = (sensitive value)
        name           = "roboticcheese"
...
```

Also updates the acceptance tests, as 1.14.4-do.0 is no longer available.

It's been five years since I last looked at any Go and never since I poked around Terraform code, so apologies in advance for any issues with this that I'm not considering. At first, I thought it could just mark the `client_key` and `client_certificate` as sensitive (matching what gets redacted by default from `kubectl config view`), but it looks like Terraform won't redact fields from a schema nested inside the resource's schema like that.