### PR TITLE
doks: Produce a valid kubeconfig file.

### DIFF
--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -246,7 +246,7 @@ func digitaloceanKubernetesClusterRead(client *godo.Client, cluster *godo.Kubern
 				return fmt.Errorf("Unable to fetch Kubernetes credentials: %s", err)
 			}
 		}
-		d.Set("kube_config", flattenCredentials(cluster.Name, creds))
+		d.Set("kube_config", flattenCredentials(cluster.Name, cluster.RegionSlug, creds))
 	}
 
 	return nil
@@ -339,8 +339,12 @@ func waitForKubernetesClusterCreate(client *godo.Client, id string) (*godo.Kuber
 }
 
 type kubernetesConfig struct {
-	Clusters []kubernetesConfigCluster `yaml:"clusters"`
-	Users    []kubernetesConfigUser    `yaml:"users"`
+	APIVersion     string                    `yaml:"apiVersion"`
+	Kind           string                    `yaml:"kind"`
+	Clusters       []kubernetesConfigCluster `yaml:"clusters"`
+	Contexts       []kubernetesConfigContext `yaml:"contexts"`
+	CurrentContext string                    `yaml:"current-context"`
+	Users          []kubernetesConfigUser    `yaml:"users"`
 }
 
 type kubernetesConfigCluster struct {
@@ -350,6 +354,15 @@ type kubernetesConfigCluster struct {
 type kubernetesConfigClusterData struct {
 	CertificateAuthorityData string `yaml:"certificate-authority-data"`
 	Server                   string `yaml:"server"`
+}
+
+type kubernetesConfigContext struct {
+	Context kubernetesConfigContextData `yaml:"context"`
+	Name    string                      `yaml:"name"`
+}
+type kubernetesConfigContextData struct {
+	Cluster string `yaml:"cluster"`
+	User    string `yaml:"user"`
 }
 
 type kubernetesConfigUser struct {
@@ -363,7 +376,7 @@ type kubernetesConfigUserData struct {
 	Token                 string `yaml:"token"`
 }
 
-func flattenCredentials(name string, creds *godo.KubernetesClusterCredentials) []interface{} {
+func flattenCredentials(name string, region string, creds *godo.KubernetesClusterCredentials) []interface{} {
 	raw := map[string]interface{}{
 		"cluster_ca_certificate": base64.StdEncoding.EncodeToString(creds.CertificateAuthorityData),
 		"host":                   creds.Server,
@@ -379,7 +392,7 @@ func flattenCredentials(name string, creds *godo.KubernetesClusterCredentials) [
 		raw["client_certificate"] = string(creds.ClientCertificateData)
 	}
 
-	kubeconfigYAML, err := renderKubeconfig(name, creds)
+	kubeconfigYAML, err := renderKubeconfig(name, region, creds)
 	if err != nil {
 		log.Printf("[DEBUG] error marshalling config: %s", err)
 		return nil
@@ -389,17 +402,29 @@ func flattenCredentials(name string, creds *godo.KubernetesClusterCredentials) [
 	return []interface{}{raw}
 }
 
-func renderKubeconfig(name string, creds *godo.KubernetesClusterCredentials) ([]byte, error) {
+func renderKubeconfig(name string, region string, creds *godo.KubernetesClusterCredentials) ([]byte, error) {
+	clusterName := fmt.Sprintf("do-%s-%s", region, name)
+	userName := fmt.Sprintf("do-%s-%s-admin", region, name)
 	config := kubernetesConfig{
+		APIVersion: "v1",
+		Kind:       "Config",
 		Clusters: []kubernetesConfigCluster{{
-			Name: "",
+			Name: clusterName,
 			Cluster: kubernetesConfigClusterData{
 				CertificateAuthorityData: base64.StdEncoding.EncodeToString(creds.CertificateAuthorityData),
 				Server:                   creds.Server,
 			},
 		}},
+		Contexts: []kubernetesConfigContext{{
+			Context: kubernetesConfigContextData{
+				Cluster: clusterName,
+				User:    userName,
+			},
+			Name: clusterName,
+		}},
+		CurrentContext: clusterName,
 		Users: []kubernetesConfigUser{{
-			Name: "",
+			Name: userName,
 			User: kubernetesConfigUserData{
 				Token: creds.Token,
 			},

--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -371,8 +371,8 @@ type kubernetesConfigUser struct {
 }
 
 type kubernetesConfigUserData struct {
-	ClientKeyData         string `yaml:"client-key-data"`
-	ClientCertificateData string `yaml:"client-certificate-data"`
+	ClientKeyData         string `yaml:"client-key-data,omitempty"`
+	ClientCertificateData string `yaml:"client-certificate-data,omitempty"`
 	Token                 string `yaml:"token"`
 }
 

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -2,9 +2,11 @@ package digitalocean
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -370,5 +372,46 @@ func Test_filterTags(t *testing.T) {
 		if !reflect.DeepEqual(filteredTags, tt.want) {
 			t.Errorf("filterTags returned %+v, expected %+v", filteredTags, tt.want)
 		}
+	}
+}
+
+func Test_renderKubeconfig(t *testing.T) {
+	certAuth := []byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURKekNDQWWlOQT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K")
+	expected := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: %v
+    server: https://6a37a0f6-c355-4527-b54d-521beffd9817.k8s.ondigitalocean.com
+  name: do-lon1-test-cluster
+contexts:
+- context:
+    cluster: do-lon1-test-cluster
+    user: do-lon1-test-cluster-admin
+  name: do-lon1-test-cluster
+current-context: do-lon1-test-cluster
+users:
+- name: do-lon1-test-cluster-admin
+  user:
+    client-key-data: ""
+    client-certificate-data: ""
+    token: 97ae2bbcfd85c34155a56b822ffa73909d6770b28eb7e5dfa78fa83e02ffc60f
+`, base64.StdEncoding.EncodeToString(certAuth))
+
+	creds := godo.KubernetesClusterCredentials{
+		Server:                   "https://6a37a0f6-c355-4527-b54d-521beffd9817.k8s.ondigitalocean.com",
+		CertificateAuthorityData: certAuth,
+		Token:                    "97ae2bbcfd85c34155a56b822ffa73909d6770b28eb7e5dfa78fa83e02ffc60f",
+		ExpiresAt:                time.Now(),
+	}
+	kubeConfigRenderd, err := renderKubeconfig("test-cluster", "lon1", &creds)
+	if err != nil {
+		t.Errorf("error calling renderKubeconfig: %s", err)
+
+	}
+	got := string(kubeConfigRenderd)
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("renderKubeconfig returned %+v\n, expected %+v\n", got, expected)
 	}
 }

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -393,8 +393,6 @@ current-context: do-lon1-test-cluster
 users:
 - name: do-lon1-test-cluster-admin
   user:
-    client-key-data: ""
-    client-certificate-data: ""
     token: 97ae2bbcfd85c34155a56b822ffa73909d6770b28eb7e5dfa78fa83e02ffc60f
 `, base64.StdEncoding.EncodeToString(certAuth))
 

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,3 @@ require (
 )
 
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 )
 
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
+
+go 1.13

--- a/website/docs/d/kubernetes_cluster.html.md
+++ b/website/docs/d/kubernetes_cluster.html.md
@@ -20,6 +20,9 @@ data "digitalocean_kubernetes_cluster" "example" {
 provider "kubernetes" {
   host  = data.digitalocean_kubernetes_cluster.example.endpoint
   token = data.digitalocean_kubernetes_cluster.example.kube_config[0].token
+  cluster_ca_certificate = base64decode(
+    data.digitalocean_kubernetes_cluster.example.kube_config[0].cluster_ca_certificate
+  )
 }
 ```
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -46,7 +46,10 @@ resource "digitalocean_kubernetes_cluster" "foo" {
 
 provider "kubernetes" {
   host  = digitalocean_kubernetes_cluster.foo.endpoint
-  token = digitalocean_kubernetes_cluster.foo.kube_config[0].token"
+  token = digitalocean_kubernetes_cluster.foo.kube_config[0].token
+  cluster_ca_certificate = base64decode(
+    digitalocean_kubernetes_cluster.foo.kube_config[0].cluster_ca_certificate
+  )
 }
 ```
 


### PR DESCRIPTION
As a side-effect of moving to the `GetCredentials` endpoint in https://github.com/terraform-providers/terraform-provider-digitalocean/pull/311, the `raw_config` is no longer a usable kubeconfig file. This PR attempts to fix that.

@snormore, I'd love your input here. This feels more fragile than I'd like. Is there a better way to get the cluster and user names for use in a kubeconfig file short of making calls to both `GetKubeConfig` and `GetCredentials`?