### PR TITLE
Require that volume names be lowercase and alphanumeric

### DIFF
--- a/digitalocean/resource_digitalocean_volume.go
+++ b/digitalocean/resource_digitalocean_volume.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/digitalocean/godo"
@@ -36,7 +37,7 @@ func resourceDigitalOceanVolume() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.NoZeroValues,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9]+$`), "Names must be lowercase and alphanumeric"),
 			},
 			"urn": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
I tried to create a volume. Terraform failed with:
```
Error: Error creating Volume: POST https://api.digitalocean.com/v2/volumes: 422 (request "a1952cf3-2088-4e8d-802d-xxxxx") failed to create volume: invalid volume name. names must be lowercase and alphanumeric
```
