### PR TITLE
Add data source for account

### DIFF
--- a/digitalocean/datasource_digitalocean_account.go
+++ b/digitalocean/datasource_digitalocean_account.go
@@ -1,0 +1,71 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceDigitalOceanAccount() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDigitalOceanAccountRead,
+		Schema: map[string]*schema.Schema{
+			"droplet_limit": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The total number of Droplets current user or team may have active at one time.",
+			},
+			"floating_ip_limit": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The total number of Floating IPs the current user or team may have.",
+			},
+			"email": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The email address used by the current user to register for DigitalOcean.",
+			},
+			"uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The unique universal identifier for the current user.",
+			},
+			"email_verified": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "If true, the user has verified their account via email. False otherwise.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "This value is one of \"active\", \"warning\" or \"locked\".",
+			},
+			"status_message": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A human-readable message giving more details about the status of the account.",
+			},
+		},
+	}
+}
+
+func dataSourceDigitalOceanAccountRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+
+	account, _, err := client.Account.Get(context.Background())
+	if err != nil {
+		return fmt.Errorf("Error retrieving account: %s", err)
+	}
+
+	d.SetId(account.UUID)
+	d.Set("droplet_limit", account.DropletLimit)
+	d.Set("floating_ip_limit", account.FloatingIPLimit)
+	d.Set("email", account.Email)
+	d.Set("uuid", account.UUID)
+	d.Set("email_verified", account.EmailVerified)
+	d.Set("status", account.Status)
+	d.Set("status_message", account.StatusMessage)
+
+	return nil
+}

--- a/digitalocean/datasource_digitalocean_account_test.go
+++ b/digitalocean/datasource_digitalocean_account_test.go
@@ -1,0 +1,28 @@
+package digitalocean
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceDigitalOceanAccount_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDataSourceDigitalOceanAccountConfig_basic),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.digitalocean_account.foobar", "uuid"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckDataSourceDigitalOceanAccountConfig_basic = `
+data "digitalocean_account" "foobar" {
+}`

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -39,6 +39,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"digitalocean_account":            dataSourceDigitalOceanAccount(),
 			"digitalocean_certificate":        dataSourceDigitalOceanCertificate(),
 			"digitalocean_database_cluster":   dataSourceDigitalOceanDatabaseCluster(),
 			"digitalocean_domain":             dataSourceDigitalOceanDomain(),

--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -13,6 +13,9 @@
         <li<%= sidebar_current("docs-do-datasource") %>>
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-do-datasource-account") %>>
+              <a href="/docs/providers/do/d/account.html">digitalocean_account</a>
+            </li>
             <li<%= sidebar_current("docs-do-datasource-certificate") %>>
               <a href="/docs/providers/do/d/certificate.html">digitalocean_certificate</a>
             </li>

--- a/website/docs/d/account.html.md
+++ b/website/docs/d/account.html.md
@@ -1,0 +1,31 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_account"
+description: |-
+  Get information on your DigitalOcean account.
+---
+
+# digitalocean_account
+
+Get information on your DigitalOcean account.
+
+## Example Usage
+
+Get the account:
+
+```hcl
+data "digitalocean_account" "example" {
+}
+```
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `droplet_limit`: The total number of droplets current user or team may have active at one time.
+* `floating_ip_limit`: The total number of floating IPs the current user or team may have.
+* `email`: The email address used by the current user to register for DigitalOcean.
+* `uuid`: The unique universal identifier for the current user.
+* `email_verified`: If true, the user has verified their account via email. False otherwise.
+* `status`: This value is one of "active", "warning" or "locked".
+* `status_message`: A human-readable message giving more details about the status of the account.

--- a/website/docs/d/account.html.md
+++ b/website/docs/d/account.html.md
@@ -1,6 +1,7 @@
 ---
 layout: "digitalocean"
 page_title: "DigitalOcean: digitalocean_account"
+sidebar_current: "docs-do-datasource-account"
 description: |-
   Get information on your DigitalOcean account.
 ---


### PR DESCRIPTION
This PR creates a new data source `digitalocean_account` to retrieve information of the authenticated user used in the provider. It is currently a basic implementation as proposed in #263, but cannot retrieve information of other users yet.

### Example Usage

```hcl
data "digitalocean_account" "example" {
}
```
