### PR TITLE
provider: Mark API token as optional (Fixes: #354).

### DIFF
--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -11,7 +11,7 @@ func Provider() terraform.ResourceProvider {
 		Schema: map[string]*schema.Schema{
 			"token": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"DIGITALOCEAN_TOKEN",
 					"DIGITALOCEAN_ACCESS_TOKEN",


### PR DESCRIPTION
This resolves the issue reported in #354 in a way that is consistent with other providers. It has the added benefit of now allowing Spaces only usage.