### PR TITLE
Update for deprecated terraform-plugin-sdk helper/validation methods. 

### DIFF
--- a/digitalocean/datasource_digitalocean_droplet_snapshot.go
+++ b/digitalocean/datasource_digitalocean_droplet_snapshot.go
@@ -23,7 +23,7 @@ func dataSourceDigitalOceanDropletSnapshot() *schema.Resource {
 			"name_regex": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ValidateFunc:  validation.ValidateRegexp,
+				ValidateFunc:  validation.StringIsValidRegExp,
 				ConflictsWith: []string{"name"},
 			},
 			"region": {

--- a/digitalocean/datasource_digitalocean_volume_snapshot.go
+++ b/digitalocean/datasource_digitalocean_volume_snapshot.go
@@ -26,7 +26,7 @@ func dataSourceDigitalOceanVolumeSnapshot() *schema.Resource {
 			"name_regex": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ValidateFunc:  validation.ValidateRegexp,
+				ValidateFunc:  validation.StringIsValidRegExp,
 				ConflictsWith: []string{"name"},
 			},
 			"region": {

--- a/digitalocean/resource_digitalocean_floating_ip.go
+++ b/digitalocean/resource_digitalocean_floating_ip.go
@@ -42,7 +42,7 @@ func resourceDigitalOceanFloatingIp() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.SingleIP(),
+				ValidateFunc: validation.IsIPv4Address,
 			},
 
 			"droplet_id": {

--- a/digitalocean/resource_digitalocean_floating_ip_assignment.go
+++ b/digitalocean/resource_digitalocean_floating_ip_assignment.go
@@ -25,7 +25,7 @@ func resourceDigitalOceanFloatingIpAssignment() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.SingleIP(),
+				ValidateFunc: validation.IsIPv4Address,
 			},
 
 			"droplet_id": {


### PR DESCRIPTION
In https://github.com/terraform-providers/terraform-provider-digitalocean/pull/375, we updated the terraform-plugin-sdk to 1.6.0. This renamed and deprecated a number of helper/validation methods. See: https://github.com/hashicorp/terraform-plugin-sdk/blob/master/CHANGELOG.md#160-january-29-2020

This PR updates the to the new versions.