### PR TITLE
Add support for Redis eviction policies (Fixes: #342).

### DIFF
--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -139,6 +139,17 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 
 			"tags": tagsSchema(),
 		},
+
+		CustomizeDiff: func(diff *schema.ResourceDiff, v interface{}) error {
+			engine := diff.Get("engine")
+			_, hasEvictionPolicy := diff.GetOk("eviction_policy")
+
+			if hasEvictionPolicy && engine != "redis" {
+				return fmt.Errorf("eviction_policy is only supported for Redis Database Clusters")
+			}
+
+			return nil
+		},
 	}
 }
 

--- a/website/docs/r/database_cluster.html.markdown
+++ b/website/docs/r/database_cluster.html.markdown
@@ -52,11 +52,12 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the database cluster.
 * `engine` - (Required) Database engine used by the cluster (ex. `pg` for PostreSQL, `mysql` for MySQL, or `redis` for Redis).
-* `size` - (Required) Database droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`).
+* `size` - (Required) Database Droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`).
 * `region` - (Required) DigitalOcean region where the cluster will reside.
 * `node_count` - (Required) Number of nodes that will be included in the cluster.
 * `version` - (Optional) Engine version used by the cluster (ex. `11` for PostgreSQL 11).
 * `tags` - (Optional) A list of tag names to be applied to the database cluster.
+* `eviction_policy` - (Optional) A string specifying the eviction policy for a Redis cluster. Valid vaules are: `noeviction`, `allkeys_lru`, `allkeys_random`, `volatile_lru`, `volatile_random`, or `volatile_ttl`.
 * `maintenance_window` - (Optional) Defines when the automatic maintenance should be performed for the database cluster.
 
 `maintenance_window` supports the following:

--- a/website/docs/r/database_cluster.html.markdown
+++ b/website/docs/r/database_cluster.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `node_count` - (Required) Number of nodes that will be included in the cluster.
 * `version` - (Optional) Engine version used by the cluster (ex. `11` for PostgreSQL 11).
 * `tags` - (Optional) A list of tag names to be applied to the database cluster.
-* `eviction_policy` - (Optional) A string specifying the eviction policy for a Redis cluster. Valid vaules are: `noeviction`, `allkeys_lru`, `allkeys_random`, `volatile_lru`, `volatile_random`, or `volatile_ttl`.
+* `eviction_policy` - (Optional) A string specifying the eviction policy for a Redis cluster. Valid values are: `noeviction`, `allkeys_lru`, `allkeys_random`, `volatile_lru`, `volatile_random`, or `volatile_ttl`.
 * `maintenance_window` - (Optional) Defines when the automatic maintenance should be performed for the database cluster.
 
 `maintenance_window` supports the following:


### PR DESCRIPTION
```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDatabaseCluster_Redis'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDatabaseCluster_Redis -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDatabaseCluster_RedisNoVersion
--- PASS: TestAccDigitalOceanDatabaseCluster_RedisNoVersion (263.90s)
=== RUN   TestAccDigitalOceanDatabaseCluster_RedisWithEvictionPolicy
--- PASS: TestAccDigitalOceanDatabaseCluster_RedisWithEvictionPolicy (296.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	560.568s
```