### PR TITLE
Add support for Database Firewalls (Fixes :#340).

### DIFF
--- a/digitalocean/import_digitalocean_database_firewall_test.go
+++ b/digitalocean/import_digitalocean_database_firewall_test.go
@@ -1,0 +1,66 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDigitalOceanDatabaseFirewall_importBasic(t *testing.T) {
+	resourceName := "digitalocean_database_firewall.example"
+	databaseClusterName := randomTestName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDatabaseFirewallDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseFirewallConfigBasic, databaseClusterName),
+			},
+			{
+				ResourceName: resourceName,
+				ImportState:  true,
+				// Needs the cluster's ID, not the firewall's
+				ImportStateIdFunc: testAccDatabaseFirewallImportID(resourceName),
+				// We do not have a way to match IDs as we the cluster's ID
+				// with resource.PrefixedUniqueId() for the DatabaseFirewall resource.
+				// ImportStateVerify: true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 1 {
+						return fmt.Errorf("expected 1 state: %#v", s)
+					}
+					rs := s[0]
+
+					clusterId := rs.Attributes["cluster_id"]
+					if !strings.HasPrefix(rs.ID, clusterId) {
+						return fmt.Errorf("expected ID to be set and begin with %s-, received: %s\n %#v",
+							clusterId, rs.ID, rs.Attributes)
+					}
+
+					if rs.Attributes["rule.#"] != "1" {
+						return fmt.Errorf("expected 1 rule, received: %s\n %#v",
+							rs.Attributes["rule.#"], rs.Attributes)
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func testAccDatabaseFirewallImportID(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", n)
+		}
+
+		return rs.Primary.Attributes["cluster_id"], nil
+	}
+}

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -63,6 +63,7 @@ func Provider() terraform.ResourceProvider {
 			"digitalocean_database_cluster":         resourceDigitalOceanDatabaseCluster(),
 			"digitalocean_database_connection_pool": resourceDigitalOceanDatabaseConnectionPool(),
 			"digitalocean_database_db":              resourceDigitalOceanDatabaseDB(),
+			"digitalocean_database_firewall":        resourceDigitalOceanDatabaseFirewall(),
 			"digitalocean_database_replica":         resourceDigitalOceanDatabaseReplica(),
 			"digitalocean_database_user":            resourceDigitalOceanDatabaseUser(),
 			"digitalocean_domain":                   resourceDigitalOceanDomain(),

--- a/digitalocean/resource_digitalocean_database_firewall.go
+++ b/digitalocean/resource_digitalocean_database_firewall.go
@@ -93,11 +93,7 @@ func resourceDigitalOceanDatabaseFirewallRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Error retrieving DatabaseFirewall: %s", err)
 	}
 
-	if err := d.Set("rule", flattenDatabaseFirewallRules(rules)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting DatabaseFirewall rule error: %#v", err)
-	}
-
-	return nil
+	return d.Set("rule", flattenDatabaseFirewallRules(rules))
 }
 
 func resourceDigitalOceanDatabaseFirewallUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -157,12 +153,9 @@ func buildDatabaseFirewallRequest(rules []interface{}) godo.DatabaseUpdateFirewa
 		expandedRules = append(expandedRules, &r)
 	}
 
-	req := godo.DatabaseUpdateFirewallRulesRequest{
+	return godo.DatabaseUpdateFirewallRulesRequest{
 		Rules: expandedRules,
 	}
-
-	return req
-
 }
 
 func flattenDatabaseFirewallRules(rules []godo.DatabaseFirewallRule) []interface{} {

--- a/digitalocean/resource_digitalocean_database_firewall.go
+++ b/digitalocean/resource_digitalocean_database_firewall.go
@@ -1,0 +1,186 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceDigitalOceanDatabaseFirewall() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDigitalOceanDatabaseFirewallCreate,
+		Read:   resourceDigitalOceanDatabaseFirewallRead,
+		Update: resourceDigitalOceanDatabaseFirewallUpdate,
+		Delete: resourceDigitalOceanDatabaseFirewallDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDigitalOceanDatabaseFirewallImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"rule": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"ip_addr",
+								"droplet",
+								"k8s",
+								"tag",
+							}, false),
+						},
+
+						"value": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.NoZeroValues,
+						},
+
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceDigitalOceanDatabaseFirewallCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+	clusterID := d.Get("cluster_id").(string)
+
+	rules := buildDatabaseFirewallRequest(d.Get("rule").(*schema.Set).List())
+
+	_, err := client.Databases.UpdateFirewallRules(context.TODO(), clusterID, &rules)
+	if err != nil {
+		return fmt.Errorf("Error creating DatabaseFirewall: %s", err)
+	}
+
+	d.SetId(resource.PrefixedUniqueId(clusterID + "-"))
+
+	return resourceDigitalOceanDatabaseFirewallRead(d, meta)
+}
+
+func resourceDigitalOceanDatabaseFirewallRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+	clusterID := d.Get("cluster_id").(string)
+
+	rules, _, err := client.Databases.GetFirewallRules(context.TODO(), clusterID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving DatabaseFirewall: %s", err)
+	}
+
+	if err := d.Set("rule", flattenDatabaseFirewallRules(rules)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting DatabaseFirewall rule error: %#v", err)
+	}
+
+	return nil
+}
+
+func resourceDigitalOceanDatabaseFirewallUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+	clusterID := d.Get("cluster_id").(string)
+
+	rules := buildDatabaseFirewallRequest(d.Get("rule").(*schema.Set).List())
+
+	_, err := client.Databases.UpdateFirewallRules(context.TODO(), clusterID, &rules)
+	if err != nil {
+		return fmt.Errorf("Error updating DatabaseFirewall: %s", err)
+	}
+
+	return resourceDigitalOceanDatabaseFirewallRead(d, meta)
+}
+
+func resourceDigitalOceanDatabaseFirewallDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+	clusterID := d.Get("cluster_id").(string)
+
+	log.Printf("[INFO] Deleting DatabaseFirewall: %s", d.Id())
+	req := godo.DatabaseUpdateFirewallRulesRequest{
+		Rules: []*godo.DatabaseFirewallRule{},
+	}
+
+	_, err := client.Databases.UpdateFirewallRules(context.TODO(), clusterID, &req)
+	if err != nil {
+		return fmt.Errorf("Error deleting DatabaseFirewall: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceDigitalOceanDatabaseFirewallImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	clusterID := d.Id()
+	d.Set("cluster_id", clusterID)
+	d.SetId(resource.PrefixedUniqueId(clusterID + "-"))
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func buildDatabaseFirewallRequest(rules []interface{}) godo.DatabaseUpdateFirewallRulesRequest {
+	expandedRules := make([]*godo.DatabaseFirewallRule, 0, len(rules))
+	for _, rawRule := range rules {
+		rule := rawRule.(map[string]interface{})
+
+		r := godo.DatabaseFirewallRule{
+			Type:  rule["type"].(string),
+			Value: rule["value"].(string),
+		}
+
+		if rule["uuid"].(string) != "" {
+			r.UUID = rule["uuid"].(string)
+		}
+
+		expandedRules = append(expandedRules, &r)
+	}
+
+	req := godo.DatabaseUpdateFirewallRulesRequest{
+		Rules: expandedRules,
+	}
+
+	return req
+
+}
+
+func flattenDatabaseFirewallRules(rules []godo.DatabaseFirewallRule) []interface{} {
+	if rules == nil {
+		return nil
+	}
+
+	flattenedRules := make([]interface{}, len(rules))
+	for i, rule := range rules {
+		rawRule := map[string]interface{}{
+			"uuid":       rule.UUID,
+			"type":       rule.Type,
+			"value":      rule.Value,
+			"created_at": rule.CreatedAt.Format(time.RFC3339),
+		}
+
+		flattenedRules[i] = rawRule
+	}
+
+	return flattenedRules
+}

--- a/digitalocean/resource_digitalocean_database_firewall_test.go
+++ b/digitalocean/resource_digitalocean_database_firewall_test.go
@@ -1,0 +1,172 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDigitalOceanDatabaseFirewall_Basic(t *testing.T) {
+	databaseClusterName := randomTestName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDatabaseFirewallDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseFirewallConfigBasic, databaseClusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_firewall.example", "rule.#", "1"),
+				),
+			},
+			// Add a new rule
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseFirewallConfigAddRule, databaseClusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_firewall.example", "rule.#", "2"),
+				),
+			},
+			// Remove an existing rule
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseFirewallConfigBasic, databaseClusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_firewall.example", "rule.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanDatabaseFirewall_MultipleResourceTypes(t *testing.T) {
+	dbName := randomTestName()
+	dropletName := randomTestName()
+	tagName := randomTestName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDatabaseFirewallDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseFirewallConfigMultipleResourceTypes,
+					dbName, dropletName, tagName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"digitalocean_database_firewall.example", "rule.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDigitalOceanDatabaseFirewallDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*CombinedConfig).godoClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "digitalocean_database_firewall" {
+			continue
+		}
+
+		clusterId := rs.Primary.Attributes["cluster_id"]
+
+		_, _, err := client.Databases.GetFirewallRules(context.Background(), clusterId)
+		if err == nil {
+			return fmt.Errorf("DatabaseFirewall still exists")
+		}
+	}
+
+	return nil
+}
+
+const testAccCheckDigitalOceanDatabaseFirewallConfigBasic = `
+resource "digitalocean_database_cluster" "foobar" {
+	name       = "%s"
+	engine     = "pg"
+	version    = "11"
+	size       = "db-s-1vcpu-1gb"
+	region     = "nyc1"
+	node_count = 1
+}
+
+resource "digitalocean_database_firewall" "example" {
+	cluster_id = digitalocean_database_cluster.foobar.id
+
+	rule {
+		type  = "ip_addr"
+		value = "192.168.1.1"
+	}
+}
+`
+
+const testAccCheckDigitalOceanDatabaseFirewallConfigAddRule = `
+resource "digitalocean_database_cluster" "foobar" {
+	name       = "%s"
+	engine     = "pg"
+	version    = "11"
+	size       = "db-s-1vcpu-1gb"
+	region     = "nyc1"
+	node_count = 1
+}
+
+resource "digitalocean_database_firewall" "example" {
+	cluster_id = digitalocean_database_cluster.foobar.id
+
+	rule {
+		type  = "ip_addr"
+		value = "192.168.1.1"
+	}
+
+	rule {
+		type  = "ip_addr"
+		value = "192.0.2.0"
+	}
+}
+`
+
+const testAccCheckDigitalOceanDatabaseFirewallConfigMultipleResourceTypes = `
+resource "digitalocean_database_cluster" "foobar" {
+	name       = "%s"
+	engine     = "pg"
+	version    = "11"
+	size       = "db-s-1vcpu-1gb"
+	region     = "nyc1"
+	node_count = 1
+}
+
+resource "digitalocean_droplet" "foobar" {
+	name      = "%s"
+	size      = "s-1vcpu-1gb"
+	image     = "centos-7-x64"
+	region    = "nyc3"
+}
+
+resource "digitalocean_tag" "foobar" {
+	name = "%s"
+}
+
+resource "digitalocean_database_firewall" "example" {
+	cluster_id = digitalocean_database_cluster.foobar.id
+
+	rule {
+		type  = "ip_addr"
+		value = "192.168.1.1"
+	}
+
+	rule {
+		type  = "droplet"
+		value = digitalocean_droplet.foobar.id
+	}
+
+	rule {
+		type  = "tag"
+		value = digitalocean_tag.foobar.name
+	}
+}
+`

--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -82,6 +82,9 @@
             <li<%= sidebar_current("docs-do-resource-database-db") %>>
               <a href="/docs/providers/do/r/database_db.html">digitalocean_database_db</a>
             </li>
+            <li<%= sidebar_current("docs-do-resource-database-firewall") %>>
+              <a href="/docs/providers/do/r/database_firewall.html">digitalocean_database_firewall</a>
+            </li>
             <li<%= sidebar_current("docs-do-resource-database-replica") %>>
               <a href="/docs/providers/do/r/database_replica.html">digitalocean_database_replica</a>
             </li>

--- a/website/docs/r/database_firewall.html.markdown
+++ b/website/docs/r/database_firewall.html.markdown
@@ -1,0 +1,96 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_database_firewall"
+sidebar_current: "docs-do-resource-database-firewall"
+description: |-
+  Provides a DigitalOcean database firewall resource.
+---
+
+# digitalocean\_database\_firewall
+
+Provides a DigitalOcean database firewall resource allowing you to restrict
+connections to your database to trusted sources. You may limit connections to
+specific Droplets, Kubernetes clusters, or IP addresses.
+
+## Example Usage
+
+### Create a new database firewall allowing multiple IP addresses
+
+```hcl
+resource "digitalocean_database_firewall" "example-fw" {
+  cluster_id = digitalocean_database_cluster.postgres-example.id
+
+  rule {
+    type  = "ip_addr"
+    value = "192.168.1.1"
+  }
+
+  rule {
+    type  = "ip_addr"
+    value = "192.0.2.0"
+  }
+}
+
+resource "digitalocean_database_cluster" "postgres-example" {
+  name       = "example-postgres-cluster"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+```
+
+### Create a new database firewall allowing a Droplet
+
+```hcl
+resource "digitalocean_database_firewall" "example-fw" {
+  cluster_id = digitalocean_database_cluster.postgres-example.id
+
+  rule {
+    type  = "droplet"
+    value = digitalocean_droplet.web.id
+  }
+}
+
+resource "digitalocean_droplet" "web" {
+  name   = "web-01"
+  size   = "s-1vcpu-1gb"
+  image  = "centos-7-x64"
+  region = "nyc3"
+}
+
+resource "digitalocean_database_cluster" "postgres-example" {
+  name       = "example-postgres-cluster"
+  engine     = "pg"
+  version    = "11"
+  size       = "db-s-1vcpu-1gb"
+  region     = "nyc1"
+  node_count = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_id` - (Required) The ID of the target database cluster.
+* `rule` - (Required) A rule specifying a resource allowed to access the database cluster. The following arguments must be specified:
+  - `type` - (Required) The type of resource that the firewall rule allows to access the database cluster. The possible values are: `droplet`, `k8s`, `ip_addr`, or `tag`.
+  - `value` - (Required) The ID of the specific resource, the name of a tag applied to a group of resources, or the IP address that the firewall rule allows to access the database cluster.
+
+## Attributes Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+* `uuid` - A unique identifier for the firewall rule.
+* `created_at` - The date and time when the firewall rule was created.
+
+## Import
+
+Database firewalls can be imported using the `id` of the target database cluster
+For example:
+
+```
+terraform import digitalocean_database_firewall.example-fw 5f55c6cd-863b-4907-99b8-7e09b0275d54
+```


### PR DESCRIPTION
```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDatabaseFirewall'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDatabaseFirewall -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDatabaseFirewall_importBasic
--- PASS: TestAccDigitalOceanDatabaseFirewall_importBasic (262.07s)
=== RUN   TestAccDigitalOceanDatabaseFirewall_Basic
--- PASS: TestAccDigitalOceanDatabaseFirewall_Basic (237.98s)
=== RUN   TestAccDigitalOceanDatabaseFirewall_MultipleResourceTypes
--- PASS: TestAccDigitalOceanDatabaseFirewall_MultipleResourceTypes (282.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	782.432s
```