### PR TITLE
add digitalocean_regions and digitalocean_region data sources

### DIFF
--- a/digitalocean/datasource_digitalocean_region.go
+++ b/digitalocean/datasource_digitalocean_region.go
@@ -56,33 +56,8 @@ func dataSourceDigitalOceanRegionRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.SetId(resource.UniqueId())
-
-	if err := d.Set("slug", region.Slug); err != nil {
-		return fmt.Errorf("Unable to set `slug` attribute: %s", err)
-	}
-
-	if err := d.Set("name", region.Name); err != nil {
-		return fmt.Errorf("Unable to set `name` attribute: %s", err)
-	}
-
-	if err := d.Set("available", region.Available); err != nil {
-		return fmt.Errorf("Unable to set `available` attribute: %s", err)
-	}
-
-	sizesSet := schema.NewSet(schema.HashString, []interface{}{})
-	for _, size := range region.Sizes {
-		sizesSet.Add(size)
-	}
-	if err := d.Set("sizes", sizesSet); err != nil {
-		return fmt.Errorf("Unable to set `sizes` attribute: %s", err)
-	}
-
-	featuresSet := schema.NewSet(schema.HashString, []interface{}{})
-	for _, feature := range region.Features {
-		featuresSet.Add(feature)
-	}
-	if err := d.Set("features", featuresSet); err != nil {
-		return fmt.Errorf("Unable to set `features` attribute: %s", err)
+	if err := setResourceDataFromMap(d, flattenRegion(region)); err != nil {
+		return err
 	}
 
 	return nil

--- a/digitalocean/datasource_digitalocean_region.go
+++ b/digitalocean/datasource_digitalocean_region.go
@@ -1,0 +1,89 @@
+package digitalocean
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceDigitalOceanRegion() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDigitalOceanRegionRead,
+		Schema: map[string]*schema.Schema{
+			"slug": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sizes": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"features": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"available": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDigitalOceanRegionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+
+	regionsBySlug, err := loadRegionsBySlug(client)
+	if err != nil {
+		return fmt.Errorf("Unable to load regions: %s", err)
+	}
+
+	slug, ok := d.GetOk("slug")
+	if !ok || slug == "" {
+		return fmt.Errorf("`slug` property must be specified")
+	}
+
+	region, ok := regionsBySlug[slug.(string)]
+	if !ok {
+		return fmt.Errorf("Region does not exist: %s", slug)
+	}
+
+	d.SetId(resource.UniqueId())
+
+	if err := d.Set("slug", region.Slug); err != nil {
+		return fmt.Errorf("Unable to set `slug` attribute: %s", err)
+	}
+
+	if err := d.Set("name", region.Name); err != nil {
+		return fmt.Errorf("Unable to set `name` attribute: %s", err)
+	}
+
+	if err := d.Set("available", region.Available); err != nil {
+		return fmt.Errorf("Unable to set `available` attribute: %s", err)
+	}
+
+	sizesSet := schema.NewSet(schema.HashString, []interface{}{})
+	for _, size := range region.Sizes {
+		sizesSet.Add(size)
+	}
+	if err := d.Set("sizes", sizesSet); err != nil {
+		return fmt.Errorf("Unable to set `sizes` attribute: %s", err)
+	}
+
+	featuresSet := schema.NewSet(schema.HashString, []interface{}{})
+	for _, feature := range region.Features {
+		featuresSet.Add(feature)
+	}
+	if err := d.Set("features", featuresSet); err != nil {
+		return fmt.Errorf("Unable to set `features` attribute: %s", err)
+	}
+
+	return nil
+}

--- a/digitalocean/datasource_digitalocean_region.go
+++ b/digitalocean/datasource_digitalocean_region.go
@@ -6,6 +6,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func dataSourceDigitalOceanRegion() *schema.Resource {
@@ -13,8 +14,9 @@ func dataSourceDigitalOceanRegion() *schema.Resource {
 		Read: dataSourceDigitalOceanRegionRead,
 		Schema: map[string]*schema.Schema{
 			"slug": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -46,14 +48,11 @@ func dataSourceDigitalOceanRegionRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Unable to load regions: %s", err)
 	}
 
-	slug, ok := d.GetOk("slug")
-	if !ok || slug == "" {
-		return fmt.Errorf("`slug` property must be specified")
-	}
+	slug := d.Get("slug").(string)
 
 	var regionForSlug *godo.Region
 	for _, region := range regions {
-		if region.Slug == slug.(string) {
+		if region.Slug == slug {
 			regionForSlug = &region
 			break
 		}

--- a/digitalocean/datasource_digitalocean_region.go
+++ b/digitalocean/datasource_digitalocean_region.go
@@ -40,7 +40,7 @@ func dataSourceDigitalOceanRegion() *schema.Resource {
 func dataSourceDigitalOceanRegionRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
-	regionsBySlug, err := loadRegionsBySlug(client)
+	regionsBySlug, err := getDigitalOceanRegions(client)
 	if err != nil {
 		return fmt.Errorf("Unable to load regions: %s", err)
 	}

--- a/digitalocean/datasource_digitalocean_region_test.go
+++ b/digitalocean/datasource_digitalocean_region_test.go
@@ -1,6 +1,7 @@
 package digitalocean
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -25,6 +26,24 @@ data "digitalocean_region" "lon1" {
 					resource.TestCheckResourceAttrSet("data.digitalocean_region.lon1", "sizes.#"),
 					resource.TestCheckResourceAttrSet("data.digitalocean_region.lon1", "features.#"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanRegion_MissingSlug(t *testing.T) {
+	config := `
+data "digitalocean_region" "xyz5" {
+	slug = "xyz5"
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("Region does not exist: xyz5"),
 			},
 		},
 	})

--- a/digitalocean/datasource_digitalocean_region_test.go
+++ b/digitalocean/datasource_digitalocean_region_test.go
@@ -1,0 +1,31 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDigitalOceanRegion_Basic(t *testing.T) {
+	config := `
+data "digitalocean_region" "lon1" {
+	slug = "lon1"
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.digitalocean_region.lon1", "slug", "lon1"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_region.lon1", "name"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_region.lon1", "available"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_region.lon1", "sizes.#"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_region.lon1", "features.#"),
+				),
+			},
+		},
+	})
+}

--- a/digitalocean/datasource_digitalocean_regions.go
+++ b/digitalocean/datasource_digitalocean_regions.go
@@ -1,0 +1,108 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceDigitalOceanRegions() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDigitalOceanRegionsRead,
+		Schema: map[string]*schema.Schema{
+			"available": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"features": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+			"slugs": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceDigitalOceanRegionsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+
+	regionsBySlug, err := loadRegionsBySlug(client)
+	if err != nil {
+		return fmt.Errorf("Unable to load regions: %s", err)
+	}
+
+	available, filterByAvailable := d.GetOk("available")
+	requiredFeatures, filterByRequiredFeatures := d.GetOk("features")
+
+	filteredRegionSlugs := []string{}
+	for _, region := range regionsBySlug {
+		if filterByAvailable && region.Available != available.(bool) {
+			continue
+		}
+
+		if filterByRequiredFeatures {
+			match := false
+			for _, requiredFeature := range requiredFeatures.([]interface{}) {
+				for _, feature := range region.Features {
+					if feature == requiredFeature.(string) {
+						match = true
+					}
+				}
+			}
+			if !match {
+				continue
+			}
+		}
+
+		filteredRegionSlugs = append(filteredRegionSlugs, region.Slug)
+	}
+
+	d.SetId(resource.UniqueId())
+	if err := d.Set("slugs", filteredRegionSlugs); err != nil {
+		return fmt.Errorf("Unable to set `slugs` attribute: %s", err)
+	}
+
+	return nil
+}
+
+func loadRegionsBySlug(client *godo.Client) (map[string]godo.Region, error) {
+	allRegions := map[string]godo.Region{}
+
+	opts := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	for {
+		regions, resp, err := client.Regions.List(context.Background(), opts)
+
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving regions: %s", err)
+		}
+
+		for _, region := range regions {
+			allRegions[region.Slug] = region
+		}
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving regions: %s", err)
+		}
+
+		opts.Page = page + 1
+	}
+
+	return allRegions, nil
+}

--- a/digitalocean/datasource_digitalocean_regions.go
+++ b/digitalocean/datasource_digitalocean_regions.go
@@ -49,16 +49,17 @@ func dataSourceDigitalOceanRegionsRead(d *schema.ResourceData, meta interface{})
 		}
 
 		if filterByRequiredFeatures {
-			match := false
 			for _, requiredFeature := range requiredFeatures.([]interface{}) {
+				match := false
 				for _, feature := range region.Features {
 					if feature == requiredFeature.(string) {
 						match = true
 					}
 				}
-			}
-			if !match {
-				continue
+
+				if !match {
+					continue
+				}
 			}
 		}
 

--- a/digitalocean/datasource_digitalocean_regions.go
+++ b/digitalocean/datasource_digitalocean_regions.go
@@ -35,7 +35,7 @@ func dataSourceDigitalOceanRegions() *schema.Resource {
 			"sort":   sortSchema(dataSourceDigitalOceanRegionsSortKeys),
 
 			"regions": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/digitalocean/datasource_digitalocean_regions.go
+++ b/digitalocean/datasource_digitalocean_regions.go
@@ -71,16 +71,9 @@ func dataSourceDigitalOceanRegions() *schema.Resource {
 func dataSourceDigitalOceanRegionsRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
-	regionsBySlug, err := getDigitalOceanRegions(client)
+	regions, err := getDigitalOceanRegions(client)
 	if err != nil {
 		return fmt.Errorf("Unable to load regions: %s", err)
-	}
-
-	regions := make([]godo.Region, len(regionsBySlug))
-	i := 0
-	for _, region := range regionsBySlug {
-		regions[i] = region
-		i += 1
 	}
 
 	if v, ok := d.GetOk("filter"); ok {

--- a/digitalocean/datasource_digitalocean_regions.go
+++ b/digitalocean/datasource_digitalocean_regions.go
@@ -3,29 +3,67 @@ package digitalocean
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+var (
+	dataSourceDigitalOceanRegionsFilterKeys = []string{
+		"slug",
+		"name",
+		"available",
+		"features",
+		"sizes",
+	}
+
+	dataSourceDigitalOceanRegionsSortKeys = []string{
+		"slug",
+		"name",
+		"available",
+	}
+)
+
 func dataSourceDigitalOceanRegions() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceDigitalOceanRegionsRead,
 		Schema: map[string]*schema.Schema{
-			"available": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"features": {
-				Type:     schema.TypeList,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-			},
-			"slugs": {
+			"filter": filterSchema(dataSourceDigitalOceanRegionsFilterKeys),
+			"sort":   sortSchema(dataSourceDigitalOceanRegionsSortKeys),
+
+			"regions": {
 				Type:     schema.TypeSet,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"slug": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sizes": {
+							Type:     schema.TypeSet,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+						},
+						"features": {
+							Type:     schema.TypeSet,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+						},
+						"available": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -34,47 +72,43 @@ func dataSourceDigitalOceanRegions() *schema.Resource {
 func dataSourceDigitalOceanRegionsRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).godoClient()
 
-	regionsBySlug, err := loadRegionsBySlug(client)
+	regionsBySlug, err := getDigitalOceanRegions(client)
 	if err != nil {
 		return fmt.Errorf("Unable to load regions: %s", err)
 	}
 
-	available, filterByAvailable := d.GetOk("available")
-	requiredFeatures, filterByRequiredFeatures := d.GetOk("features")
-
-	filteredRegionSlugs := []string{}
+	regions := make([]godo.Region, len(regionsBySlug))
+	i := 0
 	for _, region := range regionsBySlug {
-		if filterByAvailable && region.Available != available.(bool) {
-			continue
-		}
+		regions[i] = region
+		i += 1
+	}
 
-		if filterByRequiredFeatures {
-			for _, requiredFeature := range requiredFeatures.([]interface{}) {
-				match := false
-				for _, feature := range region.Features {
-					if feature == requiredFeature.(string) {
-						match = true
-					}
-				}
+	if v, ok := d.GetOk("filter"); ok {
+		filters := expandFilters(v.(*schema.Set).List())
+		regions = filterDigitalOceanRegions(regions, filters)
+	}
 
-				if !match {
-					continue
-				}
-			}
-		}
-
-		filteredRegionSlugs = append(filteredRegionSlugs, region.Slug)
+	if v, ok := d.GetOk("sort"); ok {
+		sorts := expandSorts(v.([]interface{}))
+		regions = sortDigitalOceanRegions(regions, sorts)
 	}
 
 	d.SetId(resource.UniqueId())
-	if err := d.Set("slugs", filteredRegionSlugs); err != nil {
-		return fmt.Errorf("Unable to set `slugs` attribute: %s", err)
+
+	flattenedRegions := []map[string]interface{}{}
+	for _, region := range regions {
+		flattenedRegions = append(flattenedRegions, flattenRegion(region))
+	}
+
+	if err := d.Set("regions", flattenedRegions); err != nil {
+		return fmt.Errorf("Unable to set `regions` attribute: %s", err)
 	}
 
 	return nil
 }
 
-func loadRegionsBySlug(client *godo.Client) (map[string]godo.Region, error) {
+func getDigitalOceanRegions(client *godo.Client) (map[string]godo.Region, error) {
 	allRegions := map[string]godo.Region{}
 
 	opts := &godo.ListOptions{
@@ -106,4 +140,112 @@ func loadRegionsBySlug(client *godo.Client) (map[string]godo.Region, error) {
 	}
 
 	return allRegions, nil
+}
+
+func flattenRegion(region godo.Region) map[string]interface{} {
+	flattenedRegion := map[string]interface{}{}
+	flattenedRegion["slug"] = region.Slug
+	flattenedRegion["name"] = region.Name
+	flattenedRegion["available"] = region.Available
+
+	sizesSet := schema.NewSet(schema.HashString, []interface{}{})
+	for _, size := range region.Sizes {
+		sizesSet.Add(size)
+	}
+	flattenedRegion["sizes"] = sizesSet
+
+	featuresSet := schema.NewSet(schema.HashString, []interface{}{})
+	for _, feature := range region.Features {
+		featuresSet.Add(feature)
+	}
+	flattenedRegion["features"] = featuresSet
+
+	return flattenedRegion
+}
+
+func filterDigitalOceanRegions(regions []godo.Region, filters []commonFilter) []godo.Region {
+	for _, f := range filters {
+		// Handle multiple filters by applying them in order
+		var filteredRegions []godo.Region
+
+		// Define the filter strategy based on the filter key
+		filterFunc := func(region godo.Region) bool {
+			result := false
+
+			for _, filterValue := range f.values {
+				switch f.key {
+				case "slug":
+					result = result || strings.EqualFold(filterValue, region.Slug)
+
+				case "name":
+					result = result || strings.EqualFold(filterValue, region.Name)
+
+				case "available":
+					if available, err := strconv.ParseBool(filterValue); err == nil {
+						result = result || available == region.Available
+					}
+
+				case "features":
+					for _, feature := range region.Features {
+						result = result || strings.EqualFold(filterValue, feature)
+					}
+
+				case "sizes":
+					for _, size := range region.Sizes {
+						result = result || strings.EqualFold(filterValue, size)
+					}
+
+				default:
+				}
+			}
+
+			return result
+		}
+
+		for _, region := range regions {
+			if filterFunc(region) {
+				filteredRegions = append(filteredRegions, region)
+			}
+		}
+
+		regions = filteredRegions
+	}
+
+	return regions
+}
+
+func sortDigitalOceanRegions(regions []godo.Region, sorts []commonSort) []godo.Region {
+	sort.Slice(regions, func(_i, _j int) bool {
+		for _, s := range sorts {
+			// Handle multiple sorts by applying them in order
+
+			i := _i
+			j := _j
+			if strings.EqualFold(s.direction, "desc") {
+				// If the direction is desc, reverse index to compare
+				i = _j
+				j = _i
+			}
+
+			switch s.key {
+			case "slug":
+				if regions[i].Slug != regions[j].Slug {
+					return strings.Compare(regions[i].Slug, regions[j].Slug) < 0
+				}
+
+			case "name":
+				if regions[i].Name != regions[j].Name {
+					return strings.Compare(regions[i].Name, regions[j].Name) < 0
+				}
+			case "available":
+				if regions[i].Available != regions[j].Available {
+					return !regions[i].Available && regions[j].Available
+				}
+			}
+		}
+
+		return true
+	})
+
+	return regions
 }

--- a/digitalocean/datasource_digitalocean_regions.go
+++ b/digitalocean/datasource_digitalocean_regions.go
@@ -1,7 +1,6 @@
 package digitalocean
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -106,61 +105,6 @@ func dataSourceDigitalOceanRegionsRead(d *schema.ResourceData, meta interface{})
 	}
 
 	return nil
-}
-
-func getDigitalOceanRegions(client *godo.Client) (map[string]godo.Region, error) {
-	allRegions := map[string]godo.Region{}
-
-	opts := &godo.ListOptions{
-		Page:    1,
-		PerPage: 200,
-	}
-
-	for {
-		regions, resp, err := client.Regions.List(context.Background(), opts)
-
-		if err != nil {
-			return nil, fmt.Errorf("Error retrieving regions: %s", err)
-		}
-
-		for _, region := range regions {
-			allRegions[region.Slug] = region
-		}
-
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, fmt.Errorf("Error retrieving regions: %s", err)
-		}
-
-		opts.Page = page + 1
-	}
-
-	return allRegions, nil
-}
-
-func flattenRegion(region godo.Region) map[string]interface{} {
-	flattenedRegion := map[string]interface{}{}
-	flattenedRegion["slug"] = region.Slug
-	flattenedRegion["name"] = region.Name
-	flattenedRegion["available"] = region.Available
-
-	sizesSet := schema.NewSet(schema.HashString, []interface{}{})
-	for _, size := range region.Sizes {
-		sizesSet.Add(size)
-	}
-	flattenedRegion["sizes"] = sizesSet
-
-	featuresSet := schema.NewSet(schema.HashString, []interface{}{})
-	for _, feature := range region.Features {
-		featuresSet.Add(feature)
-	}
-	flattenedRegion["features"] = featuresSet
-
-	return flattenedRegion
 }
 
 func filterDigitalOceanRegions(regions []godo.Region, filters []commonFilter) []godo.Region {

--- a/digitalocean/datasource_digitalocean_regions_test.go
+++ b/digitalocean/datasource_digitalocean_regions_test.go
@@ -1,9 +1,13 @@
 package digitalocean
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccDigitalOceanRegions_Basic(t *testing.T) {
@@ -56,6 +60,23 @@ data "digitalocean_regions" "filtered" {
 				Config: configNoFilter,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.digitalocean_regions.all", "regions.#"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_regions.all", "regions.#"),
+					testResourceInstanceState("data.digitalocean_regions.all", func(is *terraform.InstanceState) error {
+						n, err := strconv.Atoi(is.Attributes["regions.#"])
+						if err != nil {
+							return err
+						}
+
+						for i := 0; i < n; i++ {
+							key := fmt.Sprintf("regions.%d.available", i)
+							v, ok := is.Attributes[key]
+							if !ok || !strings.EqualFold(v, "true") {
+								return fmt.Errorf("`available` != true for %s in %s", key, "data.digitalocean_regions.all")
+							}
+						}
+
+						return nil
+					}),
 				),
 			},
 			{

--- a/digitalocean/datasource_digitalocean_regions_test.go
+++ b/digitalocean/datasource_digitalocean_regions_test.go
@@ -1,0 +1,62 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDigitalOceanRegions_Basic(t *testing.T) {
+	configNoFilter := `
+data "digitalocean_regions" "all" {
+}
+`
+	configAvailableFilter := `
+data "digitalocean_regions" "filtered" {
+	available = true
+}
+`
+
+	configFeaturesFilter := `
+data "digitalocean_regions" "filtered" {
+	features = ["private_networking", "backups"]
+}
+`
+
+	configAllFilters := `
+data "digitalocean_regions" "filtered" {
+	available = true
+	features = ["private_networking", "backups"]
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: configNoFilter,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.digitalocean_regions.all", "slugs.#"),
+				),
+			},
+			{
+				Config: configAvailableFilter,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.digitalocean_regions.filtered", "slugs.#"),
+				),
+			},
+			{
+				Config: configFeaturesFilter,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.digitalocean_regions.filtered", "slugs.#"),
+				),
+			},
+			{
+				Config: configAllFilters,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.digitalocean_regions.filtered", "slugs.#"),
+				),
+			},
+		},
+	})
+}

--- a/digitalocean/datasource_digitalocean_regions_test.go
+++ b/digitalocean/datasource_digitalocean_regions_test.go
@@ -13,20 +13,39 @@ data "digitalocean_regions" "all" {
 `
 	configAvailableFilter := `
 data "digitalocean_regions" "filtered" {
-	available = true
+	filter {
+        key = "available"
+        values = ["true"]
+    }
+    sort {
+		key = "slug"
+    }
 }
 `
 
 	configFeaturesFilter := `
 data "digitalocean_regions" "filtered" {
-	features = ["private_networking", "backups"]
+	filter {
+        key = "features"
+        values = ["private_networking", "backups"]
+    }
+    sort {
+		key = "available"
+		direction = "desc"
+    }
 }
 `
 
 	configAllFilters := `
 data "digitalocean_regions" "filtered" {
-	available = true
-	features = ["private_networking", "backups"]
+	filter {
+        key = "available"
+        values = ["true"]
+    }
+	filter {
+        key = "features"
+        values = ["private_networking", "backups"]
+    }
 }
 `
 	resource.Test(t, resource.TestCase{
@@ -36,25 +55,25 @@ data "digitalocean_regions" "filtered" {
 			{
 				Config: configNoFilter,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.digitalocean_regions.all", "slugs.#"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_regions.all", "regions.#"),
 				),
 			},
 			{
 				Config: configAvailableFilter,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.digitalocean_regions.filtered", "slugs.#"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_regions.filtered", "regions.#"),
 				),
 			},
 			{
 				Config: configFeaturesFilter,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.digitalocean_regions.filtered", "slugs.#"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_regions.filtered", "regions.#"),
 				),
 			},
 			{
 				Config: configAllFilters,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.digitalocean_regions.filtered", "slugs.#"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_regions.filtered", "regions.#"),
 				),
 			},
 		},

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -51,6 +51,8 @@ func Provider() terraform.ResourceProvider {
 			"digitalocean_kubernetes_versions": dataSourceDigitalOceanKubernetesVersions(),
 			"digitalocean_loadbalancer":        dataSourceDigitalOceanLoadbalancer(),
 			"digitalocean_record":              dataSourceDigitalOceanRecord(),
+			"digitalocean_region":              dataSourceDigitalOceanRegion(),
+			"digitalocean_regions":             dataSourceDigitalOceanRegions(),
 			"digitalocean_sizes":               dataSourceDigitalOceanSizes(),
 			"digitalocean_ssh_key":             dataSourceDigitalOceanSSHKey(),
 			"digitalocean_tag":                 dataSourceDigitalOceanTag(),

--- a/digitalocean/regions.go
+++ b/digitalocean/regions.go
@@ -1,0 +1,64 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func getDigitalOceanRegions(client *godo.Client) (map[string]godo.Region, error) {
+	allRegions := map[string]godo.Region{}
+
+	opts := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	for {
+		regions, resp, err := client.Regions.List(context.Background(), opts)
+
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving regions: %s", err)
+		}
+
+		for _, region := range regions {
+			allRegions[region.Slug] = region
+		}
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving regions: %s", err)
+		}
+
+		opts.Page = page + 1
+	}
+
+	return allRegions, nil
+}
+
+func flattenRegion(region godo.Region) map[string]interface{} {
+	flattenedRegion := map[string]interface{}{}
+	flattenedRegion["slug"] = region.Slug
+	flattenedRegion["name"] = region.Name
+	flattenedRegion["available"] = region.Available
+
+	sizesSet := schema.NewSet(schema.HashString, []interface{}{})
+	for _, size := range region.Sizes {
+		sizesSet.Add(size)
+	}
+	flattenedRegion["sizes"] = sizesSet
+
+	featuresSet := schema.NewSet(schema.HashString, []interface{}{})
+	for _, feature := range region.Features {
+		featuresSet.Add(feature)
+	}
+	flattenedRegion["features"] = featuresSet
+
+	return flattenedRegion
+}

--- a/digitalocean/regions.go
+++ b/digitalocean/regions.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func getDigitalOceanRegions(client *godo.Client) (map[string]godo.Region, error) {
-	allRegions := map[string]godo.Region{}
+func getDigitalOceanRegions(client *godo.Client) ([]godo.Region, error) {
+	allRegions := []godo.Region{}
 
 	opts := &godo.ListOptions{
 		Page:    1,
@@ -24,7 +24,7 @@ func getDigitalOceanRegions(client *godo.Client) (map[string]godo.Region, error)
 		}
 
 		for _, region := range regions {
-			allRegions[region.Slug] = region
+			allRegions = append(allRegions, region)
 		}
 
 		if resp.Links == nil || resp.Links.IsLastPage() {

--- a/digitalocean/schema.go
+++ b/digitalocean/schema.go
@@ -1,0 +1,16 @@
+package digitalocean
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func setResourceDataFromMap(d *schema.ResourceData, m map[string]interface{}) error {
+	for key, value := range m {
+		if err := d.Set(key, value); err != nil {
+			return fmt.Errorf("Unable to set `%s` attribute: %s", key, err)
+		}
+	}
+	return nil
+}

--- a/digitalocean/testing.go
+++ b/digitalocean/testing.go
@@ -1,0 +1,24 @@
+package digitalocean
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func testResourceInstanceState(name string, check func(*terraform.InstanceState) error) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		m := s.RootModule()
+		if rs, ok := m.Resources[name]; ok {
+			is := rs.Primary
+			if is == nil {
+				return fmt.Errorf("No primary instance: %s", name)
+			}
+
+			return check(is)
+		} else {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -24,5 +24,3 @@ replace github.com/keybase/go-crypto v0.0.0-20190523171820-b785b22cc757 => githu
 replace github.com/terraform-providers/terraform-provider-google v2.17.0+incompatible => github.com/terraform-providers/terraform-provider-google v1.20.1-0.20191008212436-363f2d283518
 
 replace github.com/terraform-providers/terraform-provider-aws v2.32.0+incompatible => github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20191010190908-1261a98537f2
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -24,3 +24,5 @@ replace github.com/keybase/go-crypto v0.0.0-20190523171820-b785b22cc757 => githu
 replace github.com/terraform-providers/terraform-provider-google v2.17.0+incompatible => github.com/terraform-providers/terraform-provider-google v1.20.1-0.20191008212436-363f2d283518
 
 replace github.com/terraform-providers/terraform-provider-aws v2.32.0+incompatible => github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20191010190908-1261a98537f2
+
+go 1.13

--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -49,6 +49,12 @@
             <li<%= sidebar_current("docs-do-datasource-record") %>>
               <a href="/docs/providers/do/d/record.html">digitalocean_record</a>
             </li>
+            <li<%= sidebar_current("docs-do-datasource-region") %>>
+              <a href="/docs/providers/do/d/record.html">digitalocean_region</a>
+            </li>
+            <li<%= sidebar_current("docs-do-datasource-regions") %>>
+              <a href="/docs/providers/do/d/record.html">digitalocean_regions</a>
+            </li>
             <li<%= sidebar_current("docs-do-datasource-sizes") %>>
               <a href="/docs/providers/do/d/sizes.html">digitalocean_sizes</a>
             </li>

--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -50,10 +50,10 @@
               <a href="/docs/providers/do/d/record.html">digitalocean_record</a>
             </li>
             <li<%= sidebar_current("docs-do-datasource-region") %>>
-              <a href="/docs/providers/do/d/record.html">digitalocean_region</a>
+              <a href="/docs/providers/do/d/region.html">digitalocean_region</a>
             </li>
             <li<%= sidebar_current("docs-do-datasource-regions") %>>
-              <a href="/docs/providers/do/d/record.html">digitalocean_regions</a>
+              <a href="/docs/providers/do/d/regions.html">digitalocean_regions</a>
             </li>
             <li<%= sidebar_current("docs-do-datasource-sizes") %>>
               <a href="/docs/providers/do/d/sizes.html">digitalocean_sizes</a>

--- a/website/docs/d/region.html.md
+++ b/website/docs/d/region.html.md
@@ -1,0 +1,36 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_region"
+sidebar_current: "docs-do-datasource-region"
+description: |-
+  Get information on a DigitalOcean region.
+---
+
+# digitalocean_region
+
+Get information on a single DigitalOcean region. This is useful to find out 
+what Droplet sizes and features are supported within a region.
+
+## Example Usage
+
+```hcl
+data "digitalocean_region" "sfo2" {
+  slug = "sfo2"
+} 
+
+output "region_name" {
+  value = data.digitalocean_region.sfo2.name
+}
+```
+
+## Argument Reference
+
+* `slug` - (Required) A human-readable string that is used as a unique identifier for each region.
+
+## Attributes Reference
+
+* `slug` - A human-readable string that is used as a unique identifier for each region.
+* `name` - The display name of the region.
+* `available` -	A boolean value that represents whether new Droplets can be created in this region.
+* `sizes` - A list of identifying slugs for the Droplet sizes available in this region.
+* `features` - A list of features available in this region.

--- a/website/docs/d/regions.html.md
+++ b/website/docs/d/regions.html.md
@@ -8,30 +8,71 @@ description: |-
 
 # digitalocean_regions
 
-Get identifiers for all or a filtered subset of DigitalOcean regions. The regions
-can be filtered using the `available` and/or `features` attributes. If no filters
-are specified, all regions will be returned.
+Retrieve information about all supported DigitalOcean regions, with the ability to
+filter and sort the results. If no filters are specified, all regions will be returned.
 
-Note: Use the `digitalocean_region` data source to obtain metadata about a single
-region.
+Note: You can use the `digitalocean_region` data source to obtain metadata about a single
+region if you already know the `slug` to retrieve.
 
 ## Example Usage
 
+Use the `filter` block with a `key` string and `values` list to filter regions.
+
+For example to find all available regions:
+
 ```hcl
 data "digitalocean_regions" "available" {
-  available = true
+  filter {
+    key = "available"
+    values = ["true"]
+  }
 } 
+```
 
-output "available_regions" {
-  value = data.digitalocean_regions.slugs
+You can filter on multiple fields and sort the results as well:
+
+```hcl
+data "digitalocean_regions" "available" {
+  filter {
+    key = "available"
+    values = ["true"]
+  }
+  filter {
+    key = "features"
+    values = ["private_networking"]
+  }
+  sort {
+    key = "name"
+    direction = "desc"
+  }
 }
 ```
 
 ## Argument Reference
 
-* `available` - (Optional) A boolean that filters the list of regions by whether or not new Droplets can be created
-* `features` - (Optional) A list of features required to be supported by matching regions  
+* `filter` - (Optional) Filter the results.
+  The `filter` block is documented below.
+* `sort` - (Optional) Sort the results.
+  The `sort` block is documented below.
+
+`filter` supports the following:
+* `key` - (Required) Filter the regions by this key. This may be one of `slug`,
+  `name`, `available`, `features`, or `sizes`.
+
+* `values` - (Required) A list of values to match against the `key` field. Only retrieves regions
+  where the `key` field takes on one or more of the values provided here.
+
+`sort` supports the following:
+
+* `key` - (Required) Sort the regions by this key. This may be one of `slug`,
+`name`, or `available`.
+* `direction` - (Required) The sort direction. This may be either `asc` or `desc`.
 
 ## Attributes Reference
 
-* `slugs` - A list of human-readable strings that are the unique identifier for each matching region. 
+* `regions` - A set of regions satisfying any `filter` and `sort` criteria. Each region has the following attributes:  
+  - `slug` - A human-readable string that is used as a unique identifier for each region.
+  - `name` - The display name of the region.
+  - `available` -	A boolean value that represents whether new Droplets can be created in this region.
+  - `sizes` - A list of identifying slugs for the Droplet sizes available in this region.
+  - `features` - A list of features available in this region.

--- a/website/docs/d/regions.html.md
+++ b/website/docs/d/regions.html.md
@@ -1,0 +1,37 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_regions"
+sidebar_current: "docs-do-datasource-regions"
+description: |-
+  Get identifiers for all or a filtered subset of DigitalOcean regions.
+---
+
+# digitalocean_regions
+
+Get identifiers for all or a filtered subset of DigitalOcean regions. The regions
+can be filtered using the `available` and/or `features` attributes. If no filters
+are specified, all regions will be returned.
+
+Note: Use the `digitalocean_region` data source to obtain metadata about a single
+region.
+
+## Example Usage
+
+```hcl
+data "digitalocean_regions" "available" {
+  available = true
+} 
+
+output "available_regions" {
+  value = data.digitalocean_regions.slugs
+}
+```
+
+## Argument Reference
+
+* `available` - (Optional) A boolean that filters the list of regions by whether or not new Droplets can be created
+* `features` - (Optional) A list of features required to be supported by matching regions  
+
+## Attributes Reference
+
+* `slugs` - A list of human-readable strings that are the unique identifier for each matching region. 

--- a/website/docs/d/regions.html.md
+++ b/website/docs/d/regions.html.md
@@ -3,7 +3,7 @@ layout: "digitalocean"
 page_title: "DigitalOcean: digitalocean_regions"
 sidebar_current: "docs-do-datasource-regions"
 description: |-
-  Get identifiers for all or a filtered subset of DigitalOcean regions.
+  Retrieve metadata about DigitalOcean regions.
 ---
 
 # digitalocean_regions


### PR DESCRIPTION
Add `digitalocean_regions` and `digitalocean_region` data sources. `digitalocean_regions` allows filtering by whether a region is available and the features present in the region. `digitalocean_region` returns metadata on a single region.

This is intended to supersede https://github.com/terraform-providers/terraform-provider-digitalocean/pull/281.