### PR TITLE
doks: bump to latest cluster version and use token auth

### DIFF
--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -129,6 +129,11 @@ func kubernetesConfigSchema() *schema.Schema {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+
+				"token": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
 			},
 		},
 	}
@@ -335,6 +340,7 @@ type kubernetesConfigUser struct {
 type kubernetesConfigUserData struct {
 	ClientKeyData     string `yaml:"client-key-data"`
 	ClientCertificate string `yaml:"client-certificate-data"`
+	Token             string `yaml:"token"`
 }
 
 func flattenKubeConfig(config *godo.KubernetesClusterConfig) []interface{} {
@@ -363,6 +369,7 @@ func flattenKubeConfig(config *godo.KubernetesClusterConfig) []interface{} {
 
 	rawConfig["client_key"] = c.Users[0].User.ClientKeyData
 	rawConfig["client_certificate"] = c.Users[0].User.ClientCertificate
+	rawConfig["token"] = c.Users[0].User.Token
 
 	return []interface{}{rawConfig}
 }

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -27,7 +27,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "region", "lon1"),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", "1.15.3-do.1"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", "1.15.3-do.3"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "ipv4_address"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "cluster_subnet"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "service_subnet"),
@@ -187,7 +187,7 @@ func testAccDigitalOceanKubernetesConfigBasic(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.1"
+	version = "1.15.3-do.3"
 	tags    = ["foo","bar", "one"]
 
 	node_pool {
@@ -205,7 +205,7 @@ func testAccDigitalOceanKubernetesConfigBasic2(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.1"
+	version = "1.15.3-do.3"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -223,7 +223,7 @@ func testAccDigitalOceanKubernetesConfigBasic3(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.1"
+	version = "1.15.3-do.3"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -241,7 +241,7 @@ func testAccDigitalOceanKubernetesConfigBasic4(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.1"
+	version = "1.15.3-do.3"
 	tags    = ["one","two"]
 
 	node_pool {
@@ -259,7 +259,7 @@ func testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(rNam
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.1"
+	version = "1.15.3-do.3"
 
 	node_pool {
 	  name = "default"

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -52,8 +52,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.raw_config"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.cluster_ca_certificate"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.host"),
-					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.client_key"),
-					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.client_certificate"),
+					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.token"),
 				),
 			},
 		},
@@ -174,8 +173,7 @@ func TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability(t *
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s), resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.raw_config"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.cluster_ca_certificate"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.host"),
-					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.client_key"),
-					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.client_certificate"),
+					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.token"),
 				),
 			},
 		},
@@ -280,6 +278,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(
     digitalocean_kubernetes_cluster.foobar.kube_config[0].cluster_ca_certificate
   )
+  token = digitalocean_kubernetes_cluster.foobar.kube_config[0].token
 }
 
 resource "kubernetes_service_account" "tiller" {

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
@@ -78,7 +78,7 @@ func testAccDigitalOceanKubernetesConfigBasicWithNodePool(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.2"
+	version = "1.15.3-do.3"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -105,7 +105,7 @@ func testAccDigitalOceanKubernetesConfigBasicWithNodePool2(rName string) string 
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.2"
+	version = "1.15.3-do.3"
 	tags    = ["foo","bar"]
 
 	node_pool {

--- a/website/docs/d/kubernetes_cluster.html.md
+++ b/website/docs/d/kubernetes_cluster.html.md
@@ -50,9 +50,10 @@ The following attributes are exported:
 * `kube_config.0` - A representation of the Kubernetes cluster's kubeconfig with the following attributes:
   - `raw_config` - The full contents of the Kubernetes cluster's kubeconfig file.
   - `host` - The URL of the API server on the Kubernetes master node.
-  - `client_key` - The base64 encoded private key used by clients to access the cluster.
-  - `client_certificate` - The base64 encoded public certificate used by clients to access the cluster.
   - `cluster_ca_certificate` - The base64 encoded public certificate for the cluster's certificate authority.
+  - `token` - The DigitalOcean API access token used by clients to access the cluster.
+  - `client_key` - The base64 encoded private key used by clients to access the cluster. Only available if token authentication is not supported on your cluster.
+  - `client_certificate` - The base64 encoded public certificate used by clients to access the cluster. Only available if token authentication is not supported on your cluster.
 * `node_pool` - A list of node pools associated with the cluster. Each node pool exports the following attributes:
   - `id` -  The unique ID that can be used to identify and reference the node pool.
   - `name` - The name of the node pool.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -82,9 +82,10 @@ In addition to the arguments listed above, the following additional attributes a
 * `kube_config.0` - A representation of the Kubernetes cluster's kubeconfig with the following attributes:
   - `raw_config` - The full contents of the Kubernetes cluster's kubeconfig file.
   - `host` - The URL of the API server on the Kubernetes master node.
-  - `client_key` - The base64 encoded private key used by clients to access the cluster.
-  - `client_certificate` - The base64 encoded public certificate used by clients to access the cluster.
   - `cluster_ca_certificate` - The base64 encoded public certificate for the cluster's certificate authority.
+  - `token` - The DigitalOcean API access token used by clients to access the cluster.
+  - `client_key` - The base64 encoded private key used by clients to access the cluster. Only available if token authentication is not supported on your cluster.
+  - `client_certificate` - The base64 encoded public certificate used by clients to access the cluster. Only available if token authentication is not supported on your cluster.
 * `node_pool` - In addition to the arguments provided, these additional attributes about the cluster's default node pool are exported:
   - `id` -  A unique ID that can be used to identify and reference the node pool.
   - `nodes` - A list of nodes in the pool. Each node exports the following attributes:

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -17,7 +17,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
   // Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.15.3-do.2"
+  version = "1.15.3-do.3"
 
   node_pool {
     name       = "worker-pool"
@@ -34,7 +34,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
   // Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.15.3-do.2"
+  version = "1.15.3-do.3"
   tags    = ["staging"]
 
   node_pool {


### PR DESCRIPTION
This PR bumps DOKS versions in acc tests to latest (`1.15.3-do.3`), and updates tests to expect tokens instead of certs in the kubeconfig. This is in preparation for some other upcoming PRs.

*Note* that this PR is rebased on top of https://github.com/terraform-providers/terraform-provider-digitalocean/pull/308 until it's merged. See https://github.com/snormore/terraform-provider-digitalocean/compare/doks-testacc-fixes...doks-bump-versions until then.

@andrewsomething @eddiezane @timoreimann

## Before

```sh
$ GOFLAGS=-mod=vendor make testacc TESTARGS="-run=TestAccDigitalOceanKubernetes -parallel=10"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanKubernetes -parallel=10 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanKubernetesCluster_Basic
=== PAUSE TestAccDigitalOceanKubernetesCluster_Basic
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== RUN   TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== PAUSE TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== RUN   TestAccDigitalOceanKubernetesNodePool_Basic
=== PAUSE TestAccDigitalOceanKubernetesNodePool_Basic
=== RUN   TestAccDigitalOceanKubernetesNodePool_Update
=== PAUSE TestAccDigitalOceanKubernetesNodePool_Update
=== CONT  TestAccDigitalOceanKubernetesCluster_Basic
=== CONT  TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== CONT  TestAccDigitalOceanKubernetesNodePool_Update
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== CONT  TestAccDigitalOceanKubernetesNodePool_Basic
--- FAIL: TestAccDigitalOceanKubernetesCluster_Basic (412.23s)
    testing.go:569: Step 0 error: Check failed: 2 errors occurred:
        	* Check 29/30 error: digitalocean_kubernetes_cluster.foobar: Attribute 'kube_config.0.client_key' expected to be set
        	* Check 30/30 error: digitalocean_kubernetes_cluster.foobar: Attribute 'kube_config.0.client_certificate' expected to be set


--- FAIL: TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability (412.83s)
    testing.go:569: Step 0 error: errors during apply:

        Error: Unauthorized

          on /var/folders/ws/s67gr8k95yq7qm2_8vthwxg40000gp/T/tf-test358169127/main.tf line 28:
          (source code not available)


--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails (524.86s)
--- PASS: TestAccDigitalOceanKubernetesNodePool_Basic (614.45s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdateCluster (684.84s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolSize (715.59s)
--- PASS: TestAccDigitalOceanKubernetesNodePool_Update (867.42s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	867.738s
FAIL
make: *** [testacc] Error 1
```

## After

```sh
$ GOFLAGS=-mod=vendor make testacc TESTARGS="-run=TestAccDigitalOceanKubernetes -parallel=10"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanKubernetes -parallel=10 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanKubernetesCluster_Basic
=== PAUSE TestAccDigitalOceanKubernetesCluster_Basic
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== RUN   TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== PAUSE TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== RUN   TestAccDigitalOceanKubernetesNodePool_Basic
=== PAUSE TestAccDigitalOceanKubernetesNodePool_Basic
=== RUN   TestAccDigitalOceanKubernetesNodePool_Update
=== PAUSE TestAccDigitalOceanKubernetesNodePool_Update
=== CONT  TestAccDigitalOceanKubernetesCluster_Basic
=== CONT  TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== CONT  TestAccDigitalOceanKubernetesNodePool_Basic
=== CONT  TestAccDigitalOceanKubernetesNodePool_Update
--- PASS: TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability (436.03s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails (446.51s)
--- PASS: TestAccDigitalOceanKubernetesCluster_Basic (472.97s)
--- PASS: TestAccDigitalOceanKubernetesNodePool_Update (688.10s)
--- PASS: TestAccDigitalOceanKubernetesNodePool_Basic (745.09s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolSize (825.52s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdateCluster (905.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	905.834s
```