### PR TITLE
Update provider docs to use >= 0.12 syntax.

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -23,7 +23,7 @@ variable "do_token" {}
 
 # Configure the DigitalOcean Provider
 provider "digitalocean" {
-  token = "${var.do_token}"
+  token = var.do_token
 }
 
 # Create a web server


### PR DESCRIPTION
Looks like I missed the main index page when I update all of the individual resources to use the current syntax. 