### PR TITLE
Mark uri, private_uri, password as sensitive for database_cluster.

### DIFF
--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -99,13 +99,15 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 			},
 
 			"uri": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			"private_uri": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			"database": {
@@ -119,8 +121,9 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 			},
 
 			"password": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			"urn": {


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-digitalocean/issues/298.