### PR TITLE
Improve kubernetes configuration example

### DIFF
--- a/website/docs/d/kubernetes_cluster.html.md
+++ b/website/docs/d/kubernetes_cluster.html.md
@@ -18,6 +18,7 @@ data "digitalocean_kubernetes_cluster" "example" {
 }
 
 provider "kubernetes" {
+  load_config_file = false
   host  = data.digitalocean_kubernetes_cluster.example.endpoint
   token = data.digitalocean_kubernetes_cluster.example.kube_config[0].token
   cluster_ca_certificate = base64decode(

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -49,6 +49,7 @@ resource "digitalocean_kubernetes_cluster" "foo" {
 }
 
 provider "kubernetes" {
+  load_config_file = false
   host  = digitalocean_kubernetes_cluster.foo.endpoint
   token = digitalocean_kubernetes_cluster.foo.kube_config[0].token
   cluster_ca_certificate = base64decode(


### PR DESCRIPTION
In the case demonstrated by this example, the user should probably use
``load_config_file = false`` to avoid running into validation errors due
to unrelated kubeconfigs.


Refs #358 