### PR TITLE
Add data source for sizes (with filter and sort)

### DIFF
--- a/digitalocean/datasource_digitalocean_sizes.go
+++ b/digitalocean/datasource_digitalocean_sizes.go
@@ -1,8 +1,11 @@
 package digitalocean
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -28,57 +31,72 @@ func dataSourceDigitalOceanSizes() *schema.Resource {
 			"sort":   sortSchema(filterKeysDigitalOceanSizes),
 
 			// Computed properties
-			"slug": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "A human-readable string that is used to uniquely identify each size.",
-			},
-			"available": {
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Description: "This represents whether new Droplets can be created with this size.",
-			},
-			"transfer": {
-				Type:        schema.TypeFloat,
-				Computed:    true,
-				Description: "The amount of transfer bandwidth that is available for Droplets created in this size. This only counts traffic on the public interface. The value is given in terabytes.",
-			},
-			"price_monthly": {
-				Type:        schema.TypeFloat,
-				Computed:    true,
-				Description: "The monthly cost of Droplets created in this size if they are kept for an entire month. The value is measured in US dollars.",
-			},
-			"price_hourly": {
-				Type:        schema.TypeFloat,
-				Computed:    true,
-				Description: "The hourly cost of Droplets created in this size as measured hourly. The value is measured in US dollars.",
-			},
-			"memory": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "The amount of RAM allocated to Droplets created of this size. The value is measured in megabytes.",
-			},
-			"vcpus": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "The number of CPUs allocated to Droplets of this size.",
-			},
-			"disk": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "The amount of disk space set aside for Droplets of this size. The value is measured in gigabytes.",
-			},
-			"regions": {
-				Type:        schema.TypeList,
-				Computed:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "List of region slugs where Droplets can be created in this size.",
+			"sizes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"slug": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A human-readable string that is used to uniquely identify each size.",
+						},
+						"available": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "This represents whether new Droplets can be created with this size.",
+						},
+						"transfer": {
+							Type:        schema.TypeFloat,
+							Computed:    true,
+							Description: "The amount of transfer bandwidth that is available for Droplets created in this size. This only counts traffic on the public interface. The value is given in terabytes.",
+						},
+						"price_monthly": {
+							Type:        schema.TypeFloat,
+							Computed:    true,
+							Description: "The monthly cost of Droplets created in this size if they are kept for an entire month. The value is measured in US dollars.",
+						},
+						"price_hourly": {
+							Type:        schema.TypeFloat,
+							Computed:    true,
+							Description: "The hourly cost of Droplets created in this size as measured hourly. The value is measured in US dollars.",
+						},
+						"memory": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The amount of RAM allocated to Droplets created of this size. The value is measured in megabytes.",
+						},
+						"vcpus": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of CPUs allocated to Droplets of this size.",
+						},
+						"disk": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The amount of disk space set aside for Droplets of this size. The value is measured in gigabytes.",
+						},
+						"regions": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "List of region slugs where Droplets can be created in this size.",
+						},
+					},
+				},
+				Description: "List of filtered digital ocean sizes.",
 			},
 		},
 	}
 }
 
 func dataSourceDigitalOceanSizeRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+	sizes, err := getAllDigitalOceanSizes(client)
+	if err != nil {
+		return err
+	}
+
 	if v, ok := d.GetOk("filter"); ok {
 		filters := expandFilters(v.(*schema.Set).List())
 		fmt.Printf("%+v", filters)
@@ -89,5 +107,69 @@ func dataSourceDigitalOceanSizeRead(d *schema.ResourceData, meta interface{}) er
 		fmt.Printf("%+v", sorts)
 	}
 
+	d.SetId(resource.UniqueId())
+	if err := d.Set("sizes", flattenDigitalOceanSizes(sizes)); err != nil {
+		return fmt.Errorf("Error setting `sizes`: %+v", err)
+	}
+
 	return nil
+}
+
+func getAllDigitalOceanSizes(client *godo.Client) ([]godo.Size, error) {
+	sizes := []godo.Size{}
+
+	opts := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	for {
+		partialSizes, resp, err := client.Sizes.List(context.Background(), opts)
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving sizes: %s", err)
+		}
+
+		for _, partialSize := range partialSizes {
+			sizes = append(sizes, partialSize)
+		}
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving sizes: %s", err)
+		}
+
+		opts.Page = page + 1
+	}
+
+	return sizes, nil
+}
+
+func flattenDigitalOceanSizes(sizes []godo.Size) []interface{} {
+	flattenedSizes := make([]interface{}, len(sizes))
+
+	for i, s := range sizes {
+		flattenedSize := make(map[string]interface{})
+		flattenedSize["slug"] = s.Slug
+		flattenedSize["available"] = s.Available
+		flattenedSize["transfer"] = s.Transfer
+		flattenedSize["price_monthly"] = s.PriceMonthly
+		flattenedSize["price_hourly"] = s.PriceHourly
+		flattenedSize["memory"] = s.Memory
+		flattenedSize["vcpus"] = s.Vcpus
+		flattenedSize["disk"] = s.Disk
+
+		flattenedRegions := schema.NewSet(schema.HashString, []interface{}{})
+		for _, r := range s.Regions {
+			flattenedRegions.Add(r)
+		}
+		flattenedSize["regions"] = flattenedRegions
+
+		flattenedSizes[i] = flattenedSize
+	}
+
+	return flattenedSizes
 }

--- a/digitalocean/datasource_digitalocean_sizes.go
+++ b/digitalocean/datasource_digitalocean_sizes.go
@@ -1,0 +1,93 @@
+package digitalocean
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+var (
+	filterKeysDigitalOceanSizes = []string{
+		"slug",
+		"regions",
+		"memory",
+		"vcpus",
+		"disk",
+		"transfer",
+		"price_monthly",
+		"price_hourly",
+		"available",
+	}
+)
+
+func dataSourceDigitalOceanSizes() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDigitalOceanSizeRead,
+		Schema: map[string]*schema.Schema{
+			"filter": filterSchema(filterKeysDigitalOceanSizes),
+			"sort":   sortSchema(filterKeysDigitalOceanSizes),
+
+			// Computed properties
+			"slug": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A human-readable string that is used to uniquely identify each size.",
+			},
+			"available": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "This represents whether new Droplets can be created with this size.",
+			},
+			"transfer": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: "The amount of transfer bandwidth that is available for Droplets created in this size. This only counts traffic on the public interface. The value is given in terabytes.",
+			},
+			"price_monthly": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: "The monthly cost of Droplets created in this size if they are kept for an entire month. The value is measured in US dollars.",
+			},
+			"price_hourly": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: "The hourly cost of Droplets created in this size as measured hourly. The value is measured in US dollars.",
+			},
+			"memory": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The amount of RAM allocated to Droplets created of this size. The value is measured in megabytes.",
+			},
+			"vcpus": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The number of CPUs allocated to Droplets of this size.",
+			},
+			"disk": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The amount of disk space set aside for Droplets of this size. The value is measured in gigabytes.",
+			},
+			"regions": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "List of region slugs where Droplets can be created in this size.",
+			},
+		},
+	}
+}
+
+func dataSourceDigitalOceanSizeRead(d *schema.ResourceData, meta interface{}) error {
+	if v, ok := d.GetOk("filter"); ok {
+		filters := expandFilters(v.(*schema.Set).List())
+		fmt.Printf("%+v", filters)
+	}
+
+	if v, ok := d.GetOk("sort"); ok {
+		sorts := expandSorts(v.(*schema.Set).List())
+		fmt.Printf("%+v", sorts)
+	}
+
+	return nil
+}

--- a/digitalocean/datasource_digitalocean_sizes.go
+++ b/digitalocean/datasource_digitalocean_sizes.go
@@ -163,7 +163,10 @@ func getDigitalOceanSizes(client *godo.Client) ([]godo.Size, error) {
 
 func filterDigitalOceanSizes(sizes []godo.Size, filters []commonFilter) []godo.Size {
 	for _, f := range filters {
+		// Handle multiple filters by applying them in order
 		var filteredSizes []godo.Size
+
+		// Define the filter strategy based on the filter key
 		filterFunc := func(size godo.Size) bool {
 			result := false
 
@@ -223,35 +226,52 @@ func filterDigitalOceanSizes(sizes []godo.Size, filters []commonFilter) []godo.S
 }
 
 func sortDigitalOceanSizes(sizes []godo.Size, sorts []commonSort) []godo.Size {
-	for _, s := range sorts {
-		sortAscFunc := func(size1, size2 godo.Size) bool {
+	sort.Slice(sizes, func(_i, _j int) bool {
+		for _, s := range sorts {
+			// Handle multiple sorts by applying them in order
+
+			i := _i
+			j := _j
+			if strings.EqualFold(s.direction, "desc") {
+				// If the direction is desc, reverse index to compare
+				i = _j
+				j = _i
+			}
+
 			switch s.key {
 			case "slug":
-				return size1.Slug <= size2.Slug
+				if sizes[i].Slug != sizes[j].Slug {
+					return sizes[i].Slug < sizes[j].Slug
+				}
 			case "memory":
-				return size1.Memory <= size2.Memory
+				if sizes[i].Memory != sizes[j].Memory {
+					return sizes[i].Memory < sizes[j].Memory
+				}
 			case "vcpus":
-				return size1.Vcpus <= size2.Vcpus
+				if sizes[i].Vcpus != sizes[j].Vcpus {
+					return sizes[i].Vcpus < sizes[j].Vcpus
+				}
 			case "disk":
-				return size1.Disk <= size2.Disk
+				if sizes[i].Disk != sizes[j].Disk {
+					return sizes[i].Disk < sizes[j].Disk
+				}
 			case "transfer":
-				return size1.Transfer <= size2.Transfer
+				if sizes[i].Transfer != sizes[j].Transfer {
+					return sizes[i].Transfer < sizes[j].Transfer
+				}
 			case "price_monthly":
-				return size1.PriceMonthly <= size2.PriceMonthly
+				if sizes[i].PriceMonthly != sizes[j].PriceMonthly {
+					return sizes[i].PriceMonthly < sizes[j].PriceMonthly
+				}
 			case "price_hourly":
-				return size1.PriceHourly <= size2.PriceHourly
-			default:
-				return true
+				if sizes[i].PriceHourly != sizes[j].PriceHourly {
+					return sizes[i].PriceHourly < sizes[j].PriceHourly
+				}
 			}
 		}
 
-		sort.Slice(sizes, func(i, j int) bool {
-			if strings.EqualFold(s.direction, "asc") {
-				return sortAscFunc(sizes[i], sizes[j])
-			}
-			return sortAscFunc(sizes[j], sizes[i])
-		})
-	}
+		return true
+	})
 
 	return sizes
 }

--- a/digitalocean/datasource_digitalocean_sizes.go
+++ b/digitalocean/datasource_digitalocean_sizes.go
@@ -116,7 +116,7 @@ func dataSourceDigitalOceanSizeRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if v, ok := d.GetOk("sort"); ok {
-		sorts := expandSorts(v.(*schema.Set).List())
+		sorts := expandSorts(v.([]interface{}))
 		sizes = sortDigitalOceanSizes(sizes, sorts)
 	}
 

--- a/digitalocean/datasource_digitalocean_sizes_test.go
+++ b/digitalocean/datasource_digitalocean_sizes_test.go
@@ -1,0 +1,61 @@
+package digitalocean
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceDigitalOceanSizes_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDataSourceDigitalOceanSizesConfigBasic),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDigitalOceanSizes_WithFilterAndSort(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDataSourceDigitalOceanSizesConfigWithFilterAndSort),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
+const testAccCheckDataSourceDigitalOceanSizesConfigBasic = `
+data "digitalocean_sizes" "foobar" {
+}`
+
+const testAccCheckDataSourceDigitalOceanSizesConfigWithFilterAndSort = `
+data "digitalocean_sizes" "foobar" {
+	filter {
+		key 	= "slug"
+		values 	= ["s-1vcpu-1gb", "s-1vcpu-2gb", "s-2vcpu-2gb", "s-3vcpu-1gb"]
+	}
+
+	filter {
+		key 	= "vcpus"
+		values 	= ["1", "2"]
+	}
+
+	sort {
+		key 		= "price_monthly"
+		direction 	= "desc"
+	}
+
+	sort {
+		key 		= "slug"
+		direction 	= "desc"
+	}
+}`

--- a/digitalocean/filter.go
+++ b/digitalocean/filter.go
@@ -1,0 +1,57 @@
+package digitalocean
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+type commonFilter struct {
+	key    string
+	values []string
+}
+
+func filterSchema(allowedKeys []string) *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeSet,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"key": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(allowedKeys, false),
+				},
+				"values": {
+					Type:     schema.TypeList,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
+		Optional:    true,
+		Description: "One or more key/value pairs to filter droplet size results.",
+	}
+}
+
+func expandFilters(rawFilters []interface{}) []commonFilter {
+	expandedFilters := make([]commonFilter, len(rawFilters))
+	for i, rawFilter := range rawFilters {
+		f := rawFilter.(map[string]interface{})
+
+		expandedFilter := commonFilter{
+			key:    f["key"].(string),
+			values: expandFilterValues(f["values"].([]interface{})),
+		}
+
+		expandedFilters[i] = expandedFilter
+	}
+	return expandedFilters
+}
+
+func expandFilterValues(rawFilterValues []interface{}) []string {
+	expandedFilterValues := make([]string, len(rawFilterValues))
+	for i, v := range rawFilterValues {
+		expandedFilterValues[i] = v.(string)
+	}
+
+	return expandedFilterValues
+}

--- a/digitalocean/filter_test.go
+++ b/digitalocean/filter_test.go
@@ -1,0 +1,34 @@
+package digitalocean
+
+import "testing"
+
+func TestExpandFilters(t *testing.T) {
+	rawFilters := []interface{}{
+		map[string]interface{}{
+			"key":    "fieldA",
+			"values": []interface{}{"foo", "bar"},
+		},
+		map[string]interface{}{
+			"key":    "fieldB",
+			"values": []interface{}{"20", "40"},
+		},
+	}
+
+	expandedFilters := expandFilters(rawFilters)
+
+	if len(rawFilters) != len(expandedFilters) {
+		t.Fatalf("incorrect expected length of expanded filters")
+	}
+	if expandedFilters[0].key != "fieldA" ||
+		len(expandedFilters[0].values) != 2 ||
+		expandedFilters[0].values[0] != "foo" ||
+		expandedFilters[0].values[1] != "bar" {
+		t.Fatalf("incorrect expansion of the 1st expanded filters")
+	}
+	if expandedFilters[1].key != "fieldB" ||
+		len(expandedFilters[1].values) != 2 ||
+		expandedFilters[1].values[0] != "20" ||
+		expandedFilters[1].values[1] != "40" {
+		t.Fatalf("incorrect expansion of the 2nd expanded filters")
+	}
+}

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -50,6 +50,7 @@ func Provider() terraform.ResourceProvider {
 			"digitalocean_kubernetes_cluster": dataSourceDigitalOceanKubernetesCluster(),
 			"digitalocean_loadbalancer":       dataSourceDigitalOceanLoadbalancer(),
 			"digitalocean_record":             dataSourceDigitalOceanRecord(),
+			"digitalocean_sizes":              dataSourceDigitalOceanSizes(),
 			"digitalocean_ssh_key":            dataSourceDigitalOceanSSHKey(),
 			"digitalocean_tag":                dataSourceDigitalOceanTag(),
 			"digitalocean_volume_snapshot":    dataSourceDigitalOceanVolumeSnapshot(),

--- a/digitalocean/sort.go
+++ b/digitalocean/sort.go
@@ -1,0 +1,52 @@
+package digitalocean
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+var (
+	sortKeys = []string{"asc", "desc"}
+)
+
+type commonSort struct {
+	key       string
+	direction string
+}
+
+func sortSchema(allowedKeys []string) *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeSet,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"key": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(allowedKeys, false),
+				},
+				"direction": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(sortKeys, false),
+				},
+			},
+		},
+		Optional:    true,
+		Description: "One or more key/direction pairs to sort droplet size results.",
+	}
+}
+
+func expandSorts(rawSorts []interface{}) []commonSort {
+	expandedSorts := make([]commonSort, len(rawSorts))
+	for i, rawSort := range rawSorts {
+		f := rawSort.(map[string]interface{})
+
+		expandedSort := commonSort{
+			key:       f["key"].(string),
+			direction: f["direction"].(string),
+		}
+
+		expandedSorts[i] = expandedSort
+	}
+	return expandedSorts
+}

--- a/digitalocean/sort.go
+++ b/digitalocean/sort.go
@@ -16,7 +16,7 @@ type commonSort struct {
 
 func sortSchema(allowedKeys []string) *schema.Schema {
 	return &schema.Schema{
-		Type: schema.TypeSet,
+		Type: schema.TypeList,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"key": {

--- a/digitalocean/sort_test.go
+++ b/digitalocean/sort_test.go
@@ -1,0 +1,30 @@
+package digitalocean
+
+import "testing"
+
+func TestExpandSorts(t *testing.T) {
+	rawSorts := []interface{}{
+		map[string]interface{}{
+			"key":       "fieldA",
+			"direction": "asc",
+		},
+		map[string]interface{}{
+			"key":       "fieldB",
+			"direction": "desc",
+		},
+	}
+
+	expandedSorts := expandSorts(rawSorts)
+
+	if len(rawSorts) != len(expandedSorts) {
+		t.Fatalf("incorrect expected length of expanded sorts")
+	}
+	if expandedSorts[0].key != "fieldA" ||
+		expandedSorts[0].direction != "asc" {
+		t.Fatalf("incorrect expansion of the 1st expanded sorts")
+	}
+	if expandedSorts[1].key != "fieldB" ||
+		expandedSorts[1].direction != "desc" {
+		t.Fatalf("incorrect expansion of the 2nd expanded sorts")
+	}
+}

--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -46,6 +46,9 @@
             <li<%= sidebar_current("docs-do-datasource-record") %>>
               <a href="/docs/providers/do/d/record.html">digitalocean_record</a>
             </li>
+            <li<%= sidebar_current("docs-do-datasource-sizes") %>>
+              <a href="/docs/providers/do/d/sizes.html">digitalocean_sizes</a>
+            </li>
             <li<%= sidebar_current("docs-do-datasource-ssh-key") %>>
               <a href="/docs/providers/do/d/ssh_key.html">digitalocean_ssh_key</a>
             </li>

--- a/website/docs/d/sizes.html.md
+++ b/website/docs/d/sizes.html.md
@@ -1,0 +1,96 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_sizes"
+description: |-
+  Retrieve information  DigitalOcean Cloud Firewall resource. This can be used to create, modify, and delete Firewalls.
+---
+
+# digitalocean_sizes
+
+Retrieves information about droplet sizes that DigitalOcean supports. This data source provides all of droplet size properties, with the ability to filter and sort the results.
+
+## Example Usage
+
+Most common usage will probably be to supply a size to droplet:
+
+```hcl
+data "digitalocean_sizes" "main" {
+  filter {
+    key    = "slug"
+    values = ["s-1vcpu-1gb"]
+  }
+}
+
+resource "digitalocean_droplet" "web" {
+  image  = "ubuntu-18-04-x64"
+  name   = "web-1"
+  region = "sgp1"
+  size   = element(data.digitalocean_sizes.main.sizes, 0).slug
+}
+```
+
+The data source also supports multiple filters and sorts. For example, fetch sizes with virtual CPU 1 or 2 that are available "sgp1" region. Pick the cheapest one:
+
+```hcl
+data "digitalocean_sizes" "main" {
+  filter {
+    key    = "vcpus"
+    values = [1, 2]
+  }
+
+  filter {
+    key    = "regions"
+    values = ["sgp1"]
+  }
+
+  sort {
+    key       = "price_monthly"
+    direction = "asc"
+  }
+}
+
+resource "digitalocean_droplet" "web" {
+  image  = "ubuntu-18-04-x64"
+  name   = "web-1"
+  region = "sgp1"
+  size   = element(data.digitalocean_sizes.main.sizes, 0).slug
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `filter` - (Optional) Filter the results.
+  The `filter` block is documented below.
+* `sort` - (Optional) Sort the results.
+  The `sort` block is documented below.
+
+`filter` supports the following:
+
+* `key` - (Required) Filter the sizes by this key. This may be one of `slug`,
+  `regions`, `memory`, `vcpus`, `disk`, `transfer`, `price_monthly`,
+  `price_hourly`, or `available`.
+* `values` - (Required) Only retrieves images which keys has value that matches
+  one of the values provided here.
+
+`sort` supports the following:
+
+* `key` - (Required) Sort the sizes by this key. This may be one of `slug`,
+  `memory`, `vcpus`, `disk`, `transfer`, `price_monthly`, or `price_hourly`.
+* `direction` - (Required) The sort direction. This may be either `asc` or `desc`.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `slug` - A human-readable string that is used to uniquely identify each size.
+* `available` - This represents whether new Droplets can be created with this size.
+* `transfer` - The amount of transfer bandwidth that is available for Droplets created in this size. This only counts traffic on the public interface. The value is given in terabytes.
+* `price_monthly` - The monthly cost of Droplets created in this size if they are kept for an entire month. The value is measured in US dollars.
+* `price_hourly` - The hourly cost of Droplets created in this size as measured hourly. The value is measured in US dollars.
+* `memory` - The amount of RAM allocated to Droplets created of this size. The value is measured in megabytes.
+* `vcpus` - The number of CPUs allocated to Droplets of this size.
+* `disk` - The amount of disk space set aside for Droplets of this size. The value is measured in gigabytes.
+* `regions` - List of region slugs where Droplets can be created in this size.

--- a/website/docs/d/sizes.html.md
+++ b/website/docs/d/sizes.html.md
@@ -1,6 +1,7 @@
 ---
 layout: "digitalocean"
 page_title: "DigitalOcean: digitalocean_sizes"
+sidebar_current: "docs-do-datasource-sizes"
 description: |-
   Retrieve information  DigitalOcean Cloud Firewall resource. This can be used to create, modify, and delete Firewalls.
 ---

--- a/website/docs/d/sizes.html.md
+++ b/website/docs/d/sizes.html.md
@@ -30,7 +30,7 @@ resource "digitalocean_droplet" "web" {
 }
 ```
 
-The data source also supports multiple filters and sorts. For example, fetch sizes with virtual CPU 1 or 2 that are available "sgp1" region. Pick the cheapest one:
+The data source also supports multiple filters and sorts. For example, to fetch sizes with 1 or 2 virtual CPU that are available "sgp1" region, then pick the cheapest one:
 
 ```hcl
 data "digitalocean_sizes" "main" {
@@ -55,6 +55,24 @@ resource "digitalocean_droplet" "web" {
   name   = "web-1"
   region = "sgp1"
   size   = element(data.digitalocean_sizes.main.sizes, 0).slug
+}
+```
+
+The data source can also handle multiple sorts. In which case, the sort will be applied in the order it is defined. For example, to sort by memory in ascending order, then sort by disk in descending order between sizes with same memory:
+
+```hcl
+data "digitalocean_sizes" "main" {
+  sort {
+    // Sort by memory ascendingly
+    key       = "memory"
+    direction = "asc"
+  }
+
+  sort {
+    // Then sort by disk descendingly for sizes with same memory
+    key       = "disk"
+    direction = "desc"
+  }
 }
 ```
 


### PR DESCRIPTION
Related with sizes data source proposal in #263. This PR creates a new data source `digitalocean_sizes` with a rudimentary implementation of filter and sort. The information is retrieved from https://developers.digitalocean.com/documentation/v2/#sizes.

### Example Usage

Most common usage will probably be to supply a size to droplet:

```hcl
data "digitalocean_sizes" "main" {
  filter {
    key    = "slug"
    values = ["s-1vcpu-1gb"]
  }
}

resource "digitalocean_droplet" "web" {
  image  = "ubuntu-18-04-x64"
  name   = "web-1"
  region = "sgp1"
  size   = element(data.digitalocean_sizes.main.sizes, 0).slug
}
```

The data source also supports multiple filters and sorts. For example, fetch sizes with virtual CPU 1 or 2 that are available "sgp1" region. Pick the cheapest one:

```hcl
data "digitalocean_sizes" "main" {
  filter {
    key    = "vcpus"
    values = [1, 2]
  }

  filter {
    key    = "regions"
    values = ["sgp1"]
  }

  sort {
    key       = "price_monthly"
    direction = "asc"
  }
}

resource "digitalocean_droplet" "web" {
  image  = "ubuntu-18-04-x64"
  name   = "web-1"
  region = "sgp1"
  size   = element(data.digitalocean_sizes.main.sizes, 0).slug
}
```
