### PR TITLE
doks: bump version in tests to 1.15.4-do.0

### DIFF
--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -27,7 +27,7 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "region", "lon1"),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", "1.15.3-do.3"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", "1.15.4-do.0"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "ipv4_address"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "cluster_subnet"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "service_subnet"),
@@ -185,7 +185,7 @@ func testAccDigitalOceanKubernetesConfigBasic(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.4-do.0"
 	tags    = ["foo","bar", "one"]
 
 	node_pool {
@@ -203,7 +203,7 @@ func testAccDigitalOceanKubernetesConfigBasic2(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.4-do.0"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -221,7 +221,7 @@ func testAccDigitalOceanKubernetesConfigBasic3(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.4-do.0"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -239,7 +239,7 @@ func testAccDigitalOceanKubernetesConfigBasic4(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.4-do.0"
 	tags    = ["one","two"]
 
 	node_pool {
@@ -257,7 +257,7 @@ func testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(rNam
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.4-do.0"
 
 	node_pool {
 	  name = "default"

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
@@ -78,7 +78,7 @@ func testAccDigitalOceanKubernetesConfigBasicWithNodePool(rName string) string {
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.4-do.0"
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -105,7 +105,7 @@ func testAccDigitalOceanKubernetesConfigBasicWithNodePool2(rName string) string 
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "1.15.3-do.3"
+	version = "1.15.4-do.0"
 	tags    = ["foo","bar"]
 
 	node_pool {

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -17,7 +17,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
   // Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.15.3-do.3"
+  version = "1.15.4-do.0"
 
   node_pool {
     name       = "worker-pool"
@@ -34,7 +34,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
   name    = "foo"
   region  = "nyc1"
   // Grab the latest version slug from `doctl kubernetes options versions`
-  version = "1.15.3-do.3"
+  version = "1.15.4-do.0"
   tags    = ["staging"]
 
   node_pool {


### PR DESCRIPTION
Bumping this every time there's a new release definitely isn't ideal. I'm going to follow-up with a PR that handles this more dynamically, at some point this week. For now, let's bump it again.

@andrewsomething @eddiezane @timoreimann