### PR TITLE
Make DBaaS version required due to DigitalOcean API changes.

### DIFF
--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -41,7 +41,7 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				// Maintain support for clusters created using defualt version
+				// Maintain support for clusters created using default version
 				// that is not set explicitly in a config.
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return new == ""

--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -40,8 +40,10 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 
 			"version": {
 				Type: schema.TypeString,
-				// In practice, this is required
-				// See transitionVersionToRequired CustomizeDiffFunc
+				// TODO: Finalize transition to being required.
+				// In practice, this is already required. The transitionVersionToRequired
+				// CustomizeDiffFunc is used to provide users with a better hint in the error message.
+				// Required: true,
 				Optional: true,
 				ForceNew: true,
 			},

--- a/digitalocean/resource_digitalocean_database_cluster.go
+++ b/digitalocean/resource_digitalocean_database_cluster.go
@@ -41,6 +41,11 @@ func resourceDigitalOceanDatabaseCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				// Maintain support for clusters created using defualt version
+				// that is not set explicitly in a config.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return new == ""
+				},
 			},
 
 			"size": {

--- a/digitalocean/resource_digitalocean_database_cluster_test.go
+++ b/digitalocean/resource_digitalocean_database_cluster_test.go
@@ -202,27 +202,8 @@ func TestAccDigitalOceanDatabaseCluster_RedisNoVersion(t *testing.T) {
 						"digitalocean_database_cluster.foobar", "name", databaseName),
 					resource.TestCheckResourceAttr(
 						"digitalocean_database_cluster.foobar", "engine", "redis"),
-					resource.TestCheckResourceAttrSet(
-						"digitalocean_database_cluster.foobar", "host"),
-					resource.TestCheckResourceAttrSet(
-						"digitalocean_database_cluster.foobar", "port"),
-					resource.TestCheckResourceAttrSet(
-						"digitalocean_database_cluster.foobar", "user"),
-					resource.TestCheckResourceAttrSet(
-						"digitalocean_database_cluster.foobar", "password"),
-					resource.TestCheckResourceAttrSet(
-						"digitalocean_database_cluster.foobar", "urn"),
 				),
-			},
-			// Add eviction policy when not initially set
-			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterConfigWithEvictionPolicyUpdate, databaseName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
-					testAccCheckDigitalOceanDatabaseClusterAttributes(&database, databaseName),
-					resource.TestCheckResourceAttr(
-						"digitalocean_database_cluster.foobar", "eviction_policy", "allkeys_lru"),
-				),
+				ExpectError: regexp.MustCompile(`The argument "version" is required, but no definition was found.`),
 			},
 		},
 	})
@@ -259,7 +240,7 @@ func TestAccDigitalOceanDatabaseCluster_RedisWithEvictionPolicy(t *testing.T) {
 			},
 			// Remove eviction policy
 			{
-				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterRedisNoVersion, databaseName),
+				Config: fmt.Sprintf(testAccCheckDigitalOceanDatabaseClusterRedis, databaseName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDatabaseClusterExists("digitalocean_database_cluster.foobar", &database),
 					testAccCheckDigitalOceanDatabaseClusterAttributes(&database, databaseName),
@@ -459,6 +440,17 @@ const testAccCheckDigitalOceanDatabaseClusterRedisNoVersion = `
 resource "digitalocean_database_cluster" "foobar" {
 	name       = "%s"
 	engine     = "redis"
+	size       = "db-s-1vcpu-1gb"
+	region     = "nyc1"
+    node_count = 1
+	tags       = ["production"]
+}`
+
+const testAccCheckDigitalOceanDatabaseClusterRedis = `
+resource "digitalocean_database_cluster" "foobar" {
+	name       = "%s"
+	engine     = "redis"
+	version    = "5"
 	size       = "db-s-1vcpu-1gb"
 	region     = "nyc1"
     node_count = 1

--- a/website/docs/r/database_cluster.html.markdown
+++ b/website/docs/r/database_cluster.html.markdown
@@ -29,6 +29,7 @@ resource "digitalocean_database_cluster" "postgres-example" {
 resource "digitalocean_database_cluster" "mysql-example" {
   name       = "example-mysql-cluster"
   engine     = "mysql"
+  version    = "8"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1
@@ -40,6 +41,7 @@ resource "digitalocean_database_cluster" "mysql-example" {
 resource "digitalocean_database_cluster" "redis-example" {
   name       = "example-redis-cluster"
   engine     = "redis"
+  version    = "5"
   size       = "db-s-1vcpu-1gb"
   region     = "nyc1"
   node_count = 1

--- a/website/docs/r/database_cluster.html.markdown
+++ b/website/docs/r/database_cluster.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `size` - (Required) Database Droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`).
 * `region` - (Required) DigitalOcean region where the cluster will reside.
 * `node_count` - (Required) Number of nodes that will be included in the cluster.
-* `version` - (Optional) Engine version used by the cluster (ex. `11` for PostgreSQL 11).
+* `version` - (Required) Engine version used by the cluster (ex. `11` for PostgreSQL 11).
 * `tags` - (Optional) A list of tag names to be applied to the database cluster.
 * `eviction_policy` - (Optional) A string specifying the eviction policy for a Redis cluster. Valid values are: `noeviction`, `allkeys_lru`, `allkeys_random`, `volatile_lru`, `volatile_random`, or `volatile_ttl`.
 * `sql_mode` - (Optional) A comma separated string specifying the  SQL modes for a MySQL cluster.


### PR DESCRIPTION
Previously, the DigitalOcean API only returned a version number for Postgres clusters. More recently, it has begun returning them for both Redis and MySQL ones as well. Creating a cluster without explicitly setting a version will use DigitalOcean's default. This change makes it so that does not return a diff when the resource is refreshed.

Successful test with this change applied:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDatabaseCluster_RedisNoVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDatabaseCluster_RedisNoVersion -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDatabaseCluster_RedisNoVersion
--- PASS: TestAccDigitalOceanDatabaseCluster_RedisNoVersion (365.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	365.106s
```

Failure before this change:

```
$ make testacc TESTARGS='-run=TestAccDigitalOceanDatabaseCluster_RedisNoVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDigitalOceanDatabaseCluster_RedisNoVersion -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDatabaseCluster_RedisNoVersion
--- FAIL: TestAccDigitalOceanDatabaseCluster_RedisNoVersion (363.94s)
    testing.go:640: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: digitalocean_database_cluster.foobar
          database:             "" => "<computed>"
          engine:               "redis" => "redis"
          host:                 "tf-acc-test-u3trulcdlf-do-user-3100395-0.db.ondigitalocean.com" => "<computed>"
          id:                   "fda631a1-a871-4d19-be4e-27ba8dd40c79" => "<computed>"
          maintenance_window.#: "0" => "0"
          name:                 "tf-acc-test-u3trulcdlf" => "tf-acc-test-u3trulcdlf"
          node_count:           "1" => "1"
          password:             "foo" => "<computed>"
          port:                 "25061" => "<computed>"
          private_host:         "private-tf-acc-test-u3trulcdlf-do-user-3100395-0.db.ondigitalocean.com" => "<computed>"
          private_uri:          "rediss://default:foo@private-tf-acc-test-u3trulcdlf-do-user-3100395-0.db.ondigitalocean.com:25061" => "<computed>"
          region:               "nyc1" => "nyc1"
          size:                 "db-s-1vcpu-1gb" => "db-s-1vcpu-1gb"
          tags.#:               "1" => "1"
          tags.0:               "production" => "production"
          uri:                  "rediss://default:foo@tf-acc-test-u3trulcdlf-do-user-3100395-0.db.ondigitalocean.com:25061" => "<computed>"
          urn:                  "do:dbaas:fda631a1-a871-4d19-be4e-27ba8dd40c79" => "<computed>"
          user:                 "default" => "<computed>"
          version:              "5" => "" (forces new resource)
        
        
        
        STATE:
        
        digitalocean_database_cluster.foobar:
          ID = fda631a1-a871-4d19-be4e-27ba8dd40c79
          provider = provider.digitalocean
          database = 
          engine = redis
          host = tf-acc-test-u3trulcdlf-do-user-3100395-0.db.ondigitalocean.com
          name = tf-acc-test-u3trulcdlf
          node_count = 1
          password = foo
          port = 25061
          private_host = private-tf-acc-test-u3trulcdlf-do-user-3100395-0.db.ondigitalocean.com
          private_uri = rediss://default:foo@private-tf-acc-test-u3trulcdlf-do-user-3100395-0.db.ondigitalocean.com:25061
          region = nyc1
          size = db-s-1vcpu-1gb
          tags.# = 1
          tags.0 = production
          uri = rediss://default:foo@tf-acc-test-u3trulcdlf-do-user-3100395-0.db.ondigitalocean.com:25061
          urn = do:dbaas:fda631a1-a871-4d19-be4e-27ba8dd40c79
          user = default
          version = 5
FAIL
FAIL	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	363.960s
FAIL
make: *** [GNUmakefile:18: testacc] Error 1
```