### PR TITLE
Don't store full certificate data in state file (Fixes: #156).

### DIFF
--- a/digitalocean/hash.go
+++ b/digitalocean/hash.go
@@ -3,9 +3,22 @@ package digitalocean
 import (
 	"crypto/sha1"
 	"encoding/hex"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func HashString(s string) string {
 	hash := sha1.Sum([]byte(s))
 	return hex.EncodeToString(hash[:])
+}
+
+func HashStringStateFunc() schema.SchemaStateFunc {
+	return func(v interface{}) string {
+		switch v.(type) {
+		case string:
+			return HashString(v.(string))
+		default:
+			return ""
+		}
+	}
 }

--- a/digitalocean/resource_digitalocean_certificate.go
+++ b/digitalocean/resource_digitalocean_certificate.go
@@ -35,6 +35,11 @@ func resourceDigitalOceanCertificate() *schema.Resource {
 				Sensitive:    true,
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
+				StateFunc:    HashStringStateFunc(),
+				// In order to support older statefiles with fully saved private_key
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return new != "" && old == d.Get("private_key")
+				},
 			},
 
 			"leaf_certificate": {
@@ -42,6 +47,11 @@ func resourceDigitalOceanCertificate() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
+				StateFunc:    HashStringStateFunc(),
+				// In order to support older statefiles with fully saved leaf_certificate
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return new != "" && old == d.Get("leaf_certificate")
+				},
 			},
 
 			"certificate_chain": {
@@ -49,6 +59,11 @@ func resourceDigitalOceanCertificate() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
+				StateFunc:    HashStringStateFunc(),
+				// In order to support older statefiles with fully saved certificate_chain
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return new != "" && old == d.Get("certificate_chain")
+				},
 			},
 
 			"domains": {

--- a/digitalocean/resource_digitalocean_certificate_test.go
+++ b/digitalocean/resource_digitalocean_certificate_test.go
@@ -74,11 +74,11 @@ func TestAccDigitalOceanCertificate_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_certificate.foobar", "name", fmt.Sprintf("certificate-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"digitalocean_certificate.foobar", "private_key", fmt.Sprintf("%s\n", privateKeyMaterial)),
+						"digitalocean_certificate.foobar", "private_key", HashString(fmt.Sprintf("%s\n", privateKeyMaterial))),
 					resource.TestCheckResourceAttr(
-						"digitalocean_certificate.foobar", "leaf_certificate", fmt.Sprintf("%s\n", leafCertMaterial)),
+						"digitalocean_certificate.foobar", "leaf_certificate", HashString(fmt.Sprintf("%s\n", leafCertMaterial))),
 					resource.TestCheckResourceAttr(
-						"digitalocean_certificate.foobar", "certificate_chain", fmt.Sprintf("%s\n", certChainMaterial)),
+						"digitalocean_certificate.foobar", "certificate_chain", HashString(fmt.Sprintf("%s\n", certChainMaterial))),
 				),
 			},
 		},

--- a/digitalocean/resource_digitalocean_droplet.go
+++ b/digitalocean/resource_digitalocean_droplet.go
@@ -169,14 +169,7 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
-				StateFunc: func(v interface{}) string {
-					switch v.(type) {
-					case string:
-						return HashString(v.(string))
-					default:
-						return ""
-					}
-				},
+				StateFunc:    HashStringStateFunc(),
 				// In order to support older statefiles with fully saved user data
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return new != "" && old == d.Get("user_data")


### PR DESCRIPTION
```
$ make testacc TESTARGS='-run=TestAccDigitalOceanCertificate_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanCertificate_Basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanCertificate_Basic
--- PASS: TestAccDigitalOceanCertificate_Basic (21.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	21.181s
```