### PR TITLE
add import support for digitalocean_kubernetes_cluster and digitalocean_kubernetes_node_pool resources

### DIFF
--- a/digitalocean/import_digitalocean_kubernetes_cluster_node_pool_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_cluster_node_pool_test.go
@@ -1,0 +1,51 @@
+package digitalocean
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDigitalOceanKubernetesClusterNodePool_Import(t *testing.T) {
+	rName := randomTestName()
+	config := fmt.Sprintf(`
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name = "%s"
+  region = "lon1"
+  version = "%s"
+
+  node_pool {
+    name = "default"
+	size = "s-1vcpu-2gb"
+	node_count = 1
+  }
+}
+
+resource digitalocean_kubernetes_node_pool "barfoo" {
+  cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
+  name = "%s"
+  size = "s-1vcpu-2gb"
+  node_count = 1
+}
+`, rName, testClusterVersion16, rName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      "digitalocean_kubernetes_cluster_node_pool.barfoo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"node_count", // because import test failed before DO had started the node in pool
+				},
+			},
+		},
+	})
+}

--- a/digitalocean/import_digitalocean_kubernetes_cluster_node_pool_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_cluster_node_pool_test.go
@@ -39,7 +39,7 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 				Config: config,
 			},
 			{
-				ResourceName:      "digitalocean_kubernetes_cluster_node_pool.barfoo",
+				ResourceName:      "digitalocean_kubernetes_node_pool.barfoo",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{

--- a/digitalocean/import_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_cluster_test.go
@@ -21,8 +21,6 @@ func TestAccDigitalOceanKubernetesCluster_ImportBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDigitalOceanKubernetesConfigBasic(clusterName, testClusterVersion16),
-			},
-			{
 				// Remove the default node pool tag so that the import code which infers
 				// the need to add the tag gets triggered.
 				Check:       testAccDigitalOceanKubernetesRemoveDefaultNodePoolTag(clusterName),
@@ -35,6 +33,7 @@ func TestAccDigitalOceanKubernetesCluster_ImportBasic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"kube_config",            // because kube_config was completely different for imported state
 					"node_pool.0.node_count", // because import test failed before DO had started the node in pool
+					"updated_at",             // because removing default tag updates the resource outside of Terraform
 				},
 			},
 		},

--- a/digitalocean/import_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_cluster_test.go
@@ -1,0 +1,31 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDigitalOceanKubernetesCluster_ImportBasic(t *testing.T) {
+	clusterName := randomTestName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDigitalOceanKubernetesConfigBasic(clusterName, testClusterVersion16),
+			},
+			{
+				ResourceName:      "digitalocean_kubernetes_cluster.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"kube_config",            // because kube_config was completely different for imported state
+					"node_pool.0.node_count", // because import test failed before DO had started the node in pool
+				},
+			},
+		},
+	})
+}

--- a/digitalocean/import_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_cluster_test.go
@@ -3,7 +3,9 @@ package digitalocean
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"regexp"
+	"sort"
 	"testing"
 
 	"github.com/digitalocean/godo"
@@ -86,4 +88,62 @@ func testAccDigitalOceanKubernetesRemoveDefaultNodePoolTag(clusterName string) r
 
 		return nil
 	}
+}
+
+func TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool(t *testing.T) {
+	testName1 := randomTestName()
+	testName2 := randomTestName()
+
+	config := fmt.Sprintf(`
+resource "digitalocean_kubernetes_cluster" "foobar" {
+  name = "%s"
+  region = "lon1"
+  version = "%s"
+
+  node_pool {
+    name = "default"
+	size = "s-1vcpu-2gb"
+	node_count = 1
+  }
+}
+
+resource "digitalocean_kubernetes_node_pool" "barfoo" {
+  cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
+  name = "%s"
+  size = "s-1vcpu-2gb"
+  node_count = 1
+}
+`, testName1, testClusterVersion16, testName2)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName: "digitalocean_kubernetes_cluster.foobar",
+				ImportState:  true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 2 {
+						return fmt.Errorf("expected 2 states: %#v", s)
+					}
+
+					actualNames := []string{s[0].Attributes["name"], s[1].Attributes["name"]}
+					expectedNames := []string{testName1, testName2}
+					sort.Strings(actualNames)
+					sort.Strings(expectedNames)
+
+					if !reflect.DeepEqual(actualNames, expectedNames) {
+						return fmt.Errorf("expected name attributes for cluster and node pools to match: expected=%#v, actual=%#v, s=%#v",
+							expectedNames, actualNames, s)
+					}
+
+					return nil
+				},
+			},
+		},
+	})
 }

--- a/digitalocean/import_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_cluster_test.go
@@ -3,6 +3,7 @@ package digitalocean
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/digitalocean/godo"
@@ -20,10 +21,12 @@ func TestAccDigitalOceanKubernetesCluster_ImportBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDigitalOceanKubernetesConfigBasic(clusterName, testClusterVersion16),
-				// TODO: We need a way to disable the ID-refresh check because removing the default node pool
-				// tag prevents the ID-refresh from succeeding since the resource will error if the tag is
-				// not present.
-				//Check:  testAccDigitalOceanKubernetesRemoveDefaultNodePoolTag(clusterName),
+			},
+			{
+				// Remove the default node pool tag so that the import code which infers
+				// the need to add the tag gets triggered.
+				Check:       testAccDigitalOceanKubernetesRemoveDefaultNodePoolTag(clusterName),
+				ExpectError: regexp.MustCompile("No default node pool was found"),
 			},
 			{
 				ResourceName:      "digitalocean_kubernetes_cluster.foobar",

--- a/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDigitalOceanKubernetesClusterNodePool_Import(t *testing.T) {
+func TestAccDigitalOceanKubernetesNodePool_Import(t *testing.T) {
 	rName := randomTestName()
 	config := fmt.Sprintf(`
 resource "digitalocean_kubernetes_cluster" "foobar" {

--- a/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
@@ -2,6 +2,8 @@ package digitalocean
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -48,16 +50,15 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 					if len(s) != 2 {
 						return fmt.Errorf("expected 2 states: %#v", s)
 					}
-					clusterState, nodePoolState := s[0], s[1]
 
-					if clusterState.Attributes["name"] != testName1 {
-						return fmt.Errorf("expected name attribute for cluster to match: expected=%s, actual=%s",
-							clusterState.Attributes["name"], testName1)
-					}
+					actualNames := []string{s[0].Attributes["name"], s[1].Attributes["name"]}
+					expectedNames := []string{testName1, testName2}
+					sort.Strings(actualNames)
+					sort.Strings(expectedNames)
 
-					if nodePoolState.Attributes["name"] != testName2 {
-						return fmt.Errorf("expected name attribute for node pool to match: expected=%s, actual=%s",
-							nodePoolState.Attributes["name"], testName2)
+					if !reflect.DeepEqual(actualNames, expectedNames) {
+						return fmt.Errorf("expected name attributes for cluster and node pools to match: expected=%#v, actual=%#v, s=%#v",
+							expectedNames, actualNames, s)
 					}
 
 					return nil

--- a/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
@@ -2,12 +2,9 @@ package digitalocean
 
 import (
 	"fmt"
-	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccDigitalOceanKubernetesNodePool_Import(t *testing.T) {
@@ -27,8 +24,8 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
   }
 }
 
-resource digitalocean_kubernetes_node_pool "barfoo" {
-  cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
+resource "digitalocean_kubernetes_node_pool" "barfoo" {
+  cluster_id = digitalocean_kubernetes_cluster.foobar.id
   name = "%s"
   size = "s-1vcpu-2gb"
   node_count = 1
@@ -44,25 +41,9 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 				Config: config,
 			},
 			{
-				ResourceName: "digitalocean_kubernetes_cluster.foobar",
-				ImportState:  true,
-				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					if len(s) != 2 {
-						return fmt.Errorf("expected 2 states: %#v", s)
-					}
-
-					actualNames := []string{s[0].Attributes["name"], s[1].Attributes["name"]}
-					expectedNames := []string{testName1, testName2}
-					sort.Strings(actualNames)
-					sort.Strings(expectedNames)
-
-					if !reflect.DeepEqual(actualNames, expectedNames) {
-						return fmt.Errorf("expected name attributes for cluster and node pools to match: expected=%#v, actual=%#v, s=%#v",
-							expectedNames, actualNames, s)
-					}
-
-					return nil
-				},
+				ResourceName:      "digitalocean_kubernetes_node_pool.barfoo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
@@ -2,6 +2,7 @@ package digitalocean
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -31,6 +32,7 @@ resource "digitalocean_kubernetes_node_pool" "barfoo" {
   node_count = 1
 }
 `, testName1, testClusterVersion16, testName2)
+	resourceName := "digitalocean_kubernetes_node_pool.barfoo"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -41,9 +43,16 @@ resource "digitalocean_kubernetes_node_pool" "barfoo" {
 				Config: config,
 			},
 			{
-				ResourceName:      "digitalocean_kubernetes_node_pool.barfoo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "this-is-not-a-valid-ID",
+				ExpectError:       regexp.MustCompile("Did not find the cluster owning the node pool"),
 			},
 		},
 	})

--- a/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccDigitalOceanKubernetesNodePool_Import(t *testing.T) {
-	rName := randomTestName()
+	testName1 := randomTestName()
+	testName2 := randomTestName()
+
 	config := fmt.Sprintf(`
 resource "digitalocean_kubernetes_cluster" "foobar" {
   name = "%s"
@@ -28,7 +31,7 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
   size = "s-1vcpu-2gb"
   node_count = 1
 }
-`, rName, testClusterVersion16, rName)
+`, testName1, testClusterVersion16, testName2)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -39,11 +42,25 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 				Config: config,
 			},
 			{
-				ResourceName:      "digitalocean_kubernetes_node_pool.barfoo",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"node_count", // because import test failed before DO had started the node in pool
+				ResourceName: "digitalocean_kubernetes_cluster.foobar",
+				ImportState:  true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 2 {
+						return fmt.Errorf("expected 2 states: %#v", s)
+					}
+					clusterState, nodePoolState := s[0], s[1]
+
+					if clusterState.Attributes["name"] != testName1 {
+						return fmt.Errorf("expected name attribute for cluster to match: expected=%s, actual=%s",
+							clusterState.Attributes["name"], testName1)
+					}
+
+					if nodePoolState.Attributes["name"] != testName2 {
+						return fmt.Errorf("expected name attribute for node pool to match: expected=%s, actual=%s",
+							nodePoolState.Attributes["name"], testName2)
+					}
+
+					return nil
 				},
 			},
 		},

--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -418,7 +418,7 @@ func resourceDigitalOceanKubernetesClusterImportState(d *schema.ResourceData, me
 		}
 	}
 
-	// Refresh the cluster and node pools so that any the added tag
+	// Refresh the cluster and node pools metadata if we added the default tag.
 	if refreshCluster {
 		cluster, _, err = client.Kubernetes.Get(context.Background(), d.Id())
 		if err != nil {

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const testClusterVersion15 = "1.15.5-do.1"
-const testClusterVersion16 = "1.16.2-do.3"
+const testClusterVersion16 = "1.16.6-do.0"
 
 func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 	t.Parallel()

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const testClusterVersion15 = "1.15.5-do.1"
-const testClusterVersion16 = "1.16.2-do.0"
+const testClusterVersion16 = "1.16.2-do.3"
 
 func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 	t.Parallel()

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool.go
@@ -19,10 +19,13 @@ const digitaloceanKubernetesDefaultNodePoolTag = "terraform:default-node-pool"
 func resourceDigitalOceanKubernetesNodePool() *schema.Resource {
 
 	return &schema.Resource{
-		Create:        resourceDigitalOceanKubernetesNodePoolCreate,
-		Read:          resourceDigitalOceanKubernetesNodePoolRead,
-		Update:        resourceDigitalOceanKubernetesNodePoolUpdate,
-		Delete:        resourceDigitalOceanKubernetesNodePoolDelete,
+		Create: resourceDigitalOceanKubernetesNodePoolCreate,
+		Read:   resourceDigitalOceanKubernetesNodePoolRead,
+		Update: resourceDigitalOceanKubernetesNodePoolUpdate,
+		Delete: resourceDigitalOceanKubernetesNodePoolDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		SchemaVersion: 1,
 
 		Schema: nodePoolResourceSchema(),

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -131,9 +131,10 @@ In addition to the arguments listed above, the following additional attributes a
 ## Import
 
 Before importing a Kubernetes cluster, the cluster's default node pool must be tagged with
-the `terraform:default-node-pool` tag. The provider adds this tag if it was responsible for 
-creating the Kubernetes cluster. Clusters created outside of Terraform, however, may not have this
-tag, and thus the tag must be added manually.
+the `terraform:default-node-pool` tag. The provider will automatically add this tag if
+the cluster has a single node pool. Clusters with more than one node pool, however, will require
+that you manually add the `terraform:default-node-pool` tag to the node pool that you intend to be
+the default node pool.
 
 Then the Kubernetes cluster may be imported using the cluster's `id`, e.g.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -136,7 +136,7 @@ the cluster has a single node pool. Clusters with more than one node pool, howev
 that you manually add the `terraform:default-node-pool` tag to the node pool that you intend to be
 the default node pool.
 
-Then the Kubernetes cluster may be imported using the cluster's `id`, e.g.
+Then the Kubernetes cluster and all of its node pools can be imported using the cluster's `id`, e.g.
 
 ```
 terraform import digitalocean_kubernetes_cluster.mycluster 1b8b2100-0e9f-4e8f-ad78-9eb578c2a0af

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -130,4 +130,13 @@ In addition to the arguments listed above, the following additional attributes a
 
 ## Import
 
-Kubernetes clusters can not be imported at this time.
+Before importing a Kubernetes cluster, the cluster's default node pool must be tagged with
+the `terraform:default-node-pool` tag. The provider adds this tag if it was responsible for 
+creating the Kubernetes cluster. Clusters created outside of Terraform, however, may not have this
+tag, and thus the tag must be added manually.
+
+Then the Kubernetes cluster may be imported using the cluster's `id`, e.g.
+
+```
+terraform import digitalocean_kubernetes_cluster.mycluster 1b8b2100-0e9f-4e8f-ad78-9eb578c2a0af
+```

--- a/website/docs/r/kubernetes_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_node_pool.html.markdown
@@ -82,4 +82,16 @@ In addition to the arguments listed above, the following additional attributes a
 
 ## Import
 
-Kubernetes node pools can not be imported at this time.
+If you are importing an existing Kubernetes cluster, just import the cluster. Importing a cluster also imports
+all of its associated node pools.
+
+If you still need to import a single node pool, then import it by using its `id`, e.g.
+
+```
+terraform import digitalocean_kubernetes_node_pool.mynodepool 9d76f410-9284-4436-9633-4066852442c8
+```
+
+Note: If the node pool has the `terraform:default-node-pool` tag, then it is a default node pool for an
+existing cluster. The provider will refuse to import the node pool in that case because the node pool
+is managed by the `digitalocean_kubernetes_cluster` resource and not by this
+`digitalocean_kubernetes_node_pool` resource.


### PR DESCRIPTION
Teach `digitalocean_kubernetes_cluster` how to import existing clusters.

The main issue is that the provider expects the default node pool to have a `terraform:default-node-pool` tag. This PR adds a check in `digitaloceanKubernetesClusterRead` to ensure that one and only one node pool has that tag. Users importing an existing cluster will need to add that tag manually.

A more advanced implementation might infer the default node pool (for example, if there was only one node pool), and automatically set the tag, but making mutating API calls during an import seems complicated so I avoided doing that. Much easier to just have the documentation mention the need to add the tag.

I ran the the acceptance test successfully (with the kubeconfig and node pool count attributes filtered out). The node pool count issue occurred because the test framework found a node count of 0 instead of 1 which implies it imported before the DO control plane had fully started the node pool.