### PR TITLE
add support for updating database cluster tags

### DIFF
--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -311,6 +311,13 @@ func resourceDigitalOceanDatabaseClusterUpdate(d *schema.ResourceData, meta inte
 		}
 	}
 
+	if d.HasChange("tags") {
+		err := setTags(client, d, godo.DatabaseResourceType)
+		if err != nil {
+			return fmt.Errorf("Error updating tags: %s", err)
+		}
+	}
+
 	return resourceDigitalOceanDatabaseClusterRead(d, meta)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-digitalocean
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0 // indirect
 	github.com/aws/aws-sdk-go v1.25.4
-	github.com/digitalocean/godo v1.28.0
+	github.com/digitalocean/godo v1.29.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/terraform v0.12.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/digitalocean/godo v1.22.0 h1:bVFBKXW2TlynZ9SqmlM6ZSW6UPEzFckltSIUT5NC
 github.com/digitalocean/godo v1.22.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
 github.com/digitalocean/godo v1.28.0 h1:lD4PwD5v9LqQ9T5n6PtkutWFsiIp4KxQmuoiYiJCutU=
 github.com/digitalocean/godo v1.28.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
+github.com/digitalocean/godo v1.29.0 h1:KgNNU0k9SZqVgn7m8NN9iDsq0+nluHBe8HR9QE0QVmA=
+github.com/digitalocean/godo v1.29.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
 github.com/dimchansky/utfbom v1.0.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dnaeon/go-vcr v0.0.0-20180920040454-5637cf3d8a31/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -396,6 +398,7 @@ github.com/hashicorp/terraform-plugin-sdk v1.1.0 h1:fFn2JYcwTnIuRKgc3pX2SJDsrc1F
 github.com/hashicorp/terraform-plugin-sdk v1.1.0/go.mod h1:NuwtLpEpPsFaKJPJNGtMcn9vlhe6Ofe+Y6NqXhJgV2M=
 github.com/hashicorp/terraform-plugin-sdk v1.1.1 h1:wQ2HtvOE8K4QYcm2JB8YFw9u7OplFJ2HMV5WOpMRL2Y=
 github.com/hashicorp/terraform-plugin-sdk v1.1.1/go.mod h1:NuwtLpEpPsFaKJPJNGtMcn9vlhe6Ofe+Y6NqXhJgV2M=
+github.com/hashicorp/terraform-plugin-sdk v1.4.1 h1:REgN6WbySD6aIYdF6Uob3ic4eQkfh4NXSWU/casmgb4=
 github.com/hashicorp/vault v0.10.4/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=
 github.com/hashicorp/vault v1.0.3 h1:8qfP7xbldsLHnTktm1BoxOwlHWLjqr9t7QNbkE4Wbyw=
 github.com/hashicorp/vault v1.0.3/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## unreleased
+
+## [v1.29.0] - 2019-12-13
+
+- #288 Add Balance Get method - @rbutler
+- #286,#289 Deserialize meta field - @timoreimann
+
 ## [v1.28.0] - 2019-12-04
 
 - #282 Add valid Redis eviction policy constants - @bentranter

--- a/vendor/github.com/digitalocean/godo/action.go
+++ b/vendor/github.com/digitalocean/godo/action.go
@@ -34,6 +34,7 @@ var _ ActionsService = &ActionsServiceOp{}
 type actionsRoot struct {
 	Actions []Action `json:"actions"`
 	Links   *Links   `json:"links"`
+	Meta    *Meta    `json:"meta"`
 }
 
 type actionRoot struct {
@@ -73,6 +74,9 @@ func (s *ActionsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Action
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Actions, resp, err

--- a/vendor/github.com/digitalocean/godo/balance.go
+++ b/vendor/github.com/digitalocean/godo/balance.go
@@ -1,0 +1,52 @@
+package godo
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// BalanceService is an interface for interfacing with the Balance
+// endpoints of the DigitalOcean API
+// See: https://developers.digitalocean.com/documentation/v2/#balance
+type BalanceService interface {
+	Get(context.Context) (*Balance, *Response, error)
+}
+
+// BalanceServiceOp handles communication with the Balance related methods of
+// the DigitalOcean API.
+type BalanceServiceOp struct {
+	client *Client
+}
+
+var _ BalanceService = &BalanceServiceOp{}
+
+// Balance represents a DigitalOcean Balance
+type Balance struct {
+	MonthToDateBalance string    `json:"month_to_date_balance"`
+	AccountBalance     string    `json:"account_balance"`
+	MonthToDateUsage   string    `json:"month_to_date_usage"`
+	GeneratedAt        time.Time `json:"generated_at"`
+}
+
+func (r Balance) String() string {
+	return Stringify(r)
+}
+
+// Get DigitalOcean balance info
+func (s *BalanceServiceOp) Get(ctx context.Context) (*Balance, *Response, error) {
+	path := "v2/customers/my/balance"
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(Balance)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}

--- a/vendor/github.com/digitalocean/godo/cdn.go
+++ b/vendor/github.com/digitalocean/godo/cdn.go
@@ -47,6 +47,7 @@ type cdnRoot struct {
 type cdnsRoot struct {
 	Endpoints []CDN  `json:"endpoints"`
 	Links     *Links `json:"links"`
+	Meta      *Meta  `json:"meta"`
 }
 
 // CDNCreateRequest represents a request to create a CDN.
@@ -92,6 +93,9 @@ func (c CDNServiceOp) List(ctx context.Context, opt *ListOptions) ([]CDN, *Respo
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Endpoints, resp, err

--- a/vendor/github.com/digitalocean/godo/certificates.go
+++ b/vendor/github.com/digitalocean/godo/certificates.go
@@ -46,6 +46,7 @@ type certificateRoot struct {
 type certificatesRoot struct {
 	Certificates []Certificate `json:"certificates"`
 	Links        *Links        `json:"links"`
+	Meta         *Meta         `json:"meta"`
 }
 
 // CertificatesServiceOp handles communication with certificates methods of the DigitalOcean API.
@@ -92,6 +93,9 @@ func (c *CertificatesServiceOp) List(ctx context.Context, opt *ListOptions) ([]C
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Certificates, resp, nil

--- a/vendor/github.com/digitalocean/godo/domains.go
+++ b/vendor/github.com/digitalocean/godo/domains.go
@@ -47,6 +47,7 @@ type domainRoot struct {
 type domainsRoot struct {
 	Domains []Domain `json:"domains"`
 	Links   *Links   `json:"links"`
+	Meta    *Meta    `json:"meta"`
 }
 
 // DomainCreateRequest respresents a request to create a domain.
@@ -121,6 +122,9 @@ func (s DomainsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Domain,
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Domains, resp, err

--- a/vendor/github.com/digitalocean/godo/droplets.go
+++ b/vendor/github.com/digitalocean/godo/droplets.go
@@ -139,21 +139,25 @@ type dropletRoot struct {
 type dropletsRoot struct {
 	Droplets []Droplet `json:"droplets"`
 	Links    *Links    `json:"links"`
+	Meta     *Meta     `json:"meta"`
 }
 
 type kernelsRoot struct {
 	Kernels []Kernel `json:"kernels,omitempty"`
 	Links   *Links   `json:"links"`
+	Meta    *Meta    `json:"meta"`
 }
 
 type dropletSnapshotsRoot struct {
 	Snapshots []Image `json:"snapshots,omitempty"`
 	Links     *Links  `json:"links"`
+	Meta      *Meta   `json:"meta"`
 }
 
 type backupsRoot struct {
 	Backups []Image `json:"backups,omitempty"`
 	Links   *Links  `json:"links"`
+	Meta    *Meta   `json:"meta"`
 }
 
 // DropletCreateImage identifies an image for the create request. It prefers slug over ID.
@@ -294,6 +298,9 @@ func (s *DropletsServiceOp) list(ctx context.Context, path string) ([]Droplet, *
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Droplets, resp, err
@@ -449,6 +456,9 @@ func (s *DropletsServiceOp) Kernels(ctx context.Context, dropletID int, opt *Lis
 	if l := root.Links; l != nil {
 		resp.Links = l
 	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
 
 	return root.Kernels, resp, err
 }
@@ -477,6 +487,9 @@ func (s *DropletsServiceOp) Actions(ctx context.Context, dropletID int, opt *Lis
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Actions, resp, err
@@ -507,6 +520,9 @@ func (s *DropletsServiceOp) Backups(ctx context.Context, dropletID int, opt *Lis
 	if l := root.Links; l != nil {
 		resp.Links = l
 	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
 
 	return root.Backups, resp, err
 }
@@ -535,6 +551,9 @@ func (s *DropletsServiceOp) Snapshots(ctx context.Context, dropletID int, opt *L
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Snapshots, resp, err

--- a/vendor/github.com/digitalocean/godo/firewalls.go
+++ b/vendor/github.com/digitalocean/godo/firewalls.go
@@ -237,6 +237,7 @@ type firewallRoot struct {
 type firewallsRoot struct {
 	Firewalls []Firewall `json:"firewalls"`
 	Links     *Links     `json:"links"`
+	Meta      *Meta      `json:"meta"`
 }
 
 func (fw *FirewallsServiceOp) createAndDoReq(ctx context.Context, method, path string, v interface{}) (*Response, error) {
@@ -261,6 +262,9 @@ func (fw *FirewallsServiceOp) listHelper(ctx context.Context, path string) ([]Fi
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Firewalls, resp, err

--- a/vendor/github.com/digitalocean/godo/floating_ips.go
+++ b/vendor/github.com/digitalocean/godo/floating_ips.go
@@ -44,6 +44,7 @@ func (f FloatingIP) URN() string {
 type floatingIPsRoot struct {
 	FloatingIPs []FloatingIP `json:"floating_ips"`
 	Links       *Links       `json:"links"`
+	Meta        *Meta        `json:"meta"`
 }
 
 type floatingIPRoot struct {
@@ -79,6 +80,9 @@ func (f *FloatingIPsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Fl
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.FloatingIPs, resp, err

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.28.0"
+	libraryVersion = "1.29.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"
@@ -45,6 +45,7 @@ type Client struct {
 	// Services used for communicating with the API
 	Account           AccountService
 	Actions           ActionsService
+	Balance           BalanceService
 	CDNs              CDNService
 	Domains           DomainsService
 	Droplets          DropletsService
@@ -93,6 +94,9 @@ type Response struct {
 	// Links that were returned with the response. These are parsed from
 	// request body and not the header.
 	Links *Links
+
+	// Meta describes generic information about the response.
+	Meta *Meta
 
 	// Monitoring URI
 	Monitor string
@@ -162,6 +166,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
 	c.Account = &AccountServiceOp{client: c}
 	c.Actions = &ActionsServiceOp{client: c}
+	c.Balance = &BalanceServiceOp{client: c}
 	c.CDNs = &CDNServiceOp{client: c}
 	c.Certificates = &CertificatesServiceOp{client: c}
 	c.Domains = &DomainsServiceOp{client: c}

--- a/vendor/github.com/digitalocean/godo/images.go
+++ b/vendor/github.com/digitalocean/godo/images.go
@@ -72,6 +72,7 @@ type imageRoot struct {
 type imagesRoot struct {
 	Images []Image
 	Links  *Links `json:"links"`
+	Meta   *Meta  `json:"meta"`
 }
 
 type listImageOptions struct {
@@ -235,6 +236,9 @@ func (s *ImagesServiceOp) list(ctx context.Context, opt *ListOptions, listOpt *l
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Images, resp, err

--- a/vendor/github.com/digitalocean/godo/keys.go
+++ b/vendor/github.com/digitalocean/godo/keys.go
@@ -46,6 +46,7 @@ type KeyUpdateRequest struct {
 type keysRoot struct {
 	SSHKeys []Key  `json:"ssh_keys"`
 	Links   *Links `json:"links"`
+	Meta    *Meta  `json:"meta"`
 }
 
 type keyRoot struct {
@@ -82,6 +83,9 @@ func (s *KeysServiceOp) List(ctx context.Context, opt *ListOptions) ([]Key, *Res
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.SSHKeys, resp, err

--- a/vendor/github.com/digitalocean/godo/kubernetes.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes.go
@@ -354,6 +354,7 @@ type KubernetesRegion struct {
 type kubernetesClustersRoot struct {
 	Clusters []*KubernetesCluster `json:"kubernetes_clusters,omitempty"`
 	Links    *Links               `json:"links,omitempty"`
+	Meta     *Meta                `json:"meta"`
 }
 
 type kubernetesClusterRoot struct {
@@ -469,6 +470,14 @@ func (svc *KubernetesServiceOp) List(ctx context.Context, opts *ListOptions) ([]
 	if err != nil {
 		return nil, resp, err
 	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
 	return root.Clusters, resp, nil
 }
 

--- a/vendor/github.com/digitalocean/godo/load_balancers.go
+++ b/vendor/github.com/digitalocean/godo/load_balancers.go
@@ -167,6 +167,7 @@ func (l dropletIDsRequest) String() string {
 type loadBalancersRoot struct {
 	LoadBalancers []LoadBalancer `json:"load_balancers"`
 	Links         *Links         `json:"links"`
+	Meta          *Meta          `json:"meta"`
 }
 
 type loadBalancerRoot struct {
@@ -217,6 +218,9 @@ func (l *LoadBalancersServiceOp) List(ctx context.Context, opt *ListOptions) ([]
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.LoadBalancers, resp, err

--- a/vendor/github.com/digitalocean/godo/meta.go
+++ b/vendor/github.com/digitalocean/godo/meta.go
@@ -1,0 +1,6 @@
+package godo
+
+// Meta describes generic information about a response.
+type Meta struct {
+	Total int `json:"total"`
+}

--- a/vendor/github.com/digitalocean/godo/projects.go
+++ b/vendor/github.com/digitalocean/godo/projects.go
@@ -125,6 +125,7 @@ type ProjectResourceLinks struct {
 type projectsRoot struct {
 	Projects []Project `json:"projects"`
 	Links    *Links    `json:"links"`
+	Meta     *Meta     `json:"meta"`
 }
 
 type projectRoot struct {
@@ -134,6 +135,7 @@ type projectRoot struct {
 type projectResourcesRoot struct {
 	Resources []ProjectResource `json:"resources"`
 	Links     *Links            `json:"links,omitempty"`
+	Meta      *Meta             `json:"meta"`
 }
 
 var _ ProjectsService = &ProjectsServiceOp{}
@@ -157,6 +159,9 @@ func (p *ProjectsServiceOp) List(ctx context.Context, opts *ListOptions) ([]Proj
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Projects, resp, err
@@ -237,6 +242,9 @@ func (p *ProjectsServiceOp) ListResources(ctx context.Context, projectID string,
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Resources, resp, err

--- a/vendor/github.com/digitalocean/godo/regions.go
+++ b/vendor/github.com/digitalocean/godo/regions.go
@@ -32,6 +32,7 @@ type Region struct {
 type regionsRoot struct {
 	Regions []Region
 	Links   *Links `json:"links"`
+	Meta    *Meta  `json:"meta"`
 }
 
 func (r Region) String() string {
@@ -58,6 +59,9 @@ func (s *RegionsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Region
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Regions, resp, err

--- a/vendor/github.com/digitalocean/godo/sizes.go
+++ b/vendor/github.com/digitalocean/godo/sizes.go
@@ -40,6 +40,7 @@ func (s Size) String() string {
 type sizesRoot struct {
 	Sizes []Size
 	Links *Links `json:"links"`
+	Meta  *Meta  `json:"meta"`
 }
 
 // List all images
@@ -62,6 +63,9 @@ func (s *SizesServiceOp) List(ctx context.Context, opt *ListOptions) ([]Size, *R
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Sizes, resp, err

--- a/vendor/github.com/digitalocean/godo/snapshots.go
+++ b/vendor/github.com/digitalocean/godo/snapshots.go
@@ -47,6 +47,7 @@ type snapshotRoot struct {
 type snapshotsRoot struct {
 	Snapshots []Snapshot `json:"snapshots"`
 	Links     *Links     `json:"links,omitempty"`
+	Meta      *Meta      `json:"meta,omitempty"`
 }
 
 type listSnapshotOptions struct {

--- a/vendor/github.com/digitalocean/godo/storage.go
+++ b/vendor/github.com/digitalocean/godo/storage.go
@@ -15,7 +15,7 @@ const (
 
 // StorageService is an interface for interfacing with the storage
 // endpoints of the Digital Ocean API.
-// See: https://developers.digitalocean.com/documentation/v2#storage
+// See: https://developers.digitalocean.com/documentation/v2/#block-storage
 type StorageService interface {
 	ListVolumes(context.Context, *ListVolumeParams) ([]Volume, *Response, error)
 	GetVolume(context.Context, string) (*Volume, *Response, error)
@@ -67,6 +67,7 @@ func (f Volume) URN() string {
 type storageVolumesRoot struct {
 	Volumes []Volume `json:"volumes"`
 	Links   *Links   `json:"links"`
+	Meta    *Meta    `json:"meta"`
 }
 
 type storageVolumeRoot struct {
@@ -121,6 +122,9 @@ func (svc *StorageServiceOp) ListVolumes(ctx context.Context, params *ListVolume
 
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Volumes, resp, nil
@@ -202,6 +206,9 @@ func (svc *StorageServiceOp) ListSnapshots(ctx context.Context, volumeID string,
 
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Snapshots, resp, nil

--- a/vendor/github.com/digitalocean/godo/storage_actions.go
+++ b/vendor/github.com/digitalocean/godo/storage_actions.go
@@ -120,6 +120,9 @@ func (s *StorageActionsServiceOp) list(ctx context.Context, path string) ([]Acti
 	if l := root.Links; l != nil {
 		resp.Links = l
 	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
 
 	return root.Actions, resp, err
 }

--- a/vendor/github.com/digitalocean/godo/tags.go
+++ b/vendor/github.com/digitalocean/godo/tags.go
@@ -43,6 +43,8 @@ const (
 	LoadBalancerResourceType ResourceType = "load_balancer"
 	// VolumeSnapshotResourceType holds the string representing our ResourceType for storage Snapshots.
 	VolumeSnapshotResourceType ResourceType = "volume_snapshot"
+	// DatabaseResourceType holds the string representing our ResourceType of Database.
+	DatabaseResourceType ResourceType = "database"
 )
 
 // Resource represent a single resource for associating/disassociating with tags
@@ -53,11 +55,13 @@ type Resource struct {
 
 // TaggedResources represent the set of resources a tag is attached to
 type TaggedResources struct {
-	Count         int                      `json:"count"`
-	LastTaggedURI string                   `json:"last_tagged_uri,omitempty"`
-	Droplets      *TaggedDropletsResources `json:"droplets,omitempty"`
-	Images        *TaggedImagesResources   `json:"images"`
-	Volumes       *TaggedVolumesResources  `json:"volumes"`
+	Count           int                             `json:"count"`
+	LastTaggedURI   string                          `json:"last_tagged_uri,omitempty"`
+	Droplets        *TaggedDropletsResources        `json:"droplets,omitempty"`
+	Images          *TaggedImagesResources          `json:"images"`
+	Volumes         *TaggedVolumesResources         `json:"volumes"`
+	VolumeSnapshots *TaggedVolumeSnapshotsResources `json:"volume_snapshots"`
+	Databases       *TaggedDatabasesResources       `json:"databases"`
 }
 
 // TaggedDropletsResources represent the droplet resources a tag is attached to
@@ -78,6 +82,12 @@ type TaggedImagesResources TaggedResourcesData
 
 // TaggedVolumesResources represent the volume resources a tag is attached to
 type TaggedVolumesResources TaggedResourcesData
+
+// TaggedVolumeSnapshotsResources represent the volume snapshot resources a tag is attached to
+type TaggedVolumeSnapshotsResources TaggedResourcesData
+
+// TaggedDatabasesResources represent the database resources a tag is attached to
+type TaggedDatabasesResources TaggedResourcesData
 
 // Tag represent DigitalOcean tag
 type Tag struct {
@@ -103,6 +113,7 @@ type UntagResourcesRequest struct {
 type tagsRoot struct {
 	Tags  []Tag  `json:"tags"`
 	Links *Links `json:"links"`
+	Meta  *Meta  `json:"meta"`
 }
 
 type tagRoot struct {
@@ -130,6 +141,9 @@ func (s *TagsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Tag, *Res
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.Tags, resp, err

--- a/vendor/github.com/digitalocean/godo/vpcs.go
+++ b/vendor/github.com/digitalocean/godo/vpcs.go
@@ -63,6 +63,7 @@ type vpcRoot struct {
 type vpcsRoot struct {
 	VPCs  []*VPC `json:"vpcs"`
 	Links *Links `json:"links"`
+	Meta  *Meta  `json:"meta"`
 }
 
 // Get returns the details of a Virtual Private Cloud.
@@ -117,6 +118,9 @@ func (v *VPCsServiceOp) List(ctx context.Context, opt *ListOptions) ([]*VPC, *Re
 	}
 	if l := root.Links; l != nil {
 		resp.Links = l
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
 	}
 
 	return root.VPCs, resp, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -80,7 +80,7 @@ github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 github.com/davecgh/go-spew/spew
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible
 github.com/dgrijalva/jwt-go
-# github.com/digitalocean/godo v1.28.0
+# github.com/digitalocean/godo v1.29.0
 github.com/digitalocean/godo
 # github.com/fatih/color v1.7.0
 github.com/fatih/color


### PR DESCRIPTION
This PR adds support for updating tags to the `digitalocean_database_cluster` resource.

```
=== RUN   TestAccDigitalOceanDatabaseCluster_TagUpdate
--- PASS: TestAccDigitalOceanDatabaseCluster_TagUpdate (381.72s)
PASS
ok      github.com/terraform-providers/terraform-provider-digitalocean/digitalocean     381.822s
```