### PR TITLE
Add missing sidebar link to digitalocean_database_replica resource page

### DIFF
--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -70,6 +70,9 @@
             <li<%= sidebar_current("docs-do-resource-database-cluster") %>>
               <a href="/docs/providers/do/r/database_cluster.html">digitalocean_database_cluster</a>
             </li>
+            <li<%= sidebar_current("docs-do-resource-database-replica") %>>
+              <a href="/docs/providers/do/r/database_replica.html">digitalocean_database_replica</a>
+            </li>
             <li<%= sidebar_current("docs-do-resource-domain") %>>
               <a href="/docs/providers/do/r/domain.html">digitalocean_domain</a>
             </li>


### PR DESCRIPTION
There is a documentation page for this resource created in #294, but the sidebar doesn't display it.