### PR TITLE
document use of @ as name on digitalocean_record

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/terraform-providers/terraform-provider-digitalocean
 
+go 1.11
+
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0 // indirect
 	github.com/aws/aws-sdk-go v1.25.4

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/terraform-providers/terraform-provider-digitalocean
 
-go 1.11
-
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0 // indirect
 	github.com/aws/aws-sdk-go v1.25.4

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -17,7 +17,7 @@ resource "digitalocean_domain" "default" {
   name = "example.com"
 }
 
-# Add a record to the domain
+# Add an A record to the domain for www.example.com.
 resource "digitalocean_record" "www" {
   domain = digitalocean_domain.default.name
   type   = "A"
@@ -25,9 +25,23 @@ resource "digitalocean_record" "www" {
   value  = "192.168.0.11"
 }
 
-# Output the FQDN for the record
-output "fqdn" {
-  value = digitalocean_record.www.fqdn
+# Add a MX record for the example.com domain itself.
+resource "digitalocean_record" "mx" {
+  domain   = digitalocean_domain.default.name
+  type     = "MX"
+  name     = "@"
+  priority = 10
+  value    = "mail.example.com."
+}
+
+# Output the FQDN for the www A record.
+output "www_fqdn" {
+  value = digitalocean_record.www.fqdn  # => www.example.com
+}
+
+# Output the FQDN for the MX record.
+output "mx_fqdn" {
+  value = digitalocean_record.mx.fqdn  # => example.com
 }
 ```
 
@@ -38,7 +52,7 @@ The following arguments are supported:
 * `type` - (Required) The type of record. Must be one of `A`, `AAAA`, `CAA`, `CNAME`, `MX`, `NS`, `TXT`, or `SRV`.
 * `domain` - (Required) The domain to add the record to.
 * `value` - (Required) The value of the record.
-* `name` - (Required) The name of the record.
+* `name` - (Required) The name of the record. Use `@` for records on domain's name itself.
 * `port` - (Optional) The port of the record. Only valid when type is `SRV`.  Must be between 1 and 65535.
 * `priority` - (Optional) The priority of the record. Only valid when type is `MX` or `SRV`. Must be between 0 and 65535.
 * `weight` - (Optional) The weight of the record. Only valid when type is `SRV`.  Must be between 0 and 65535.


### PR DESCRIPTION
Document that `@` as the name on a `digitalocean_record` resource allows the creation of DNS records on the exact domain.