### PR TITLE
add labels support to Kubernetes node pools

### DIFF
--- a/digitalocean/datasource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/datasource_digitalocean_kubernetes_cluster.go
@@ -98,6 +98,14 @@ func dataSourceDigitalOceanKubernetesCluster() *schema.Resource {
 
 						"tags": tagsSchema(),
 
+						"labels": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+
 						"nodes": nodeSchema(),
 					},
 				},

--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -181,6 +181,7 @@ func resourceDigitalOceanKubernetesClusterCreate(d *schema.ResourceData, meta in
 			Name:      pool.Name,
 			Size:      pool.Size,
 			Tags:      tags,
+			Labels:    pool.Labels,
 			Count:     pool.Count,
 			AutoScale: pool.AutoScale,
 			MinNodes:  pool.MinNodes,
@@ -613,6 +614,10 @@ func flattenNodePool(d *schema.ResourceData, keyPrefix string, pool *godo.Kubern
 
 	if pool.Tags != nil {
 		rawPool["tags"] = flattenTags(filterTags(pool.Tags))
+	}
+
+	if pool.Labels != nil {
+		rawPool["labels"] = flattenLabels(pool.Labels)
 	}
 
 	if pool.Nodes != nil {

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -50,6 +50,8 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.tags.#", "2"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.tags.2053932785", "one"), // Currently tags are being copied from parent this will fail
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.tags.298486374", "two"),  // requires API update
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.labels.%", "1"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.labels.priority", "high"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.nodes.#", "1"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "node_pool.0.nodes.0.name"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "node_pool.0.nodes.0.status"),
@@ -91,6 +93,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdateCluster(t *testing.T) {
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "tags.#", "2"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "tags.2053932785", "one"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "tags.298486374", "two"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.labels.%", "0"),
 				),
 			},
 		},
@@ -128,6 +131,9 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.node_count", "2"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.actual_node_count", "2"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.tags.#", "3"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.labels.%", "2"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.labels.priority", "high"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "node_pool.0.labels.purpose", "awesome"),
 				),
 			},
 		},
@@ -465,6 +471,9 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 		size  = "s-1vcpu-2gb"
 		node_count = 1
 		tags  = ["one","two"]
+        labels = {
+            priority = "high"
+        }
 	}
 }
 `, rName, testClusterVersion)
@@ -483,6 +492,10 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 		size  = "s-1vcpu-2gb"
 		node_count = 2
 		tags  = ["one","two","three"]
+        labels = {
+            priority = "high"
+            purpose = "awesome"
+        }
 	}
 }
 `, rName, testClusterVersion)

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool.go
@@ -485,16 +485,20 @@ func waitForKubernetesNodePoolDelete(client *godo.Client, id string, poolID stri
 
 func expandLabels(labels map[string]interface{}) map[string]string {
 	expandedLabels := make(map[string]string)
-	for key, value := range labels {
-		expandedLabels[key] = value.(string)
+	if labels != nil {
+		for key, value := range labels {
+			expandedLabels[key] = value.(string)
+		}
 	}
 	return expandedLabels
 }
 
 func flattenLabels(labels map[string]string) map[string]interface{} {
 	flattenedLabels := make(map[string]interface{})
-	for key, value := range labels {
-		flattenedLabels[key] = value
+	if labels != nil {
+		for key, value := range labels {
+			flattenedLabels[key] = value
+		}
 	}
 	return flattenedLabels
 }

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool.go
@@ -123,6 +123,14 @@ func nodePoolSchema() map[string]*schema.Schema {
 
 		"tags": tagsSchema(),
 
+		"labels": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+
 		"nodes": nodeSchema(),
 	}
 }
@@ -174,6 +182,7 @@ func resourceDigitalOceanKubernetesNodePoolCreate(d *schema.ResourceData, meta i
 		"name":       d.Get("name"),
 		"size":       d.Get("size"),
 		"tags":       d.Get("tags"),
+		"labels":     d.Get("labels"),
 		"node_count": d.Get("node_count"),
 		"auto_scale": d.Get("auto_scale"),
 		"min_nodes":  d.Get("min_nodes"),
@@ -208,6 +217,7 @@ func resourceDigitalOceanKubernetesNodePoolRead(d *schema.ResourceData, meta int
 	d.Set("node_count", pool.Count)
 	d.Set("actual_node_count", pool.Count)
 	d.Set("tags", flattenTags(filterTags(pool.Tags)))
+	d.Set("labels", flattenLabels(pool.Labels))
 	d.Set("auto_scale", pool.AutoScale)
 	d.Set("min_nodes", pool.MinNodes)
 	d.Set("max_nodes", pool.MaxNodes)
@@ -234,6 +244,7 @@ func resourceDigitalOceanKubernetesNodePoolUpdate(d *schema.ResourceData, meta i
 		rawPool["node_count"] = d.Get("node_count")
 	}
 
+	rawPool["labels"] = d.Get("labels")
 	rawPool["auto_scale"] = d.Get("auto_scale")
 	rawPool["min_nodes"] = d.Get("min_nodes")
 	rawPool["max_nodes"] = d.Get("max_nodes")
@@ -324,6 +335,7 @@ func digitaloceanKubernetesNodePoolCreate(client *godo.Client, pool map[string]i
 		Size:      pool["size"].(string),
 		Count:     pool["node_count"].(int),
 		Tags:      tags,
+		Labels:    expandLabels(pool["labels"].(map[string]interface{})),
 		AutoScale: pool["auto_scale"].(bool),
 		MinNodes:  pool["min_nodes"].(int),
 		MaxNodes:  pool["max_nodes"].(int),
@@ -367,6 +379,10 @@ func digitaloceanKubernetesNodePoolUpdate(client *godo.Client, pool map[string]i
 
 	if pool["max_nodes"] != nil {
 		req.MaxNodes = intPtr(pool["max_nodes"].(int))
+	}
+
+	if pool["labels"] != nil {
+		req.Labels = expandLabels(pool["labels"].(map[string]interface{}))
 	}
 
 	p, resp, err := client.Kubernetes.UpdateNodePool(context.Background(), clusterID, poolID, req)
@@ -467,6 +483,22 @@ func waitForKubernetesNodePoolDelete(client *godo.Client, id string, poolID stri
 	return fmt.Errorf("Timeout waiting to delete nodepool")
 }
 
+func expandLabels(labels map[string]interface{}) map[string]string {
+	expandedLabels := make(map[string]string)
+	for key, value := range labels {
+		expandedLabels[key] = value.(string)
+	}
+	return expandedLabels
+}
+
+func flattenLabels(labels map[string]string) map[string]interface{} {
+	flattenedLabels := make(map[string]interface{})
+	for key, value := range labels {
+		flattenedLabels[key] = value
+	}
+	return flattenedLabels
+}
+
 func expandNodePools(nodePools []interface{}) []*godo.KubernetesNodePool {
 	expandedNodePools := make([]*godo.KubernetesNodePool, 0, len(nodePools))
 	for _, rawPool := range nodePools {
@@ -480,6 +512,7 @@ func expandNodePools(nodePools []interface{}) []*godo.KubernetesNodePool {
 			MinNodes:  pool["min_nodes"].(int),
 			MaxNodes:  pool["max_nodes"].(int),
 			Tags:      expandTags(pool["tags"].(*schema.Set).List()),
+			Labels:    expandLabels(pool["labels"].(map[string]interface{})),
 			Nodes:     expandNodes(pool["nodes"].([]interface{})),
 		}
 

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
@@ -53,6 +53,8 @@ func TestAccDigitalOceanKubernetesNodePool_Update(t *testing.T) {
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "name", rName),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "tags.#", "2"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "labels.%", "0"),
+					resource.TestCheckNoResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "labels.priority"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "node_count", "1"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "actual_node_count", "1"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "nodes.#", "1"),
@@ -66,6 +68,8 @@ func TestAccDigitalOceanKubernetesNodePool_Update(t *testing.T) {
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "name", rName+"-updated"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "tags.#", "3"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "labels.%", "1"),
+					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "labels.priority", "high"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "node_count", "2"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "actual_node_count", "2"),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_node_pool.barfoo", "nodes.#", "2"),
@@ -442,6 +446,9 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 	size  = "s-1vcpu-2gb"
 	node_count = 2
 	tags  = ["one","two", "three"]
+	labels = {
+      priority = "high"
+	}
 }
 `, rName, testClusterVersion16, rName)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-digitalocean
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0 // indirect
 	github.com/aws/aws-sdk-go v1.25.4
-	github.com/digitalocean/godo v1.29.0
+	github.com/digitalocean/godo v1.30.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/terraform v0.12.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/digitalocean/godo v1.28.0 h1:lD4PwD5v9LqQ9T5n6PtkutWFsiIp4KxQmuoiYiJC
 github.com/digitalocean/godo v1.28.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
 github.com/digitalocean/godo v1.29.0 h1:KgNNU0k9SZqVgn7m8NN9iDsq0+nluHBe8HR9QE0QVmA=
 github.com/digitalocean/godo v1.29.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
+github.com/digitalocean/godo v1.30.0 h1:4Zb+xBlKMXKg772eyQk6px3sk9RhWj/CR75tQ375A/U=
+github.com/digitalocean/godo v1.30.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
 github.com/dimchansky/utfbom v1.0.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dnaeon/go-vcr v0.0.0-20180920040454-5637cf3d8a31/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/vendor/github.com/digitalocean/godo/.whitesource
+++ b/vendor/github.com/digitalocean/godo/.whitesource
@@ -1,0 +1,8 @@
+{
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure"
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW"
+  }
+}

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
-## unreleased
+## [v1.30.0] - 2020-02-03
+
+- #295 registry: support the created_at field - @adamwg
+- #293 doks: node pool labels - @snormore
 
 ## [v1.29.0] - 2019-12-13
 

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.29.0"
+	libraryVersion = "1.30.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/kubernetes.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes.go
@@ -84,24 +84,26 @@ type KubernetesClusterUpgradeRequest struct {
 // KubernetesNodePoolCreateRequest represents a request to create a node pool for a
 // Kubernetes cluster.
 type KubernetesNodePoolCreateRequest struct {
-	Name      string   `json:"name,omitempty"`
-	Size      string   `json:"size,omitempty"`
-	Count     int      `json:"count,omitempty"`
-	Tags      []string `json:"tags,omitempty"`
-	AutoScale bool     `json:"auto_scale,omitempty"`
-	MinNodes  int      `json:"min_nodes,omitempty"`
-	MaxNodes  int      `json:"max_nodes,omitempty"`
+	Name      string            `json:"name,omitempty"`
+	Size      string            `json:"size,omitempty"`
+	Count     int               `json:"count,omitempty"`
+	Tags      []string          `json:"tags,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
+	AutoScale bool              `json:"auto_scale,omitempty"`
+	MinNodes  int               `json:"min_nodes,omitempty"`
+	MaxNodes  int               `json:"max_nodes,omitempty"`
 }
 
 // KubernetesNodePoolUpdateRequest represents a request to update a node pool in a
 // Kubernetes cluster.
 type KubernetesNodePoolUpdateRequest struct {
-	Name      string   `json:"name,omitempty"`
-	Count     *int     `json:"count,omitempty"`
-	Tags      []string `json:"tags,omitempty"`
-	AutoScale *bool    `json:"auto_scale,omitempty"`
-	MinNodes  *int     `json:"min_nodes,omitempty"`
-	MaxNodes  *int     `json:"max_nodes,omitempty"`
+	Name      string            `json:"name,omitempty"`
+	Count     *int              `json:"count,omitempty"`
+	Tags      []string          `json:"tags,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
+	AutoScale *bool             `json:"auto_scale,omitempty"`
+	MinNodes  *int              `json:"min_nodes,omitempty"`
+	MaxNodes  *int              `json:"max_nodes,omitempty"`
 }
 
 // KubernetesNodePoolRecycleNodesRequest is DEPRECATED please use DeleteNode
@@ -297,14 +299,15 @@ type KubernetesClusterStatus struct {
 
 // KubernetesNodePool represents a node pool in a Kubernetes cluster.
 type KubernetesNodePool struct {
-	ID        string   `json:"id,omitempty"`
-	Name      string   `json:"name,omitempty"`
-	Size      string   `json:"size,omitempty"`
-	Count     int      `json:"count,omitempty"`
-	Tags      []string `json:"tags,omitempty"`
-	AutoScale bool     `json:"auto_scale,omitempty"`
-	MinNodes  int      `json:"min_nodes,omitempty"`
-	MaxNodes  int      `json:"max_nodes,omitempty"`
+	ID        string            `json:"id,omitempty"`
+	Name      string            `json:"name,omitempty"`
+	Size      string            `json:"size,omitempty"`
+	Count     int               `json:"count,omitempty"`
+	Tags      []string          `json:"tags,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
+	AutoScale bool              `json:"auto_scale,omitempty"`
+	MinNodes  int               `json:"min_nodes,omitempty"`
+	MaxNodes  int               `json:"max_nodes,omitempty"`
 
 	Nodes []*KubernetesNode `json:"nodes,omitempty"`
 }

--- a/vendor/github.com/digitalocean/godo/registry.go
+++ b/vendor/github.com/digitalocean/godo/registry.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 const (
@@ -41,7 +42,8 @@ type RegistryDockerCredentialsRequest struct {
 
 // Registry represents a registry.
 type Registry struct {
-	Name string `json:"name,omitempty"`
+	Name      string    `json:"name,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
 }
 
 type registryRoot struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -80,7 +80,7 @@ github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 github.com/davecgh/go-spew/spew
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible
 github.com/dgrijalva/jwt-go
-# github.com/digitalocean/godo v1.29.0
+# github.com/digitalocean/godo v1.30.0
 github.com/digitalocean/godo
 # github.com/fatih/color v1.7.0
 github.com/fatih/color

--- a/website/docs/d/kubernetes_cluster.html.md
+++ b/website/docs/d/kubernetes_cluster.html.md
@@ -66,7 +66,7 @@ The following attributes are exported:
   - `min_nodes` - If auto-scaling is enabled, this represents the minimum number of nodes that the node pool can be scaled down to.
   - `max_nodes` - If auto-scaling is enabled, this represents the maximum number of nodes that the node pool can be scaled up to.
   - `tags` - A list of tag names applied to the node pool.
-  - `labels` - A map of key/value pairs applied to nodes in the pool.
+  - `labels` - A map of key/value pairs applied to nodes in the pool. The labels are exposed in the Kubernetes API as labels in the metadata of the corresponding [Node resources](https://kubernetes.io/docs/concepts/architecture/nodes/).
   - `nodes` - A list of nodes in the pool. Each node exports the following attributes:
      + `id` -  A unique ID that can be used to identify and reference the node.
      + `name` - The auto-generated name for the node.

--- a/website/docs/d/kubernetes_cluster.html.md
+++ b/website/docs/d/kubernetes_cluster.html.md
@@ -66,6 +66,7 @@ The following attributes are exported:
   - `min_nodes` - If auto-scaling is enabled, this represents the minimum number of nodes that the node pool can be scaled down to.
   - `max_nodes` - If auto-scaling is enabled, this represents the maximum number of nodes that the node pool can be scaled up to.
   - `tags` - A list of tag names applied to the node pool.
+  - `labels` - The key/value pairs applied to nodes in the node pool 
   - `nodes` - A list of nodes in the pool. Each node exports the following attributes:
      + `id` -  A unique ID that can be used to identify and reference the node.
      + `name` - The auto-generated name for the node.

--- a/website/docs/d/kubernetes_cluster.html.md
+++ b/website/docs/d/kubernetes_cluster.html.md
@@ -66,7 +66,7 @@ The following attributes are exported:
   - `min_nodes` - If auto-scaling is enabled, this represents the minimum number of nodes that the node pool can be scaled down to.
   - `max_nodes` - If auto-scaling is enabled, this represents the maximum number of nodes that the node pool can be scaled up to.
   - `tags` - A list of tag names applied to the node pool.
-  - `labels` - The key/value pairs applied to nodes in the node pool 
+  - `labels` - A map of key/value pairs applied to nodes in the pool.
   - `nodes` - A list of nodes in the pool. Each node exports the following attributes:
      + `id` -  A unique ID that can be used to identify and reference the node.
      + `name` - The auto-generated name for the node.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -96,6 +96,7 @@ The following arguments are supported:
   - `min_nodes` - (Optional) If auto-scaling is enabled, this represents the minimum number of nodes that the node pool can be scaled down to.
   - `max_nodes` - (Optional) If auto-scaling is enabled, this represents the maximum number of nodes that the node pool can be scaled up to.
   - `tags` - (Optional) A list of tag names to be applied to the Kubernetes cluster.
+  - `labels` - (Optional) key/value pairs to apply to nodes in the default node pool 
 * `tags` - (Optional) A list of tag names to be applied to the Kubernetes cluster.
 
 ## Attributes Reference

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -96,7 +96,7 @@ The following arguments are supported:
   - `min_nodes` - (Optional) If auto-scaling is enabled, this represents the minimum number of nodes that the node pool can be scaled down to.
   - `max_nodes` - (Optional) If auto-scaling is enabled, this represents the maximum number of nodes that the node pool can be scaled up to.
   - `tags` - (Optional) A list of tag names to be applied to the Kubernetes cluster.
-  - `labels` - (Optional) key/value pairs to apply to nodes in the default node pool 
+  - `labels` - (Optional) A map of key/value pairs to apply to nodes in the pool.
 * `tags` - (Optional) A list of tag names to be applied to the Kubernetes cluster.
 
 ## Attributes Reference

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -96,7 +96,7 @@ The following arguments are supported:
   - `min_nodes` - (Optional) If auto-scaling is enabled, this represents the minimum number of nodes that the node pool can be scaled down to.
   - `max_nodes` - (Optional) If auto-scaling is enabled, this represents the maximum number of nodes that the node pool can be scaled up to.
   - `tags` - (Optional) A list of tag names to be applied to the Kubernetes cluster.
-  - `labels` - (Optional) A map of key/value pairs to apply to nodes in the pool.
+  - `labels` - (Optional) A map of key/value pairs to apply to nodes in the pool. The labels are exposed in the Kubernetes API as labels in the metadata of the corresponding [Node resources](https://kubernetes.io/docs/concepts/architecture/nodes/).
 * `tags` - (Optional) A list of tag names to be applied to the Kubernetes cluster.
 
 ## Attributes Reference

--- a/website/docs/r/kubernetes_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_node_pool.html.markdown
@@ -34,6 +34,11 @@ resource "digitalocean_kubernetes_node_pool" "bar" {
   size       = "c-2"
   node_count = 2
   tags       = ["backend"]
+
+  labels = {
+    service  = "backend"
+    priority = "high"
+  }
 }
 ```
 
@@ -53,7 +58,6 @@ resource "digitalocean_kubernetes_node_pool" "autoscale-pool-01" {
 }
 ```
 
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -66,7 +70,7 @@ The following arguments are supported:
 * `min_nodes` - (Optional) If auto-scaling is enabled, this represents the minimum number of nodes that the node pool can be scaled down to.
 * `max_nodes` - (Optional) If auto-scaling is enabled, this represents the maximum number of nodes that the node pool can be scaled up to.
 * `tags` - (Optional) A list of tag names to be applied to the Kubernetes cluster.
-* `labels` - (Optional) key/value pairs to apply to nodes in the node pool 
+* `labels` - (Optional) A map of key/value pairs to apply to nodes in the pool.
 
 ## Attributes Reference
 

--- a/website/docs/r/kubernetes_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_node_pool.html.markdown
@@ -66,6 +66,7 @@ The following arguments are supported:
 * `min_nodes` - (Optional) If auto-scaling is enabled, this represents the minimum number of nodes that the node pool can be scaled down to.
 * `max_nodes` - (Optional) If auto-scaling is enabled, this represents the maximum number of nodes that the node pool can be scaled up to.
 * `tags` - (Optional) A list of tag names to be applied to the Kubernetes cluster.
+* `labels` - (Optional) key/value pairs to apply to nodes in the node pool 
 
 ## Attributes Reference
 

--- a/website/docs/r/kubernetes_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_node_pool.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 * `min_nodes` - (Optional) If auto-scaling is enabled, this represents the minimum number of nodes that the node pool can be scaled down to.
 * `max_nodes` - (Optional) If auto-scaling is enabled, this represents the maximum number of nodes that the node pool can be scaled up to.
 * `tags` - (Optional) A list of tag names to be applied to the Kubernetes cluster.
-* `labels` - (Optional) A map of key/value pairs to apply to nodes in the pool.
+* `labels` - (Optional) A map of key/value pairs to apply to nodes in the pool. The labels are exposed in the Kubernetes API as labels in the metadata of the corresponding [Node resources](https://kubernetes.io/docs/concepts/architecture/nodes/).
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds support to configure labels on `digitalocean_kubernetes_node_pool` resources and the default node pool of `digitalocean_kubernetes_cluster` resources. Upgrades `godo` to v1.30.0 to pick up labels support. Implements https://github.com/terraform-providers/terraform-provider-digitalocean/issues/374.