### PR TITLE
add support for volume snapshot tags

### DIFF
--- a/digitalocean/datasource_digitalocean_volume_snapshot.go
+++ b/digitalocean/datasource_digitalocean_volume_snapshot.go
@@ -65,6 +65,7 @@ func dataSourceDigitalOceanVolumeSnapshot() *schema.Resource {
 				Type:     schema.TypeFloat,
 				Computed: true,
 			},
+			"tags": tagsDataSourceSchema(),
 		},
 	}
 }
@@ -146,6 +147,7 @@ func dataSourceDigitalOceanVolumeSnapshotRead(d *schema.ResourceData, meta inter
 	d.Set("regions", snapshot.Regions)
 	d.Set("volume_id", snapshot.ResourceID)
 	d.Set("size", snapshot.SizeGigaBytes)
+	d.Set("tags", flattenTags(snapshot.Tags))
 
 	return nil
 }

--- a/digitalocean/datasource_digitalocean_volume_snapshot_test.go
+++ b/digitalocean/datasource_digitalocean_volume_snapshot_test.go
@@ -27,6 +27,7 @@ func TestAccDataSourceDigitalOceanVolumeSnapshot_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "size", "0"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "min_disk_size", "100"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "regions.#", "1"),
+					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "tags.#", "2"),
 					resource.TestCheckResourceAttrSet("data.digitalocean_volume_snapshot.foobar", "volume_id"),
 				),
 			},
@@ -50,6 +51,7 @@ func TestAccDataSourceDigitalOceanVolumeSnapshot_regex(t *testing.T) {
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "size", "0"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "min_disk_size", "100"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "regions.#", "1"),
+					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "tags.#", "2"),
 					resource.TestCheckResourceAttrSet("data.digitalocean_volume_snapshot.foobar", "volume_id"),
 				),
 			},
@@ -73,6 +75,7 @@ func TestAccDataSourceDigitalOceanVolumeSnapshot_region(t *testing.T) {
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "size", "0"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "min_disk_size", "100"),
 					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "regions.#", "1"),
+					resource.TestCheckResourceAttr("data.digitalocean_volume_snapshot.foobar", "tags.#", "0"),
 					resource.TestCheckResourceAttrSet("data.digitalocean_volume_snapshot.foobar", "volume_id"),
 				),
 			},
@@ -120,6 +123,7 @@ resource "digitalocean_volume" "foo" {
 resource "digitalocean_volume_snapshot" "foo" {
   name = "snapshot-%d"
   volume_id = "${digitalocean_volume.foo.id}"
+  tags = ["foo","bar"]
 }
 
 data "digitalocean_volume_snapshot" "foobar" {
@@ -138,6 +142,7 @@ resource "digitalocean_volume" "foo" {
 resource "digitalocean_volume_snapshot" "foo" {
   name = "snapshot-%d"
   volume_id = "${digitalocean_volume.foo.id}"
+  tags = ["foo","bar"]
 }
 
 data "digitalocean_volume_snapshot" "foobar" {
@@ -163,6 +168,7 @@ resource "digitalocean_volume" "bar" {
 resource "digitalocean_volume_snapshot" "foo" {
   name = "snapshot-%d"
   volume_id = "${digitalocean_volume.foo.id}"
+  tags   = ["foo","bar"]
 }
 
 resource "digitalocean_volume_snapshot" "bar" {

--- a/digitalocean/resource_digitalocean_volume_snapshot.go
+++ b/digitalocean/resource_digitalocean_volume_snapshot.go
@@ -85,11 +85,8 @@ func resourceDigitalOceanVolumeSnapshotCreate(d *schema.ResourceData, meta inter
 func resourceDigitalOceanVolumeSnapshotUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
-	// godo.VolumeSnapshotResourceType is currently incorrectly set as "volumesnapshot"
-	var VolumeSnapshotResourceType godo.ResourceType = "volume_snapshot"
-
 	if d.HasChange("tags") {
-		err := setTags(client, d, VolumeSnapshotResourceType)
+		err := setTags(client, d, godo.VolumeSnapshotResourceType)
 		if err != nil {
 			return fmt.Errorf("Error updating tags: %s", err)
 		}

--- a/digitalocean/resource_digitalocean_volume_snapshot.go
+++ b/digitalocean/resource_digitalocean_volume_snapshot.go
@@ -14,6 +14,7 @@ func resourceDigitalOceanVolumeSnapshot() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDigitalOceanVolumeSnapshotCreate,
 		Read:   resourceDigitalOceanVolumeSnapshotRead,
+		Update: resourceDigitalOceanVolumeSnapshotUpdate,
 		Delete: resourceDigitalOceanVolumeSnapshotDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -54,6 +55,8 @@ func resourceDigitalOceanVolumeSnapshot() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -64,6 +67,7 @@ func resourceDigitalOceanVolumeSnapshotCreate(d *schema.ResourceData, meta inter
 	opts := &godo.SnapshotCreateRequest{
 		Name:     d.Get("name").(string),
 		VolumeID: d.Get("volume_id").(string),
+		Tags:     expandTags(d.Get("tags").(*schema.Set).List()),
 	}
 
 	log.Printf("[DEBUG] Volume Snapshot create configuration: %#v", opts)
@@ -74,6 +78,22 @@ func resourceDigitalOceanVolumeSnapshotCreate(d *schema.ResourceData, meta inter
 
 	d.SetId(snapshot.ID)
 	log.Printf("[INFO] Volume Snapshot name: %s", snapshot.Name)
+
+	return resourceDigitalOceanVolumeSnapshotRead(d, meta)
+}
+
+func resourceDigitalOceanVolumeSnapshotUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+
+	// godo.VolumeSnapshotResourceType is currently incorrectly set as "volumesnapshot"
+	var VolumeSnapshotResourceType godo.ResourceType = "volume_snapshot"
+
+	if d.HasChange("tags") {
+		err := setTags(client, d, VolumeSnapshotResourceType)
+		if err != nil {
+			return fmt.Errorf("Error updating tags: %s", err)
+		}
+	}
 
 	return resourceDigitalOceanVolumeSnapshotRead(d, meta)
 }
@@ -99,6 +119,7 @@ func resourceDigitalOceanVolumeSnapshotRead(d *schema.ResourceData, meta interfa
 	d.Set("size", snapshot.SizeGigaBytes)
 	d.Set("created_at", snapshot.Created)
 	d.Set("min_disk_size", snapshot.MinDiskSize)
+	d.Set("tags", flattenTags(snapshot.Tags))
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-digitalocean
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0 // indirect
 	github.com/aws/aws-sdk-go v1.25.4
-	github.com/digitalocean/godo v1.22.0
+	github.com/digitalocean/godo v1.28.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/terraform v0.12.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/digitalocean/godo v1.22.0 h1:bVFBKXW2TlynZ9SqmlM6ZSW6UPEzFckltSIUT5NC8L4=
 github.com/digitalocean/godo v1.22.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
+github.com/digitalocean/godo v1.28.0 h1:lD4PwD5v9LqQ9T5n6PtkutWFsiIp4KxQmuoiYiJCutU=
+github.com/digitalocean/godo v1.28.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
 github.com/dimchansky/utfbom v1.0.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dnaeon/go-vcr v0.0.0-20180920040454-5637cf3d8a31/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Change Log
 
+## [v1.28.0] - 2019-12-04
+
+- #282 Add valid Redis eviction policy constants - @bentranter
+- #281 Remove databases info from top-level godoc string - @bentranter
+- #280 Fix VolumeSnapshotResourceType value volumesnapshot -> volume_snapshot - @aqche
+
+## [v1.27.0] - 2019-11-18
+
+- #278 add mysql user auth settings for database users - @gregmankes
+
+## [v1.26.0] - 2019-11-13
+
+- #272 dbaas: get and set mysql sql mode - @mikejholly
+
+## [v1.25.0] - 2019-11-13
+
+- #275 registry/docker-credentials: add support for the read/write parameter - @kamaln7
+- #273 implement the registry/docker-credentials endpoint - @kamaln7
+- #271 Add registry resource - @snormore
+
+## [v1.24.1] - 2019-11-04
+
+- #264 Update isLast to check p.Next - @aqche
+
+## [v1.24.0] - 2019-10-30
+
+- #267 Return []DatabaseFirewallRule in addition to raw response. - @andrewsomething
+
+## [v1.23.1] - 2019-10-30
+
+- #265 add support for getting/setting firewall rules - @gregmankes
+- #262 remove ResolveReference call - @mdanzinger
+- #261 Update CONTRIBUTING.md - @mdanzinger
+
 ## [v1.22.0] - 2019-09-24
 
 - #259 Add Kubernetes GetCredentials method - @snormore

--- a/vendor/github.com/digitalocean/godo/CONTRIBUTING.md
+++ b/vendor/github.com/digitalocean/godo/CONTRIBUTING.md
@@ -18,7 +18,7 @@ go get -u github.com/stretchr/testify/assert
 If outside `$GOPATH`, just clone the repository:
 
 ```sh
-git clone github.com/digitalocean/godo
+git clone https://github.com/digitalocean/godo
 ```
 
 ## Running tests

--- a/vendor/github.com/digitalocean/godo/databases.go
+++ b/vendor/github.com/digitalocean/godo/databases.go
@@ -4,29 +4,88 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
 const (
-	databaseBasePath        = "/v2/databases"
-	databaseSinglePath      = databaseBasePath + "/%s"
-	databaseResizePath      = databaseBasePath + "/%s/resize"
-	databaseMigratePath     = databaseBasePath + "/%s/migrate"
-	databaseMaintenancePath = databaseBasePath + "/%s/maintenance"
-	databaseBackupsPath     = databaseBasePath + "/%s/backups"
-	databaseUsersPath       = databaseBasePath + "/%s/users"
-	databaseUserPath        = databaseBasePath + "/%s/users/%s"
-	databaseDBPath          = databaseBasePath + "/%s/dbs/%s"
-	databaseDBsPath         = databaseBasePath + "/%s/dbs"
-	databasePoolPath        = databaseBasePath + "/%s/pools/%s"
-	databasePoolsPath       = databaseBasePath + "/%s/pools"
-	databaseReplicaPath     = databaseBasePath + "/%s/replicas/%s"
-	databaseReplicasPath    = databaseBasePath + "/%s/replicas"
-	evictionPolicyPath      = databaseBasePath + "/%s/eviction_policy"
+	databaseBasePath           = "/v2/databases"
+	databaseSinglePath         = databaseBasePath + "/%s"
+	databaseResizePath         = databaseBasePath + "/%s/resize"
+	databaseMigratePath        = databaseBasePath + "/%s/migrate"
+	databaseMaintenancePath    = databaseBasePath + "/%s/maintenance"
+	databaseBackupsPath        = databaseBasePath + "/%s/backups"
+	databaseUsersPath          = databaseBasePath + "/%s/users"
+	databaseUserPath           = databaseBasePath + "/%s/users/%s"
+	databaseDBPath             = databaseBasePath + "/%s/dbs/%s"
+	databaseDBsPath            = databaseBasePath + "/%s/dbs"
+	databasePoolPath           = databaseBasePath + "/%s/pools/%s"
+	databasePoolsPath          = databaseBasePath + "/%s/pools"
+	databaseReplicaPath        = databaseBasePath + "/%s/replicas/%s"
+	databaseReplicasPath       = databaseBasePath + "/%s/replicas"
+	databaseEvictionPolicyPath = databaseBasePath + "/%s/eviction_policy"
+	databaseSQLModePath        = databaseBasePath + "/%s/sql_mode"
+	databaseFirewallRulesPath  = databaseBasePath + "/%s/firewall"
 )
 
-// DatabasesService is an interface for interfacing with the databases endpoints
-// of the DigitalOcean API.
+// SQL Mode constants allow for MySQL-specific SQL flavor configuration.
+const (
+	SQLModeAllowInvalidDates     = "ALLOW_INVALID_DATES"
+	SQLModeANSIQuotes            = "ANSI_QUOTES"
+	SQLModeHighNotPrecedence     = "HIGH_NOT_PRECEDENCE"
+	SQLModeIgnoreSpace           = "IGNORE_SPACE"
+	SQLModeNoAuthCreateUser      = "NO_AUTO_CREATE_USER"
+	SQLModeNoAutoValueOnZero     = "NO_AUTO_VALUE_ON_ZERO"
+	SQLModeNoBackslashEscapes    = "NO_BACKSLASH_ESCAPES"
+	SQLModeNoDirInCreate         = "NO_DIR_IN_CREATE"
+	SQLModeNoEngineSubstitution  = "NO_ENGINE_SUBSTITUTION"
+	SQLModeNoFieldOptions        = "NO_FIELD_OPTIONS"
+	SQLModeNoKeyOptions          = "NO_KEY_OPTIONS"
+	SQLModeNoTableOptions        = "NO_TABLE_OPTIONS"
+	SQLModeNoUnsignedSubtraction = "NO_UNSIGNED_SUBTRACTION"
+	SQLModeNoZeroDate            = "NO_ZERO_DATE"
+	SQLModeNoZeroInDate          = "NO_ZERO_IN_DATE"
+	SQLModeOnlyFullGroupBy       = "ONLY_FULL_GROUP_BY"
+	SQLModePadCharToFullLength   = "PAD_CHAR_TO_FULL_LENGTH"
+	SQLModePipesAsConcat         = "PIPES_AS_CONCAT"
+	SQLModeRealAsFloat           = "REAL_AS_FLOAT"
+	SQLModeStrictAllTables       = "STRICT_ALL_TABLES"
+	SQLModeStrictTransTables     = "STRICT_TRANS_TABLES"
+	SQLModeANSI                  = "ANSI"
+	SQLModeDB2                   = "DB2"
+	SQLModeMaxDB                 = "MAXDB"
+	SQLModeMSSQL                 = "MSSQL"
+	SQLModeMYSQL323              = "MYSQL323"
+	SQLModeMYSQL40               = "MYSQL40"
+	SQLModeOracle                = "ORACLE"
+	SQLModePostgreSQL            = "POSTGRESQL"
+	SQLModeTraditional           = "TRADITIONAL"
+)
+
+// SQL Auth constants allow for MySQL-specific user auth plugins
+const (
+	SQLAuthPluginNative      = "mysql_native_password"
+	SQLAuthPluginCachingSHA2 = "caching_sha2_password"
+)
+
+// Redis eviction policies supported by the managed Redis product.
+const (
+	EvictionPolicyNoEviction     = "noeviction"
+	EvictionPolicyAllKeysLRU     = "allkeys_lru"
+	EvictionPolicyAllKeysRandom  = "allkeys_random"
+	EvictionPolicyVolatileLRU    = "volatile_lru"
+	EvictionPolicyVolatileRandom = "volatile_random"
+	EvictionPolicyVolatileTTL    = "volatile_ttl"
+)
+
+// The DatabasesService provides access to the DigitalOcean managed database
+// suite of products through the public API. Customers can create new database
+// clusters, migrate them  between regions, create replicas and interact with
+// their configurations. Each database service is refered to as a Database. A
+// SQL database service can have multiple databases residing in the system. To
+// help make these entities distinct from Databases in godo, we refer to them
+// here as DatabaseDBs.
+//
 // See: https://developers.digitalocean.com/documentation/v2#databases
 type DatabasesService interface {
 	List(context.Context, *ListOptions) ([]Database, *Response, error)
@@ -55,6 +114,10 @@ type DatabasesService interface {
 	DeleteReplica(context.Context, string, string) (*Response, error)
 	GetEvictionPolicy(context.Context, string) (string, *Response, error)
 	SetEvictionPolicy(context.Context, string, string) (*Response, error)
+	GetSQLMode(context.Context, string) (string, *Response, error)
+	SetSQLMode(context.Context, string, ...string) (*Response, error)
+	GetFirewallRules(context.Context, string) ([]DatabaseFirewallRule, *Response, error)
+	UpdateFirewallRules(context.Context, string, *DatabaseUpdateFirewallRulesRequest) (*Response, error)
 }
 
 // DatabasesServiceOp handles communication with the Databases related methods
@@ -102,9 +165,15 @@ type DatabaseConnection struct {
 
 // DatabaseUser represents a user in the database
 type DatabaseUser struct {
-	Name     string `json:"name,omitempty"`
-	Role     string `json:"role,omitempty"`
-	Password string `json:"password,omitempty"`
+	Name          string                     `json:"name,omitempty"`
+	Role          string                     `json:"role,omitempty"`
+	Password      string                     `json:"password,omitempty"`
+	MySQLSettings *DatabaseMySQLUserSettings `json:"mysql_settings,omitempty"`
+}
+
+// DatabaseMySQLUserSettings contains MySQL-specific user settings
+type DatabaseMySQLUserSettings struct {
+	AuthPlugin string `json:"auth_plugin"`
 }
 
 // DatabaseMaintenanceWindow represents the maintenance_window of a database
@@ -194,7 +263,8 @@ type DatabaseCreatePoolRequest struct {
 
 // DatabaseCreateUserRequest is used to create a new database user
 type DatabaseCreateUserRequest struct {
-	Name string `json:"name"`
+	Name          string                     `json:"name"`
+	MySQLSettings *DatabaseMySQLUserSettings `json:"mysql_settings,omitempty"`
 }
 
 // DatabaseCreateDBRequest is used to create a new engine-specific database within the cluster
@@ -209,6 +279,20 @@ type DatabaseCreateReplicaRequest struct {
 	Size               string   `json:"size"`
 	PrivateNetworkUUID string   `json:"private_network_uuid"`
 	Tags               []string `json:"tags,omitempty"`
+}
+
+// DatabaseUpdateFirewallRulesRequest is used to set the firewall rules for a database
+type DatabaseUpdateFirewallRulesRequest struct {
+	Rules []*DatabaseFirewallRule `json:"rules"`
+}
+
+// DatabaseFirewallRule is a rule describing an inbound source to a database
+type DatabaseFirewallRule struct {
+	UUID        string    `json:"uuid"`
+	ClusterUUID string    `json:"cluster_uuid"`
+	Type        string    `json:"type"`
+	Value       string    `json:"value"`
+	CreatedAt   time.Time `json:"created_at"`
 }
 
 type databaseUserRoot struct {
@@ -259,6 +343,15 @@ type evictionPolicyRoot struct {
 	EvictionPolicy string `json:"eviction_policy"`
 }
 
+type sqlModeRoot struct {
+	SQLMode string `json:"sql_mode"`
+}
+
+type databaseFirewallRuleRoot struct {
+	Rules []DatabaseFirewallRule `json:"rules"`
+}
+
+// URN returns a URN identifier for the database
 func (d Database) URN() string {
 	return ToURN("dbaas", d.ID)
 }
@@ -642,7 +735,7 @@ func (svc *DatabasesServiceOp) DeleteReplica(ctx context.Context, databaseID, na
 
 // GetEvictionPolicy loads the eviction policy for a given Redis cluster.
 func (svc *DatabasesServiceOp) GetEvictionPolicy(ctx context.Context, databaseID string) (string, *Response, error) {
-	path := fmt.Sprintf(evictionPolicyPath, databaseID)
+	path := fmt.Sprintf(databaseEvictionPolicyPath, databaseID)
 	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return "", nil, err
@@ -656,8 +749,11 @@ func (svc *DatabasesServiceOp) GetEvictionPolicy(ctx context.Context, databaseID
 }
 
 // SetEvictionPolicy updates the eviction policy for a given Redis cluster.
+//
+// The valid eviction policies are documented by the exported string constants
+// with the prefix `EvictionPolicy`.
 func (svc *DatabasesServiceOp) SetEvictionPolicy(ctx context.Context, databaseID, policy string) (*Response, error) {
-	path := fmt.Sprintf(evictionPolicyPath, databaseID)
+	path := fmt.Sprintf(databaseEvictionPolicyPath, databaseID)
 	root := &evictionPolicyRoot{EvictionPolicy: policy}
 	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, root)
 	if err != nil {
@@ -668,4 +764,61 @@ func (svc *DatabasesServiceOp) SetEvictionPolicy(ctx context.Context, databaseID
 		return resp, err
 	}
 	return resp, nil
+}
+
+// GetSQLMode loads the SQL Mode settings for a given MySQL cluster.
+func (svc *DatabasesServiceOp) GetSQLMode(ctx context.Context, databaseID string) (string, *Response, error) {
+	path := fmt.Sprintf(databaseSQLModePath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return "", nil, err
+	}
+	root := &sqlModeRoot{}
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return "", resp, err
+	}
+	return root.SQLMode, resp, nil
+}
+
+// SetSQLMode updates the SQL Mode settings for a given MySQL cluster.
+func (svc *DatabasesServiceOp) SetSQLMode(ctx context.Context, databaseID string, sqlModes ...string) (*Response, error) {
+	path := fmt.Sprintf(databaseSQLModePath, databaseID)
+	root := &sqlModeRoot{SQLMode: strings.Join(sqlModes, ",")}
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, root)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// GetFirewallRules loads the inbound sources for a given cluster.
+func (svc *DatabasesServiceOp) GetFirewallRules(ctx context.Context, databaseID string) ([]DatabaseFirewallRule, *Response, error) {
+	path := fmt.Sprintf(databaseFirewallRulesPath, databaseID)
+	root := new(databaseFirewallRuleRoot)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Rules, resp, nil
+}
+
+// UpdateFirewallRules sets the inbound sources for a given cluster.
+func (svc *DatabasesServiceOp) UpdateFirewallRules(ctx context.Context, databaseID string, firewallRulesReq *DatabaseUpdateFirewallRulesRequest) (*Response, error) {
+	path := fmt.Sprintf(databaseFirewallRulesPath, databaseID)
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, firewallRulesReq)
+	if err != nil {
+		return nil, err
+	}
+	return svc.client.Do(ctx, req, nil)
 }

--- a/vendor/github.com/digitalocean/godo/doc.go
+++ b/vendor/github.com/digitalocean/godo/doc.go
@@ -1,11 +1,2 @@
-// Package godo is the DigtalOcean API v2 client for Go
-//
-// Databases
-//
-// The Databases service provides access to the DigitalOcean managed database
-// suite of products. Customers can create new database clusters, migrate them
-// between regions, create replicas and interact with their configurations.
-// Each database service is refered to as a Database. A SQL database service
-// can have multiple databases residing in the system. To help make these
-// entities distinct from Databases in godo, we refer to them here as DatabaseDBs.
+// Package godo is the DigtalOcean API v2 client for Go.
 package godo

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.22.0"
+	libraryVersion = "1.28.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"
@@ -65,6 +65,7 @@ type Client struct {
 	Firewalls         FirewallsService
 	Projects          ProjectsService
 	Kubernetes        KubernetesService
+	Registry          RegistryService
 	Databases         DatabasesService
 	VPCs              VPCsService
 
@@ -181,6 +182,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.StorageActions = &StorageActionsServiceOp{client: c}
 	c.Tags = &TagsServiceOp{client: c}
 	c.Kubernetes = &KubernetesServiceOp{client: c}
+	c.Registry = &RegistryServiceOp{client: c}
 	c.Databases = &DatabasesServiceOp{client: c}
 	c.VPCs = &VPCsServiceOp{client: c}
 
@@ -227,12 +229,10 @@ func SetUserAgent(ua string) ClientOpt {
 // BaseURL of the Client. Relative URLS should always be specified without a preceding slash. If specified, the
 // value pointed to by body is JSON encoded and included in as the request body.
 func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
-	rel, err := url.Parse(urlStr)
+	u, err := c.BaseURL.Parse(urlStr)
 	if err != nil {
 		return nil, err
 	}
-
-	u := c.BaseURL.ResolveReference(rel)
 
 	buf := new(bytes.Buffer)
 	if body != nil {

--- a/vendor/github.com/digitalocean/godo/links.go
+++ b/vendor/github.com/digitalocean/godo/links.go
@@ -59,7 +59,7 @@ func (l *Links) IsLastPage() bool {
 }
 
 func (p *Pages) isLast() bool {
-	return p.Last == ""
+	return p.Next == ""
 }
 
 func pageForURL(urlText string) (int, error) {

--- a/vendor/github.com/digitalocean/godo/registry.go
+++ b/vendor/github.com/digitalocean/godo/registry.go
@@ -1,0 +1,119 @@
+package godo
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const (
+	registryPath = "/v2/registry"
+)
+
+// RegistryService is an interface for interfacing with the Registry endpoints
+// of the DigitalOcean API.
+// See: https://developers.digitalocean.com/documentation/v2#registry
+type RegistryService interface {
+	Create(context.Context, *RegistryCreateRequest) (*Registry, *Response, error)
+	Get(context.Context) (*Registry, *Response, error)
+	Delete(context.Context) (*Response, error)
+	DockerCredentials(context.Context, *RegistryDockerCredentialsRequest) (*DockerCredentials, *Response, error)
+}
+
+var _ RegistryService = &RegistryServiceOp{}
+
+// RegistryServiceOp handles communication with Registry methods of the DigitalOcean API.
+type RegistryServiceOp struct {
+	client *Client
+}
+
+// RegistryCreateRequest represents a request to create a registry.
+type RegistryCreateRequest struct {
+	Name string `json:"name,omitempty"`
+}
+
+// RegistryDockerCredentialsRequest represents a request to retrieve docker
+// credentials for a registry.
+type RegistryDockerCredentialsRequest struct {
+	ReadWrite bool `json:"read_write"`
+}
+
+// Registry represents a registry.
+type Registry struct {
+	Name string `json:"name,omitempty"`
+}
+
+type registryRoot struct {
+	Registry *Registry `json:"registry,omitempty"`
+}
+
+// Get retrieves the details of a Registry.
+func (svc *RegistryServiceOp) Get(ctx context.Context) (*Registry, *Response, error) {
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, registryPath, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(registryRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Registry, resp, nil
+}
+
+// Create creates a registry.
+func (svc *RegistryServiceOp) Create(ctx context.Context, create *RegistryCreateRequest) (*Registry, *Response, error) {
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, registryPath, create)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(registryRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Registry, resp, nil
+}
+
+// Delete deletes a registry. There is no way to recover a registry once it has
+// been destroyed.
+func (svc *RegistryServiceOp) Delete(ctx context.Context) (*Response, error) {
+	req, err := svc.client.NewRequest(ctx, http.MethodDelete, registryPath, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// DockerCredentials is the content of a Docker config file
+// that is used by the docker CLI
+// See: https://docs.docker.com/engine/reference/commandline/cli/#configjson-properties
+type DockerCredentials struct {
+	DockerConfigJSON []byte
+}
+
+// DockerCredentials retrieves a Docker config file containing the registry's credentials.
+func (svc *RegistryServiceOp) DockerCredentials(ctx context.Context, request *RegistryDockerCredentialsRequest) (*DockerCredentials, *Response, error) {
+	path := fmt.Sprintf("%s/%s?read_write=%t", registryPath, "docker-credentials", request.ReadWrite)
+
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var buf bytes.Buffer
+	resp, err := svc.client.Do(ctx, req, &buf)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	dc := &DockerCredentials{
+		DockerConfigJSON: buf.Bytes(),
+	}
+	return dc, resp, nil
+}

--- a/vendor/github.com/digitalocean/godo/tags.go
+++ b/vendor/github.com/digitalocean/godo/tags.go
@@ -42,7 +42,7 @@ const (
 	// LoadBalancerResourceType holds the string representing our ResourceType of LoadBalancer.
 	LoadBalancerResourceType ResourceType = "load_balancer"
 	// VolumeSnapshotResourceType holds the string representing our ResourceType for storage Snapshots.
-	VolumeSnapshotResourceType ResourceType = "volumesnapshot"
+	VolumeSnapshotResourceType ResourceType = "volume_snapshot"
 )
 
 // Resource represent a single resource for associating/disassociating with tags

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -80,7 +80,7 @@ github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 github.com/davecgh/go-spew/spew
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible
 github.com/dgrijalva/jwt-go
-# github.com/digitalocean/godo v1.22.0
+# github.com/digitalocean/godo v1.28.0
 github.com/digitalocean/godo
 # github.com/fatih/color v1.7.0
 github.com/fatih/color

--- a/website/docs/d/volume_snapshot.html.md
+++ b/website/docs/d/volume_snapshot.html.md
@@ -65,3 +65,4 @@ The following attributes are exported:
 * `regions` - A list of DigitalOcean region "slugs" indicating where the volume snapshot is available.
 * `volume_id` - The ID of the volume from which the volume snapshot originated.
 * `size` - The billable size of the volume snapshot in gigabytes.
+* `tags` - A list of the tags associated to the volume snapshot.

--- a/website/docs/r/volume_snapshot.html.markdown
+++ b/website/docs/r/volume_snapshot.html.markdown
@@ -32,6 +32,7 @@ The following arguments are supported:
 
 * `name` - (Required) A name for the volume snapshot.
 * `volume_id` - (Required) The ID of the volume from which the volume snapshot originated.
+* `tags` - (Optional) A list of the tags to be applied to this volume snapshot.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds support for `tags` to the `digitalocean_volume_snapshot` resource and data source.

Volume Snapshot Resource Tests:
```
=== RUN   TestAccDigitalOceanVolumeSnapshot_importBasic
--- PASS: TestAccDigitalOceanVolumeSnapshot_importBasic (10.58s)
=== RUN   TestAccDigitalOceanVolumeSnapshot_Basic
--- PASS: TestAccDigitalOceanVolumeSnapshot_Basic (10.65s)
=== RUN   TestAccDigitalOceanVolumeSnapshot_UpdateTags
--- PASS: TestAccDigitalOceanVolumeSnapshot_UpdateTags (13.67s)
PASS
ok      github.com/terraform-providers/terraform-provider-digitalocean/digitalocean     34.940s
```

Volume Snapshot Data Source Tests:
```
=== RUN   TestAccDataSourceDigitalOceanVolumeSnapshot_basic
--- PASS: TestAccDataSourceDigitalOceanVolumeSnapshot_basic (22.78s)
=== RUN   TestAccDataSourceDigitalOceanVolumeSnapshot_regex
--- PASS: TestAccDataSourceDigitalOceanVolumeSnapshot_regex (21.49s)
=== RUN   TestAccDataSourceDigitalOceanVolumeSnapshot_region
--- PASS: TestAccDataSourceDigitalOceanVolumeSnapshot_region (35.49s)
PASS
ok      github.com/terraform-providers/terraform-provider-digitalocean/digitalocean     79.792s
```