### PR TITLE
Add support for configuring SQL mode.

### DIFF
--- a/digitalocean/resource_digitalocean_database_cluster_test.go
+++ b/digitalocean/resource_digitalocean_database_cluster_test.go
@@ -135,6 +135,39 @@ func TestAccDigitalOceanDatabaseCluster_WithMaintWindow(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanDatabaseCluster_WithSQLMode(t *testing.T) {
+	var database godo.Database
+	databaseName := randomTestName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDatabaseClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigWithSQLMode, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
+					testAccCheckDigitalOceanDatabaseClusterAttributes(&database, databaseName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "sql_mode",
+						"ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_DATE,NO_ZERO_IN_DATE"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigWithSQLModeUpdate, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
+					testAccCheckDigitalOceanDatabaseClusterAttributes(&database, databaseName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_cluster.foobar", "sql_mode",
+						"ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanDatabaseCluster_RedisNoVersion(t *testing.T) {
 	var database godo.Database
 	databaseName := randomTestName()
@@ -343,6 +376,26 @@ resource "digitalocean_database_cluster" "foobar" {
         day  = "friday"
         hour = "13:00:00"
 	}
+}`
+
+const testAccCheckDigitalOceanDatabaseClusterConfigWithSQLMode = `
+resource "digitalocean_database_cluster" "foobar" {
+	name       = "%s"
+	engine     = "mysql"
+	size       = "db-s-1vcpu-1gb"
+	region     = "lon1"
+    node_count = 1
+    sql_mode   = "ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_DATE,NO_ZERO_IN_DATE"
+}`
+
+const testAccCheckDigitalOceanDatabaseClusterConfigWithSQLModeUpdate = `
+resource "digitalocean_database_cluster" "foobar" {
+	name       = "%s"
+	engine     = "mysql"
+	size       = "db-s-1vcpu-1gb"
+	region     = "lon1"
+    node_count = 1
+    sql_mode   = "ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE"
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterRedisNoVersion = `

--- a/digitalocean/resource_digitalocean_database_cluster_test.go
+++ b/digitalocean/resource_digitalocean_database_cluster_test.go
@@ -168,6 +168,22 @@ func TestAccDigitalOceanDatabaseCluster_WithSQLMode(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanDatabaseCluster_CheckSQLModeSupport(t *testing.T) {
+	databaseName := randomTestName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDatabaseClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigWithRedisSQLModeError, databaseName),
+				ExpectError: regexp.MustCompile(`sql_mode is only supported for MySQL`),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanDatabaseCluster_RedisNoVersion(t *testing.T) {
 	var database godo.Database
 	databaseName := randomTestName()
@@ -396,6 +412,16 @@ resource "digitalocean_database_cluster" "foobar" {
 	region     = "lon1"
     node_count = 1
     sql_mode   = "ANSI,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE"
+}`
+
+const testAccCheckDigitalOceanDatabaseClusterConfigWithRedisSQLModeError = `
+resource "digitalocean_database_cluster" "foobar" {
+	name       = "%s"
+	engine     = "redis"
+	size       = "db-s-1vcpu-1gb"
+	region     = "nyc1"
+    node_count = 1
+    sql_mode   = "ANSI"
 }`
 
 const testAccCheckDigitalOceanDatabaseClusterRedisNoVersion = `

--- a/website/docs/r/database_cluster.html.markdown
+++ b/website/docs/r/database_cluster.html.markdown
@@ -58,6 +58,7 @@ The following arguments are supported:
 * `version` - (Optional) Engine version used by the cluster (ex. `11` for PostgreSQL 11).
 * `tags` - (Optional) A list of tag names to be applied to the database cluster.
 * `eviction_policy` - (Optional) A string specifying the eviction policy for a Redis cluster. Valid values are: `noeviction`, `allkeys_lru`, `allkeys_random`, `volatile_lru`, `volatile_random`, or `volatile_ttl`.
+* `sql_mode` - (Optional) A comma separated string specifying the  SQL modes for a MySQL cluster.
 * `maintenance_window` - (Optional) Defines when the automatic maintenance should be performed for the database cluster.
 
 `maintenance_window` supports the following:


### PR DESCRIPTION
```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDatabaseCluster_WithSQLMode'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDatabaseCluster_WithSQLMode -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDatabaseCluster_WithSQLMode
--- PASS: TestAccDigitalOceanDatabaseCluster_WithSQLMode (324.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	324.521s
```