### PR TITLE
Add support for volume tags

### DIFF
--- a/digitalocean/datasource_digitalocean_volume.go
+++ b/digitalocean/datasource_digitalocean_volume.go
@@ -63,6 +63,7 @@ func dataSourceDigitalOceanVolume() *schema.Resource {
 				Computed:    true,
 				Description: "list of droplet ids the volume is attached to",
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -120,6 +121,7 @@ func dataSourceDigitalOceanVolumeRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("urn", volume.URN())
 	d.Set("region", volume.Region.Slug)
 	d.Set("size", int(volume.SizeGigaBytes))
+	d.Set("tags", volume.Tags)
 
 	if v := volume.Description; v != "" {
 		d.Set("description", v)

--- a/digitalocean/datasource_digitalocean_volume.go
+++ b/digitalocean/datasource_digitalocean_volume.go
@@ -63,7 +63,7 @@ func dataSourceDigitalOceanVolume() *schema.Resource {
 				Computed:    true,
 				Description: "list of droplet ids the volume is attached to",
 			},
-			"tags": tagsSchema(),
+			"tags": tagsDataSourceSchema(),
 		},
 	}
 }
@@ -121,7 +121,7 @@ func dataSourceDigitalOceanVolumeRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("urn", volume.URN())
 	d.Set("region", volume.Region.Slug)
 	d.Set("size", int(volume.SizeGigaBytes))
-	d.Set("tags", volume.Tags)
+	d.Set("tags", flattenTags(volume.Tags))
 
 	if v := volume.Description; v != "" {
 		d.Set("description", v)

--- a/digitalocean/datasource_digitalocean_volume_test.go
+++ b/digitalocean/datasource_digitalocean_volume_test.go
@@ -34,6 +34,8 @@ func TestAccDataSourceDigitalOceanVolume_Basic(t *testing.T) {
 						"data.digitalocean_volume.foobar", "size", "10"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_volume.foobar", "droplet_ids.#", "0"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_volume.foobar", "tags.#", "2"),
 					resource.TestMatchResourceAttr("data.digitalocean_volume.foobar", "urn", expectedURNRegEx),
 				),
 			},
@@ -61,6 +63,8 @@ func TestAccDataSourceDigitalOceanVolume_RegionScoped(t *testing.T) {
 						"data.digitalocean_volume.foobar", "size", "20"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_volume.foobar", "droplet_ids.#", "0"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_volume.foobar", "tags.#", "0"),
 				),
 			},
 		},
@@ -103,6 +107,7 @@ resource "digitalocean_volume" "foo" {
   region = "nyc3"
   name   = "volume-%d"
   size   = 10
+  tags   = ["foo","bar"]
 }
 
 data "digitalocean_volume" "foobar" {
@@ -116,6 +121,7 @@ resource "digitalocean_volume" "foo" {
   region = "nyc3"
   name   = "volume-%d"
   size   = 10
+  tags   = ["foo","bar"]
 }
 
 resource "digitalocean_volume" "bar" {

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -555,7 +555,7 @@ func resourceDigitalOceanDropletUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if d.HasChange("tags") {
-		err = setTags(client, d)
+		err = setTags(client, d, godo.DropletResourceType)
 		if err != nil {
 			return fmt.Errorf("Error updating tags: %s", err)
 		}

--- a/digitalocean/resource_digitalocean_volume.go
+++ b/digitalocean/resource_digitalocean_volume.go
@@ -211,7 +211,7 @@ func resourceDigitalOceanVolumeRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("region", volume.Region.Slug)
 	d.Set("size", int(volume.SizeGigaBytes))
 	d.Set("urn", volume.URN())
-	d.Set("tags", volume.Tags)
+	d.Set("tags", flattenTags(volume.Tags))
 
 	if v := volume.Description; v != "" {
 		d.Set("description", v)

--- a/digitalocean/tags.go
+++ b/digitalocean/tags.go
@@ -42,7 +42,7 @@ func validateTag(value interface{}, key string) ([]string, []error) {
 
 // setTags is a helper to set the tags for a resource. It expects the
 // tags field to be named "tags"
-func setTags(conn *godo.Client, d *schema.ResourceData) error {
+func setTags(conn *godo.Client, d *schema.ResourceData, resourceType godo.ResourceType) error {
 	oraw, nraw := d.GetChange("tags")
 	remove, create := diffTags(tagsFromSchema(oraw), tagsFromSchema(nraw))
 
@@ -52,7 +52,7 @@ func setTags(conn *godo.Client, d *schema.ResourceData) error {
 			Resources: []godo.Resource{
 				{
 					ID:   d.Id(),
-					Type: godo.DropletResourceType,
+					Type: resourceType,
 				},
 			},
 		})
@@ -75,7 +75,7 @@ func setTags(conn *godo.Client, d *schema.ResourceData) error {
 			Resources: []godo.Resource{
 				{
 					ID:   d.Id(),
-					Type: godo.DropletResourceType,
+					Type: resourceType,
 				},
 			},
 		})

--- a/website/docs/d/volume.html.md
+++ b/website/docs/d/volume.html.md
@@ -65,3 +65,4 @@ The following attributes are exported:
 * `filesystem_type` - Filesystem type currently in-use on the block storage volume.
 * `filesystem_label` - Filesystem label currently in-use on the block storage volume.
 * `droplet_ids` - A list of associated Droplet ids.
+* `tags` - A list of the tags associated to the Volume.

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
 * `snapshot_id` - (Optional) The ID of an existing volume snapshot from which the new volume will be created. If supplied, the region and size will be limitied on creation to that of the referenced snapshot
 * `initial_filesystem_type` - (Optional) Initial filesystem type (`xfs` or `ext4`) for the block storage volume.
 * `initial_filesystem_label` - (Optional) Initial filesystem label for the block storage volume.
+* `tags` - (Optional) A list of the tags to be applied to this Volume.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Saw volumes can support tags so this PR adds the `tags` argument to the `digitalocean_volume` resource.

Seems like a few other resources can support tags so if this PR looks good, I can probably spend some time adding tag support for other resources in future PR's.