### PR TITLE
Add resource for database user

### DIFF
--- a/digitalocean/import_digitalocean_database_user_test.go
+++ b/digitalocean/import_digitalocean_database_user_test.go
@@ -1,0 +1,58 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDigitalOceanDatabaseUser_importBasic(t *testing.T) {
+	resourceName := "digitalocean_database_user.foobar_user"
+	databaseClusterName := fmt.Sprintf("foobar-test-terraform-%s", acctest.RandString(10))
+	databaseUserName := fmt.Sprintf("foobar-test-user-terraform-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseUserConfigBasic, databaseClusterName, databaseUserName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Requires passing both the cluster ID and replica name
+				ImportStateIdFunc: testAccDatabaseUserImportID(resourceName),
+			},
+			// Test importing non-existent resource provides expected error.
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     fmt.Sprintf("%s,%s", "this-cluster-id-does-not-exist", databaseUserName),
+				ExpectError:       regexp.MustCompile(`(Please verify the ID is correct|Cannot import non-existent remote object)`),
+			},
+		},
+	})
+}
+
+func testAccDatabaseUserImportID(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", n)
+		}
+
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		name := rs.Primary.Attributes["name"]
+
+		return fmt.Sprintf("%s,%s", clusterID, name), nil
+	}
+}

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -61,6 +61,7 @@ func Provider() terraform.ResourceProvider {
 			"digitalocean_cdn":                    resourceDigitalOceanCDN(),
 			"digitalocean_database_cluster":       resourceDigitalOceanDatabaseCluster(),
 			"digitalocean_database_replica":       resourceDigitalOceanDatabaseReplica(),
+			"digitalocean_database_user":          resourceDigitalOceanDatabaseUser(),
 			"digitalocean_domain":                 resourceDigitalOceanDomain(),
 			"digitalocean_droplet":                resourceDigitalOceanDroplet(),
 			"digitalocean_droplet_snapshot":       resourceDigitalOceanDropletSnapshot(),

--- a/digitalocean/resource_digitalocean_database_user.go
+++ b/digitalocean/resource_digitalocean_database_user.go
@@ -1,0 +1,123 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceDigitalOceanDatabaseUser() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDigitalOceanDatabaseUserCreate,
+		Read:   resourceDigitalOceanDatabaseUserRead,
+		Delete: resourceDigitalOceanDatabaseUserDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDigitalOceanDatabaseUserImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"cluster_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			// Computed Properties
+			"role": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceDigitalOceanDatabaseUserCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+	clusterID := d.Get("cluster_id").(string)
+
+	opts := &godo.DatabaseCreateUserRequest{
+		Name: d.Get("name").(string),
+	}
+
+	log.Printf("[DEBUG] Database User create configuration: %#v", opts)
+	user, _, err := client.Databases.CreateUser(context.Background(), clusterID, opts)
+	if err != nil {
+		return fmt.Errorf("Error creating Database User: %s", err)
+	}
+
+	d.SetId(makeDatabaseUserID(clusterID, user.Name))
+	log.Printf("[INFO] Database User Name: %s", user.Name)
+
+	return resourceDigitalOceanDatabaseUserRead(d, meta)
+}
+
+func resourceDigitalOceanDatabaseUserRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+	clusterID := d.Get("cluster_id").(string)
+	name := d.Get("name").(string)
+
+	// Check if the database user still exists
+	user, resp, err := client.Databases.GetUser(context.Background(), clusterID, name)
+	if err != nil {
+		// If the database user is somehow already destroyed, mark as
+		// successfully gone
+		if resp != nil && resp.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Database User: %s", err)
+	}
+
+	d.Set("role", user.Role)
+	d.Set("password", user.Password)
+
+	return nil
+}
+
+func resourceDigitalOceanDatabaseUserDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+	clusterID := d.Get("cluster_id").(string)
+	name := d.Get("name").(string)
+
+	log.Printf("[INFO] Deleting Database User: %s", d.Id())
+	_, err := client.Databases.DeleteUser(context.Background(), clusterID, name)
+	if err != nil {
+		return fmt.Errorf("Error deleting Database User: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceDigitalOceanDatabaseUserImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	if strings.Contains(d.Id(), ",") {
+		s := strings.Split(d.Id(), ",")
+		d.SetId(makeDatabaseUserID(s[0], s[1]))
+		d.Set("cluster_id", s[0])
+		d.Set("name", s[1])
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func makeDatabaseUserID(clusterID string, name string) string {
+	return fmt.Sprintf("%s/user/%s", clusterID, name)
+}

--- a/digitalocean/resource_digitalocean_database_user_test.go
+++ b/digitalocean/resource_digitalocean_database_user_test.go
@@ -1,0 +1,164 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDigitalOceanDatabaseUser_Basic(t *testing.T) {
+	var databaseUser godo.DatabaseUser
+	databaseClusterName := fmt.Sprintf("foobar-test-terraform-%s", acctest.RandString(10))
+	databaseUserName := fmt.Sprintf("foobar-test-user-terraform-%s", acctest.RandString(10))
+	databaseUserNameUpdated := databaseUserName + "-up"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseUserConfigBasic, databaseClusterName, databaseUserName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseUserExists("digitalocean_database_user.foobar_user", &databaseUser),
+					testAccCheckDigitalOceanDatabaseUserAttributes(&databaseUser, databaseUserName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "name", databaseUserName),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_user.foobar_user", "role"),
+					resource.TestCheckResourceAttrSet(
+						"digitalocean_database_user.foobar_user", "password"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseUserConfigBasic, databaseClusterName, databaseUserNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseUserExists("digitalocean_database_user.foobar_user", &databaseUser),
+					testAccCheckDigitalOceanDatabaseUserNotExists("digitalocean_database_user.foobar_user", databaseUserName),
+					testAccCheckDigitalOceanDatabaseUserAttributes(&databaseUser, databaseUserNameUpdated),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_user.foobar_user", "name", databaseUserNameUpdated),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDigitalOceanDatabaseUserDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*CombinedConfig).godoClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "digitalocean_database_user" {
+			continue
+		}
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		name := rs.Primary.Attributes["name"]
+
+		// Try to find the database
+		_, _, err := client.Databases.GetUser(context.Background(), clusterID, name)
+
+		if err == nil {
+			return fmt.Errorf("Database User still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDigitalOceanDatabaseUserExists(n string, databaseUser *godo.DatabaseUser) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Database User ID is set")
+		}
+
+		client := testAccProvider.Meta().(*CombinedConfig).godoClient()
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		name := rs.Primary.Attributes["name"]
+
+		foundDatabaseUser, _, err := client.Databases.GetUser(context.Background(), clusterID, name)
+
+		if err != nil {
+			return err
+		}
+
+		if foundDatabaseUser.Name != name {
+			return fmt.Errorf("Database user not found")
+		}
+
+		*databaseUser = *foundDatabaseUser
+
+		return nil
+	}
+}
+
+func testAccCheckDigitalOceanDatabaseUserNotExists(n string, databaseUserName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Database User ID is set")
+		}
+
+		client := testAccProvider.Meta().(*CombinedConfig).godoClient()
+		clusterID := rs.Primary.Attributes["cluster_id"]
+
+		_, resp, err := client.Databases.GetDB(context.Background(), clusterID, databaseUserName)
+
+		if err != nil && resp.StatusCode != http.StatusNotFound {
+			return err
+		}
+
+		if err == nil {
+			return fmt.Errorf("Database User %s still exists", databaseUserName)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDigitalOceanDatabaseUserAttributes(databaseUser *godo.DatabaseUser, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if databaseUser.Name != name {
+			return fmt.Errorf("Bad name: %s", databaseUser.Name)
+		}
+
+		return nil
+	}
+}
+
+const testAccCheckDigitalOceanDatabaseUserConfigBasic = `
+resource "digitalocean_database_cluster" "foobar" {
+	name       = "%s"
+	engine     = "pg"
+	version    = "11"
+	size       = "db-s-1vcpu-1gb"
+	region     = "nyc1"
+	node_count = 1
+
+	maintenance_window {
+        day  = "friday"
+        hour = "13:00:00"
+	}
+}
+
+resource "digitalocean_database_user" "foobar_user" {
+  cluster_id = "${digitalocean_database_cluster.foobar.id}"
+  name       = "%s"
+}`

--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -76,6 +76,9 @@
             <li<%= sidebar_current("docs-do-resource-database-replica") %>>
               <a href="/docs/providers/do/r/database_replica.html">digitalocean_database_replica</a>
             </li>
+            <li<%= sidebar_current("docs-do-resource-database-user") %>>
+              <a href="/docs/providers/do/r/database_user.html">digitalocean_database_user</a>
+            </li>
             <li<%= sidebar_current("docs-do-resource-domain") %>>
               <a href="/docs/providers/do/r/domain.html">digitalocean_domain</a>
             </li>

--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_database_user"
+sidebar_current: "docs-do-resource-database-user"
+description: |-
+  Provides a DigitalOcean database user resource.
+---
+
+# digitalocean\_database\_user
+
+Provides a DigitalOcean database user resource. When creating a new database cluster, a default admin user with name `doadmin` will be created. Then, this resource can be used to provide additional normal users inside the cluster.
+
+~> **NOTE:** Any new users created will always have `normal` role, only default user that comes with database cluster creation has `primary` role.
+More permissions need to be added manually to interact with the database (e.g. querying).
+
+## Example Usage
+
+### Create a new PostgreSQL database user
+```hcl
+resource "digitalocean_database_user" "user-example" {
+  cluster_id = "${digitalocean_database_cluster.postgres-example.id}"
+  name       = "foobar"
+}
+
+resource "digitalocean_database_cluster" "postgres-example" {
+  name       = "example-postgres-cluster"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_id` - (Required) The ID of the original source database cluster.
+* `name` - (Required) The name for the database user.
+
+## Attributes Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+* `role` - Role for the database user. The value will be either "primary" or "normal".
+* `password` - Password for the database user.
+
+## Import
+
+Database user can be imported using the `id` of the source database cluster
+and the `name` of the user joined with a comma. For example:
+
+```
+terraform import digitalocean_database_user.user-example 245bcfd0-7f31-4ce6-a2bc-475a116cca97,foobar
+```

--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -10,15 +10,14 @@ description: |-
 
 Provides a DigitalOcean database user resource. When creating a new database cluster, a default admin user with name `doadmin` will be created. Then, this resource can be used to provide additional normal users inside the cluster.
 
-~> **NOTE:** Any new users created will always have `normal` role, only default user that comes with database cluster creation has `primary` role.
-More permissions need to be added manually to interact with the database (e.g. querying).
+~> **NOTE:** Any new users created will always have `normal` role, only the default user that comes with database cluster creation has `primary` role. Additional permissions must be managed manually.
 
 ## Example Usage
 
 ### Create a new PostgreSQL database user
 ```hcl
 resource "digitalocean_database_user" "user-example" {
-  cluster_id = "${digitalocean_database_cluster.postgres-example.id}"
+  cluster_id = digitalocean_database_cluster.postgres-example.id
   name       = "foobar"
 }
 


### PR DESCRIPTION
Implement `digitalocean_database_user` as per #222.

### Example Usage

```hcl
resource "digitalocean_database_user" "user-example" {
  cluster_id = "${digitalocean_database_cluster.postgres-example.id}"
  name       = "foobar"
}

resource "digitalocean_database_cluster" "postgres-example" {
  name       = "example-postgres-cluster"
  engine     = "pg"
  version    = "11"
  size       = "db-s-1vcpu-1gb"
  region     = "nyc1"
  node_count = 1
}
```

### Extra Nudge

Currently it will always create `normal` user with limited access to the database. It'd be super useful if the API allows us to manage user's permissions as well, e.g. automatically giving the user read/write access to a database. Any way to give feedback to Digital Ocean about this? 😄 
