### PR TITLE
add droplet ID to node pools and droplet datasource

### DIFF
--- a/digitalocean/datasource_digitalocean_droplet_test.go
+++ b/digitalocean/datasource_digitalocean_droplet_test.go
@@ -42,6 +42,36 @@ func TestAccDataSourceDigitalOceanDroplet_BasicByName(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceDigitalOceanDroplet_BasicById(t *testing.T) {
+	var droplet godo.Droplet
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDataSourceDigitalOceanDropletConfig_basicById(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceDigitalOceanDropletExists("data.digitalocean_droplet.foobar", &droplet),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_droplet.foobar", "name", name),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_droplet.foobar", "image", "centos-7-x64"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_droplet.foobar", "region", "nyc3"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_droplet.foobar", "ipv6", "true"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_droplet.foobar", "private_networking", "false"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_droplet.foobar", "urn"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_droplet.foobar", "created_at"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceDigitalOceanDroplet_BasicByTag(t *testing.T) {
 	var droplet godo.Droplet
 	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
@@ -128,6 +158,22 @@ resource "digitalocean_droplet" "foo" {
 
 data "digitalocean_droplet" "foobar" {
   name = "${digitalocean_droplet.foo.name}"
+}
+`, name)
+}
+
+func testAccCheckDataSourceDigitalOceanDropletConfig_basicById(name string) string {
+	return fmt.Sprintf(`
+resource "digitalocean_droplet" "foo" {
+  name   = "%s"
+  size   = "512mb"
+  image  = "centos-7-x64"
+  region = "nyc3"
+  ipv6   = true
+}
+
+data "digitalocean_droplet" "foobar" {
+  id = "${digitalocean_droplet.foo.id}"
 }
 `, name)
 }

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool.go
@@ -145,6 +145,11 @@ func nodeSchema() *schema.Schema {
 					Computed: true,
 				},
 
+				"droplet_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+
 				"created_at": {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -445,6 +450,7 @@ func flattenNodes(nodes []*godo.KubernetesNode) []interface{} {
 			"id":         node.ID,
 			"name":       node.Name,
 			"status":     node.Status.State,
+			"droplet_id": node.DropletID,
 			"created_at": node.CreatedAt.UTC().String(),
 			"updated_at": node.UpdatedAt.UTC().String(),
 		}

--- a/go.mod
+++ b/go.mod
@@ -24,3 +24,5 @@ replace github.com/keybase/go-crypto v0.0.0-20190523171820-b785b22cc757 => githu
 replace github.com/terraform-providers/terraform-provider-google v2.17.0+incompatible => github.com/terraform-providers/terraform-provider-google v1.20.1-0.20191008212436-363f2d283518
 
 replace github.com/terraform-providers/terraform-provider-aws v2.32.0+incompatible => github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20191010190908-1261a98537f2
+
+go 1.13

--- a/website/docs/d/droplet.html.md
+++ b/website/docs/d/droplet.html.md
@@ -38,11 +38,20 @@ data "digitalocean_droplet" "example" {
 }
 ```
 
+Get the Droplet by ID:
+
+```hcl
+data "digitalocean_droplet" "example" {
+  id = digitalocean_kubernetes_cluster.example.node_pool[0].nodes[0].droplet_id
+}
+```
+
 ## Argument Reference
 
 One of following the arguments must be provided:
 
-* `name` - (Optional) The name of Droplet.
+* `id` - (Optional) The ID of the Droplet
+* `name` - (Optional) The name of the Droplet.
 * `tag` - (Optional) A tag applied to the Droplet.
 
 ## Attributes Reference

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -125,6 +125,7 @@ In addition to the arguments listed above, the following additional attributes a
      + `id` -  A unique ID that can be used to identify and reference the node.
      + `name` - The auto-generated name for the node.
      + `status` -  A string indicating the current status of the individual node.
+     + `droplet_id` - The id of the node's droplet
      + `created_at` - The date and time when the node was created.
      + `updated_at` - The date and time when the node was last updated.
 

--- a/website/docs/r/kubernetes_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_node_pool.html.markdown
@@ -77,6 +77,7 @@ In addition to the arguments listed above, the following additional attributes a
   - `id` -  A unique ID that can be used to identify and reference the node.
   - `name` - The auto-generated name for the node.
   - `status` -  A string indicating the current status of the individual node.
+  - `droplet_id` - The id of the node's droplet
   - `created_at` - The date and time when the node was created.
   - `updated_at` - The date and time when the node was last updated.
 


### PR DESCRIPTION
Add `droplet_id` attribute to the nodes in a node pool of a Kubernetes cluster. And then allow lookups of droplets by ID for `data.digitalocean_droplet`. This seemed a more robust way of looking up full information on a droplet in a node pool since it was unclear to me whether `name` is guaranteed to be unique within an account. (In my use case, getting the public IP of a node in a node pool to assign to a DNS record.)