### PR TITLE
Provide private connection details for `database_cluster'

### DIFF
--- a/digitalocean/datasource_digitalocean_database_cluster.go
+++ b/digitalocean/datasource_digitalocean_database_cluster.go
@@ -164,10 +164,10 @@ func dataSourceDigitalOceanDatabaseClusterRead(d *schema.ResourceData, meta inte
 			}
 
 			d.Set("host", db.Connection.Host)
-			d.Set("private_host", database.PrivateConnection.Host)
+			d.Set("private_host", db.PrivateConnection.Host)
 			d.Set("port", db.Connection.Port)
 			d.Set("uri", db.Connection.URI)
-			d.Set("private_uri", database.PrivateConnection.URI)
+			d.Set("private_uri", db.PrivateConnection.URI)
 			d.Set("database", db.Connection.Database)
 			d.Set("user", db.Connection.User)
 			d.Set("urn", db.URN())

--- a/digitalocean/datasource_digitalocean_database_cluster.go
+++ b/digitalocean/datasource_digitalocean_database_cluster.go
@@ -68,12 +68,22 @@ func dataSourceDigitalOceanDatabaseCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"private_host": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"port": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
 			"uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"private_uri": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -154,8 +164,10 @@ func dataSourceDigitalOceanDatabaseClusterRead(d *schema.ResourceData, meta inte
 			}
 
 			d.Set("host", db.Connection.Host)
+			d.Set("private_host", database.PrivateConnection.Host)
 			d.Set("port", db.Connection.Port)
 			d.Set("uri", db.Connection.URI)
+			d.Set("private_uri", database.PrivateConnection.URI)
 			d.Set("database", db.Connection.Database)
 			d.Set("user", db.Connection.User)
 			d.Set("urn", db.URN())

--- a/digitalocean/datasource_digitalocean_database_cluster_test.go
+++ b/digitalocean/datasource_digitalocean_database_cluster_test.go
@@ -34,6 +34,8 @@ func TestAccDataSourceDigitalOceanDatabaseCluster_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"data.digitalocean_database_cluster.foobar", "host"),
 					resource.TestCheckResourceAttrSet(
+						"data.digitalocean_database_cluster.foobar", "private_host"),
+					resource.TestCheckResourceAttrSet(
 						"data.digitalocean_database_cluster.foobar", "port"),
 					resource.TestCheckResourceAttrSet(
 						"data.digitalocean_database_cluster.foobar", "user"),

--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -88,12 +88,22 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"private_host": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"port": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
 			"uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"private_uri": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -112,10 +122,12 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
 			"urn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -267,8 +279,10 @@ func resourceDigitalOceanDatabaseClusterRead(d *schema.ResourceData, meta interf
 
 	// Computed values
 	d.Set("host", database.Connection.Host)
+	d.Set("private_host", database.PrivateConnection.Host)
 	d.Set("port", database.Connection.Port)
 	d.Set("uri", database.Connection.URI)
+	d.Set("private_uri", database.PrivateConnection.URI)
 	d.Set("database", database.Connection.Database)
 	d.Set("user", database.Connection.User)
 	d.Set("password", database.Connection.Password)

--- a/digitalocean/resource_digitalocean_database_cluster_test.go
+++ b/digitalocean/resource_digitalocean_database_cluster_test.go
@@ -32,6 +32,8 @@ func TestAccDigitalOceanDatabaseCluster_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_cluster.foobar", "host"),
 					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_cluster.foobar", "private_host"),
+					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_cluster.foobar", "port"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_cluster.foobar", "user"),

--- a/website/docs/r/database_cluster.html.markdown
+++ b/website/docs/r/database_cluster.html.markdown
@@ -71,8 +71,10 @@ In addition to the above arguments, the following attributes are exported:
 * `id` - The ID of the database cluster.
 * `urn` - The uniform resource name of the database cluster.
 * `host` - Database cluster's hostname.
+* `private_host` - Same as `host`, but only accessible from resources within the account and in the same region.
 * `port` - Network port that the database cluster is listening on.
 * `uri` - The full URI for connecting to the database cluster.
+* `private_uri` - Same as `uri`, but only accessible from resources within the account and in the same region.
 * `database` - Name of the cluster's default database.
 * `user` - Username for the cluster's default user.
 * `password` - Password for the cluster's default user.


### PR DESCRIPTION
Adds `private_host` and `private_uri` attributes for `digitalocean_database_cluster` resource and datasource.

Reference: https://github.com/terraform-providers/terraform-provider-digitalocean/issues/299.