### PR TITLE
doks: fix acc tests

### DIFF
--- a/digitalocean/datasource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/datasource_digitalocean_kubernetes_cluster_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccDataSourceDigitalOceanKubernetesCluster_Basic(t *testing.T) {
+	t.Parallel()
 	rName := acctest.RandString(10)
 	var k8s godo.KubernetesCluster
 

--- a/digitalocean/datasource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/datasource_digitalocean_kubernetes_cluster_test.go
@@ -6,14 +6,13 @@ import (
 	"testing"
 
 	"github.com/digitalocean/godo"
-	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDataSourceDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 	t.Parallel()
-	rName := acctest.RandString(10)
+	rName := randomTestName()
 	var k8s godo.KubernetesCluster
 
 	resource.Test(t, resource.TestCase{

--- a/digitalocean/provider_test.go
+++ b/digitalocean/provider_test.go
@@ -1,9 +1,11 @@
 package digitalocean
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-kubernetes/kubernetes"
@@ -71,4 +73,12 @@ func TestURLDefault(t *testing.T) {
 	if client.BaseURL.String() != "https://api.digitalocean.com" {
 		t.Fatalf("Expected %s, got %s", "https://api.digitalocean.com", client.BaseURL.String())
 	}
+}
+
+func randomTestName() string {
+	return randomName("test-", 5)
+}
+
+func randomName(prefix string, length int) string {
+	return fmt.Sprintf("%s%s", prefix, acctest.RandString(length))
 }

--- a/digitalocean/provider_test.go
+++ b/digitalocean/provider_test.go
@@ -11,8 +11,12 @@ import (
 	"github.com/terraform-providers/terraform-provider-kubernetes/kubernetes"
 )
 
-var testAccProviders map[string]terraform.ResourceProvider
-var testAccProvider *schema.Provider
+const testNamePrefix = "tf-acc-test-"
+
+var (
+	testAccProviders map[string]terraform.ResourceProvider
+	testAccProvider  *schema.Provider
+)
 
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
@@ -76,7 +80,7 @@ func TestURLDefault(t *testing.T) {
 }
 
 func randomTestName() string {
-	return randomName("test-", 5)
+	return randomName(testNamePrefix, 10)
 }
 
 func randomName(prefix string, length int) string {

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -27,7 +27,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "region", "lon1"),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", "1.15.3-do.1"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", "1.15.3-do.3"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "ipv4_address"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "cluster_subnet"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "service_subnet"),
@@ -187,7 +187,7 @@ func testAccDigitalOceanKubernetesConfigBasic(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.1"
+	version = "1.15.3-do.3"
 	tags    = ["foo","bar", "one"]
 
 	node_pool {
@@ -205,7 +205,7 @@ func testAccDigitalOceanKubernetesConfigBasic2(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.1"
+	version = "1.15.3-do.3"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -223,7 +223,7 @@ func testAccDigitalOceanKubernetesConfigBasic3(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.1"
+	version = "1.15.3-do.3"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -241,7 +241,7 @@ func testAccDigitalOceanKubernetesConfigBasic4(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.1"
+	version = "1.15.3-do.3"
 	tags    = ["one","two"]
 
 	node_pool {
@@ -259,7 +259,7 @@ func testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(rNam
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.1"
+	version = "1.15.3-do.3"
 
 	node_pool {
 	  name = "default"

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -7,14 +7,13 @@ import (
 	"testing"
 
 	"github.com/digitalocean/godo"
-	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 	t.Parallel()
-	rName := acctest.RandString(10)
+	rName := randomTestName()
 	var k8s godo.KubernetesCluster
 
 	resource.Test(t, resource.TestCase{
@@ -63,7 +62,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 
 func TestAccDigitalOceanKubernetesCluster_UpdateCluster(t *testing.T) {
 	t.Parallel()
-	rName := acctest.RandString(10)
+	rName := randomTestName()
 	var k8s godo.KubernetesCluster
 
 	resource.Test(t, resource.TestCase{
@@ -94,7 +93,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdateCluster(t *testing.T) {
 
 func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
 	t.Parallel()
-	rName := acctest.RandString(10)
+	rName := randomTestName()
 	var k8s godo.KubernetesCluster
 
 	resource.Test(t, resource.TestCase{
@@ -128,7 +127,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
 
 func TestAccDigitalOceanKubernetesCluster_UpdatePoolSize(t *testing.T) {
 	t.Parallel()
-	rName := acctest.RandString(10)
+	rName := randomTestName()
 	var k8s godo.KubernetesCluster
 
 	resource.Test(t, resource.TestCase{
@@ -161,7 +160,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolSize(t *testing.T) {
 
 func TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability(t *testing.T) {
 	t.Parallel()
-	rName := acctest.RandString(10)
+	rName := randomTestName()
 	var k8s godo.KubernetesCluster
 
 	resource.Test(t, resource.TestCase{

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
+	t.Parallel()
 	rName := acctest.RandString(10)
 	var k8s godo.KubernetesCluster
 
@@ -61,6 +62,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 }
 
 func TestAccDigitalOceanKubernetesCluster_UpdateCluster(t *testing.T) {
+	t.Parallel()
 	rName := acctest.RandString(10)
 	var k8s godo.KubernetesCluster
 
@@ -91,6 +93,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdateCluster(t *testing.T) {
 }
 
 func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
+	t.Parallel()
 	rName := acctest.RandString(10)
 	var k8s godo.KubernetesCluster
 
@@ -124,6 +127,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
 }
 
 func TestAccDigitalOceanKubernetesCluster_UpdatePoolSize(t *testing.T) {
+	t.Parallel()
 	rName := acctest.RandString(10)
 	var k8s godo.KubernetesCluster
 
@@ -156,6 +160,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolSize(t *testing.T) {
 }
 
 func TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability(t *testing.T) {
+	t.Parallel()
 	rName := acctest.RandString(10)
 	var k8s godo.KubernetesCluster
 

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -27,7 +27,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "region", "lon1"),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", "1.15.3-do.3"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", "1.15.3-do.1"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "ipv4_address"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "cluster_subnet"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "service_subnet"),
@@ -187,7 +187,7 @@ func testAccDigitalOceanKubernetesConfigBasic(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.3-do.1"
 	tags    = ["foo","bar", "one"]
 
 	node_pool {
@@ -205,7 +205,7 @@ func testAccDigitalOceanKubernetesConfigBasic2(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.3-do.1"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -223,7 +223,7 @@ func testAccDigitalOceanKubernetesConfigBasic3(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.3-do.1"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -241,7 +241,7 @@ func testAccDigitalOceanKubernetesConfigBasic4(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.3-do.1"
 	tags    = ["one","two"]
 
 	node_pool {
@@ -259,7 +259,7 @@ func testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(rNam
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.3-do.1"
 
 	node_pool {
 	  name = "default"

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool.go
@@ -259,7 +259,7 @@ func waitForKubernetesNodePoolCreate(client *godo.Client, id string, poolID stri
 			return fmt.Errorf("Error trying to read nodepool state: %s", err)
 		}
 
-		allRunning := true
+		allRunning := len(pool.Nodes) == pool.Count
 		for _, n := range pool.Nodes {
 			if n.Status.State != "running" {
 				allRunning = false

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
@@ -6,14 +6,13 @@ import (
 	"testing"
 
 	"github.com/digitalocean/godo"
-	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDigitalOceanKubernetesNodePool_Basic(t *testing.T) {
 	t.Parallel()
-	rName := acctest.RandString(10)
+	rName := randomTestName()
 	var k8s godo.KubernetesCluster
 	var k8sPool godo.KubernetesNodePool
 
@@ -37,7 +36,7 @@ func TestAccDigitalOceanKubernetesNodePool_Basic(t *testing.T) {
 
 func TestAccDigitalOceanKubernetesNodePool_Update(t *testing.T) {
 	t.Parallel()
-	rName := acctest.RandString(10)
+	rName := randomTestName()
 	var k8s godo.KubernetesCluster
 	var k8sPool godo.KubernetesNodePool
 

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
@@ -78,7 +78,7 @@ func testAccDigitalOceanKubernetesConfigBasicWithNodePool(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.2"
+	version = "1.15.3-do.3"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -105,7 +105,7 @@ func testAccDigitalOceanKubernetesConfigBasicWithNodePool2(rName string) string 
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.2"
+	version = "1.15.3-do.3"
 	tags    = ["foo","bar"]
 
 	node_pool {

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
@@ -78,7 +78,7 @@ func testAccDigitalOceanKubernetesConfigBasicWithNodePool(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.3-do.2"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -105,7 +105,7 @@ func testAccDigitalOceanKubernetesConfigBasicWithNodePool2(rName string) string 
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.3-do.2"
 	tags    = ["foo","bar"]
 
 	node_pool {

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccDigitalOceanKubernetesNodePool_Basic(t *testing.T) {
+	t.Parallel()
 	rName := acctest.RandString(10)
 	var k8s godo.KubernetesCluster
 	var k8sPool godo.KubernetesNodePool
@@ -35,6 +36,7 @@ func TestAccDigitalOceanKubernetesNodePool_Basic(t *testing.T) {
 }
 
 func TestAccDigitalOceanKubernetesNodePool_Update(t *testing.T) {
+	t.Parallel()
 	rName := acctest.RandString(10)
 	var k8s godo.KubernetesCluster
 	var k8sPool godo.KubernetesNodePool

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -17,7 +17,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
   // Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.15.3-do.2"
+  version = "1.15.3-do.3"
 
   node_pool {
     name       = "worker-pool"
@@ -34,7 +34,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
   // Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.15.3-do.2"
+  version = "1.15.3-do.3"
   tags    = ["staging"]
 
   node_pool {

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -17,7 +17,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
   // Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.15.3-do.3"
+  version = "1.15.3-do.2"
 
   node_pool {
     name       = "worker-pool"
@@ -34,7 +34,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
   // Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.15.3-do.3"
+  version = "1.15.3-do.2"
   tags    = ["staging"]
 
   node_pool {


### PR DESCRIPTION
A few `testacc` updates while working through some upcoming PRs:
 - Support running the `testacc` tests in parallel using `t.Parallel()`
 - Use alpha-prefixed random cluster and node pool names in tests to avoid validation errors when they start with a digit.
 - Wait for number of nodes in a pool to match the expected count in `waitForKubernetesNodePoolCreate` (which is also used for waiting after updates)

I can break this into individual PRs if you'd prefer, just LMK.

@andrewsomething @eddiezane @timoreimann 

## Before

Node name validation failure:
```sh
--- FAIL: TestAccDigitalOceanKubernetesCluster_UpdateCluster (0.56s)
    testing.go:569: Step 0 error: errors during apply:

        Error: Error creating Kubernetes cluster: POST https://api.digitalocean.com/v2/kubernetes/clusters: 422 rpc error: code = InvalidArgument desc = validation error: cluster_spec.invalid name

          on /var/folders/ws/s67gr8k95yq7qm2_8vthwxg40000gp/T/tf-test741942474/main.tf line 2:
          (source code not available)
```

Node pool count failure:
```sh
$ GOFLAGS=-mod=vendor make testacc TESTARGS="-run=TestAccDigitalOceanKubernetes -parallel=10"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanKubernetes -parallel=10 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanKubernetesCluster_Basic
=== PAUSE TestAccDigitalOceanKubernetesCluster_Basic
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== RUN   TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== PAUSE TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== RUN   TestAccDigitalOceanKubernetesNodePool_Basic
=== PAUSE TestAccDigitalOceanKubernetesNodePool_Basic
=== RUN   TestAccDigitalOceanKubernetesNodePool_Update
=== PAUSE TestAccDigitalOceanKubernetesNodePool_Update
=== CONT  TestAccDigitalOceanKubernetesCluster_Basic
=== CONT  TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== CONT  TestAccDigitalOceanKubernetesNodePool_Update
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== CONT  TestAccDigitalOceanKubernetesNodePool_Basic
--- PASS: TestAccDigitalOceanKubernetesCluster_Basic (393.26s)
--- PASS: TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability (446.51s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails (516.18s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdateCluster (676.67s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolSize (686.58s)
--- FAIL: TestAccDigitalOceanKubernetesNodePool_Update (707.19s)
    testing.go:569: Step 1 error: Check failed: 1 error occurred:
        	* Check 7/7 error: digitalocean_kubernetes_node_pool.barfoo: Attribute 'nodes.#' expected "2", got "1"


--- PASS: TestAccDigitalOceanKubernetesNodePool_Basic (764.94s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	765.239s
FAIL
make: *** [testacc] Error 1
```

## After

```sh
$ GOFLAGS=-mod=vendor make testacc TESTARGS="-run=TestAccDigitalOceanKubernetes -parallel=10"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanKubernetes -parallel=10 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanKubernetesCluster_Basic
=== PAUSE TestAccDigitalOceanKubernetesCluster_Basic
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== RUN   TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== PAUSE TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== RUN   TestAccDigitalOceanKubernetesNodePool_Basic
=== PAUSE TestAccDigitalOceanKubernetesNodePool_Basic
=== RUN   TestAccDigitalOceanKubernetesNodePool_Update
=== PAUSE TestAccDigitalOceanKubernetesNodePool_Update
=== CONT  TestAccDigitalOceanKubernetesCluster_Basic
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== CONT  TestAccDigitalOceanKubernetesNodePool_Basic
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== CONT  TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== CONT  TestAccDigitalOceanKubernetesNodePool_Update
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdateCluster
--- PASS: TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability (345.96s)
--- PASS: TestAccDigitalOceanKubernetesCluster_Basic (393.35s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails (487.26s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdateCluster (685.95s)
--- PASS: TestAccDigitalOceanKubernetesNodePool_Basic (695.07s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolSize (707.41s)
--- PASS: TestAccDigitalOceanKubernetesNodePool_Update (838.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	838.421s
```