### PR TITLE
Expose private connection info for replicas and mark final DBaaS fields sensitive

### DIFF
--- a/digitalocean/datasource_digitalocean_database_cluster.go
+++ b/digitalocean/datasource_digitalocean_database_cluster.go
@@ -78,14 +78,22 @@ func dataSourceDigitalOceanDatabaseCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"password": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
 			"uri": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			"private_uri": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			"database": {
@@ -170,6 +178,7 @@ func dataSourceDigitalOceanDatabaseClusterRead(d *schema.ResourceData, meta inte
 			d.Set("private_uri", db.PrivateConnection.URI)
 			d.Set("database", db.Connection.Database)
 			d.Set("user", db.Connection.User)
+			d.Set("password", db.Connection.Password)
 			d.Set("urn", db.URN())
 
 			break

--- a/digitalocean/datasource_digitalocean_database_cluster_test.go
+++ b/digitalocean/datasource_digitalocean_database_cluster_test.go
@@ -39,6 +39,8 @@ func TestAccDataSourceDigitalOceanDatabaseCluster_Basic(t *testing.T) {
 						"data.digitalocean_database_cluster.foobar", "port"),
 					resource.TestCheckResourceAttrSet(
 						"data.digitalocean_database_cluster.foobar", "user"),
+					resource.TestCheckResourceAttrSet(
+						"data.digitalocean_database_cluster.foobar", "password"),
 				),
 			},
 		},

--- a/digitalocean/resource_digitalocean_database_replica.go
+++ b/digitalocean/resource_digitalocean_database_replica.go
@@ -53,14 +53,26 @@ func resourceDigitalOceanDatabaseReplica() *schema.Resource {
 				Computed: true,
 			},
 
+			"private_host": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"port": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
 			"uri": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"private_uri": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			"database": {
@@ -74,8 +86,9 @@ func resourceDigitalOceanDatabaseReplica() *schema.Resource {
 			},
 
 			"password": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			"tags": {
@@ -141,8 +154,10 @@ func resourceDigitalOceanDatabaseReplicaRead(d *schema.ResourceData, meta interf
 
 	// Computed values
 	d.Set("host", replica.Connection.Host)
+	d.Set("private_host", replica.PrivateConnection.Host)
 	d.Set("port", replica.Connection.Port)
 	d.Set("uri", replica.Connection.URI)
+	d.Set("private_uri", replica.PrivateConnection.URI)
 	d.Set("database", replica.Connection.Database)
 	d.Set("user", replica.Connection.User)
 	d.Set("password", replica.Connection.Password)

--- a/digitalocean/resource_digitalocean_database_replica_test.go
+++ b/digitalocean/resource_digitalocean_database_replica_test.go
@@ -35,11 +35,15 @@ func TestAccDigitalOceanDatabaseReplica_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_replica.read-01", "host"),
 					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_replica.read-01", "private_host"),
+					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_replica.read-01", "port"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_replica.read-01", "user"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_replica.read-01", "uri"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_replica.read-01", "private_uri"),
 					resource.TestCheckResourceAttrSet(
 						"digitalocean_database_replica.read-01", "password"),
 					resource.TestCheckResourceAttr(

--- a/website/docs/d/database_cluster.html.markdown
+++ b/website/docs/d/database_cluster.html.markdown
@@ -39,10 +39,13 @@ The following attributes are exported:
 * `maintenance_window` - Defines when the automatic maintenance should be performed for the database cluster.
 
 * `host` - Database cluster's hostname.
+* `private_host` - Same as `host`, but only accessible from resources within the account and in the same region.
 * `port` - Network port that the database cluster is listening on.
 * `uri` - The full URI for connecting to the database cluster.
+* `private_uri` - Same as `uri`, but only accessible from resources within the account and in the same region.
 * `database` - Name of the cluster's default database.
 * `user` - Username for the cluster's default user.
+* `password` - Password for the cluster's default user.
 
 `maintenance_window` supports the following:
 

--- a/website/docs/r/database_replica.html.markdown
+++ b/website/docs/r/database_replica.html.markdown
@@ -46,8 +46,10 @@ In addition to the above arguments, the following attributes are exported:
 
 * `id` - The ID of the database replica.
 * `host` - Database replica's hostname.
+* `private_host` - Same as `host`, but only accessible from resources within the account and in the same region.
 * `port` - Network port that the database replica is listening on.
 * `uri` - The full URI for connecting to the database replica.
+* `private_uri` - Same as `uri`, but only accessible from resources within the account and in the same region.
 * `database` - Name of the replica's default database.
 * `user` - Username for the replica's default user.
 * `password` - Password for the replica's default user.


### PR DESCRIPTION
This PR ties up a few loose ends related to #294, #300, and #301. Specifically:  

* datasource/database_cluster: Add password to exported attributes and mark fields sensitive
* resource/database_replica: Expose private connection info and mark fields sensitive