### PR TITLE
add datasource for projects

### DIFF
--- a/digitalocean/datasource_digitalocean_project.go
+++ b/digitalocean/datasource_digitalocean_project.go
@@ -3,64 +3,28 @@ package digitalocean
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func dataSourceDigitalOceanProject() *schema.Resource {
+	recordSchema := projectSchema()
+
+	for _, f := range recordSchema {
+		f.Computed = true
+	}
+
+	recordSchema["id"].ConflictsWith = []string{"name"}
+	recordSchema["id"].Optional = true
+	recordSchema["id"].Computed = false
+	recordSchema["name"].ConflictsWith = []string{"id"}
+	recordSchema["name"].Optional = true
+	recordSchema["name"].Computed = false
+
 	return &schema.Resource{
-		Read: dataSourceDigitalOceanProjectRead,
-		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"purpose": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"environment": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"owner_uuid": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"owner_id": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"is_default": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"created_at": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "the date and time when the project was created, (ISO8601)",
-			},
-			"updated_at": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "the date and time when the project was last updated, (ISO8601)",
-			},
-			"resources": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-		},
+		Read:   dataSourceDigitalOceanProjectRead,
+		Schema: recordSchema,
 	}
 }
 
@@ -75,6 +39,26 @@ func dataSourceDigitalOceanProjectRead(d *schema.ResourceData, meta interface{})
 			return fmt.Errorf("Unable to load project ID %s: %s", projectId, err)
 		}
 		project = thisProject
+	} else if name, ok := d.GetOk("name"); ok {
+		projects, err := getDigitalOceanProjects(client)
+		if err != nil {
+			return fmt.Errorf("Unable to load projects: %s", err)
+		}
+
+		var projectsWithName []*godo.Project
+		for _, project := range projects {
+			if project.Name == name {
+				projectsWithName = append(projectsWithName, project)
+			}
+		}
+		if len(projectsWithName) == 0 {
+			return fmt.Errorf("No projects found with name '%s'", name)
+		} else if len(projectsWithName) > 1 {
+			return fmt.Errorf("Multiple projects found with name '%s'", name)
+		}
+
+		// Single result so choose that project.
+		project = projects[0]
 	} else {
 		defaultProject, _, err := client.Projects.GetDefault(context.Background())
 		if err != nil {
@@ -83,47 +67,15 @@ func dataSourceDigitalOceanProjectRead(d *schema.ResourceData, meta interface{})
 		project = defaultProject
 	}
 
-	if err := d.Set("id", project.ID); err != nil {
-		return fmt.Errorf("Unable to set `id` attribute: %s", err)
-	}
-	if err := d.Set("name", project.Name); err != nil {
-		return fmt.Errorf("Unable to set `name` attribute: %s", err)
-	}
-	if err := d.Set("purpose", strings.TrimPrefix(project.Purpose, "Other: ")); err != nil {
-		return fmt.Errorf("Unable to set `purpose` attribute: %s", err)
-	}
-	if err := d.Set("description", project.Description); err != nil {
-		return fmt.Errorf("Unable to set `description` attribute: %s", err)
-	}
-	if err := d.Set("environment", project.Environment); err != nil {
-		return fmt.Errorf("Unable to set `environment` attribute: %s", err)
-	}
-	if err := d.Set("owner_uuid", project.OwnerUUID); err != nil {
-		return fmt.Errorf("Unable to set `owner_uuid` attribute: %s", err)
-	}
-	if err := d.Set("owner_id", project.OwnerID); err != nil {
-		return fmt.Errorf("Unable to set `owner_id` attribute: %s", err)
-	}
-	if err := d.Set("is_default", project.IsDefault); err != nil {
-		return fmt.Errorf("Unable to set `is_default` attribute: %s", err)
-	}
-	if err := d.Set("created_at", project.CreatedAt); err != nil {
-		return fmt.Errorf("Unable to set `created_at` attribute: %s", err)
-	}
-	if err := d.Set("updated_at", project.UpdatedAt); err != nil {
-		return fmt.Errorf("Unable to set `updated_at` attribute: %s", err)
-	}
-
-	urns, err := loadResourceURNs(client, project.ID)
+	flattenedProject, err := flattenDigitalOceanProject(project, meta)
 	if err != nil {
-		return fmt.Errorf("Error loading project resource URNs: %s", err)
+		return err
 	}
 
-	if err := d.Set("resources", urns); err != nil {
-		return fmt.Errorf("Unable to set `resources` attribute: %s", err)
+	if err := setResourceDataFromMap(d, flattenedProject); err != nil {
+		return err
 	}
 
 	d.SetId(project.ID)
-
 	return nil
 }

--- a/digitalocean/datasource_digitalocean_project.go
+++ b/digitalocean/datasource_digitalocean_project.go
@@ -1,0 +1,129 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceDigitalOceanProject() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDigitalOceanProjectRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"purpose": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"environment": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner_uuid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"is_default": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "the date and time when the project was created, (ISO8601)",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "the date and time when the project was last updated, (ISO8601)",
+			},
+			"resources": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceDigitalOceanProjectRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+
+	// Load the specified project, otherwise load the default project.
+	var project *godo.Project
+	if projectId, ok := d.GetOk("id"); ok {
+		thisProject, _, err := client.Projects.Get(context.Background(), projectId.(string))
+		if err != nil {
+			return fmt.Errorf("Unable to load project ID %s: %s", projectId, err)
+		}
+		project = thisProject
+	} else {
+		defaultProject, _, err := client.Projects.GetDefault(context.Background())
+		if err != nil {
+			return fmt.Errorf("Unable to load default project: %s", err)
+		}
+		project = defaultProject
+	}
+
+	if err := d.Set("id", project.ID); err != nil {
+		return fmt.Errorf("Unable to set `id` attribute: %s", err)
+	}
+	if err := d.Set("name", project.Name); err != nil {
+		return fmt.Errorf("Unable to set `name` attribute: %s", err)
+	}
+	if err := d.Set("purpose", strings.TrimPrefix(project.Purpose, "Other: ")); err != nil {
+		return fmt.Errorf("Unable to set `purpose` attribute: %s", err)
+	}
+	if err := d.Set("description", project.Description); err != nil {
+		return fmt.Errorf("Unable to set `description` attribute: %s", err)
+	}
+	if err := d.Set("environment", project.Environment); err != nil {
+		return fmt.Errorf("Unable to set `environment` attribute: %s", err)
+	}
+	if err := d.Set("owner_uuid", project.OwnerUUID); err != nil {
+		return fmt.Errorf("Unable to set `owner_uuid` attribute: %s", err)
+	}
+	if err := d.Set("owner_id", project.OwnerID); err != nil {
+		return fmt.Errorf("Unable to set `owner_id` attribute: %s", err)
+	}
+	if err := d.Set("is_default", project.IsDefault); err != nil {
+		return fmt.Errorf("Unable to set `is_default` attribute: %s", err)
+	}
+	if err := d.Set("created_at", project.CreatedAt); err != nil {
+		return fmt.Errorf("Unable to set `created_at` attribute: %s", err)
+	}
+	if err := d.Set("updated_at", project.UpdatedAt); err != nil {
+		return fmt.Errorf("Unable to set `updated_at` attribute: %s", err)
+	}
+
+	urns, err := loadResourceURNs(client, project.ID)
+	if err != nil {
+		return fmt.Errorf("Error loading project resource URNs: %s", err)
+	}
+
+	if err := d.Set("resources", urns); err != nil {
+		return fmt.Errorf("Unable to set `resources` attribute: %s", err)
+	}
+
+	d.SetId(project.ID)
+
+	return nil
+}

--- a/digitalocean/datasource_digitalocean_project.go
+++ b/digitalocean/datasource_digitalocean_project.go
@@ -38,7 +38,7 @@ func dataSourceDigitalOceanProjectRead(d *schema.ResourceData, meta interface{})
 		}
 		foundProject = thisProject
 	} else if name, ok := d.GetOk("name"); ok {
-		projects, err := getDigitalOceanProjects(client)
+		projects, err := getDigitalOceanProjects(meta)
 		if err != nil {
 			return fmt.Errorf("Unable to load projects: %s", err)
 		}

--- a/digitalocean/datasource_digitalocean_project.go
+++ b/digitalocean/datasource_digitalocean_project.go
@@ -17,10 +17,8 @@ func dataSourceDigitalOceanProject() *schema.Resource {
 
 	recordSchema["id"].ConflictsWith = []string{"name"}
 	recordSchema["id"].Optional = true
-	recordSchema["id"].Computed = false
 	recordSchema["name"].ConflictsWith = []string{"id"}
 	recordSchema["name"].Optional = true
-	recordSchema["name"].Computed = false
 
 	return &schema.Resource{
 		Read:   dataSourceDigitalOceanProjectRead,

--- a/digitalocean/datasource_digitalocean_project_test.go
+++ b/digitalocean/datasource_digitalocean_project_test.go
@@ -1,6 +1,7 @@
 package digitalocean
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -28,15 +29,17 @@ data "digitalocean_project" "default" {
 }
 
 func TestAccDataSourceDigitalOceanProject_NonDefaultProject(t *testing.T) {
-	config := `
+	nonDefaultProjectName := randomName("tf-acc-project-", 6)
+	config := fmt.Sprintf(`
 resource "digitalocean_project" "foo" {
-	name = "Non-default project"
+	name = "%s"
 }
 
 data "digitalocean_project" "bar" {
   	id = digitalocean_project.foo.id
 }
-`
+`, nonDefaultProjectName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -47,7 +50,7 @@ data "digitalocean_project" "bar" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.digitalocean_project.bar", "id"),
 					resource.TestCheckResourceAttr("data.digitalocean_project.bar", "is_default", "false"),
-					resource.TestCheckResourceAttr("data.digitalocean_project.bar", "name", "Non-default project"),
+					resource.TestCheckResourceAttr("data.digitalocean_project.bar", "name", nonDefaultProjectName),
 				),
 			},
 		},

--- a/digitalocean/datasource_digitalocean_project_test.go
+++ b/digitalocean/datasource_digitalocean_project_test.go
@@ -1,0 +1,55 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceDigitalOceanProject_DefaultProject(t *testing.T) {
+	config := `
+data "digitalocean_project" "default" {
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.digitalocean_project.default", "id"),
+					resource.TestCheckResourceAttrSet("data.digitalocean_project.default", "name"),
+					resource.TestCheckResourceAttr("data.digitalocean_project.default", "is_default", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDigitalOceanProject_NonDefaultProject(t *testing.T) {
+	config := `
+resource "digitalocean_project" "foo" {
+	name = "Non-default project"
+}
+
+data "digitalocean_project" "bar" {
+  	id = digitalocean_project.foo.id
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.digitalocean_project.bar", "id"),
+					resource.TestCheckResourceAttr("data.digitalocean_project.bar", "is_default", "false"),
+					resource.TestCheckResourceAttr("data.digitalocean_project.bar", "name", "Non-default project"),
+				),
+			},
+		},
+	})
+}

--- a/digitalocean/datasource_digitalocean_project_test.go
+++ b/digitalocean/datasource_digitalocean_project_test.go
@@ -40,9 +40,9 @@ data "digitalocean_project" "bar" {
 }
 
 data "digitalocean_project" "barfoo" {
-    name = "%s"
+    name = digitalocean_project.foo.name
 }
-`, nonDefaultProjectName, nonDefaultProjectName)
+`, nonDefaultProjectName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/digitalocean/datasource_digitalocean_project_test.go
+++ b/digitalocean/datasource_digitalocean_project_test.go
@@ -38,7 +38,11 @@ resource "digitalocean_project" "foo" {
 data "digitalocean_project" "bar" {
   	id = digitalocean_project.foo.id
 }
-`, nonDefaultProjectName)
+
+data "digitalocean_project" "barfoo" {
+    name = "%s"
+}
+`, nonDefaultProjectName, nonDefaultProjectName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -51,6 +55,8 @@ data "digitalocean_project" "bar" {
 					resource.TestCheckResourceAttrSet("data.digitalocean_project.bar", "id"),
 					resource.TestCheckResourceAttr("data.digitalocean_project.bar", "is_default", "false"),
 					resource.TestCheckResourceAttr("data.digitalocean_project.bar", "name", nonDefaultProjectName),
+					resource.TestCheckResourceAttr("data.digitalocean_project.barfoo", "is_default", "false"),
+					resource.TestCheckResourceAttr("data.digitalocean_project.barfoo", "name", nonDefaultProjectName),
 				),
 			},
 		},

--- a/digitalocean/datasource_digitalocean_projects.go
+++ b/digitalocean/datasource_digitalocean_projects.go
@@ -1,272 +1,42 @@
 package digitalocean
 
 import (
-	"context"
-	"fmt"
-	"log"
-	"sort"
-	"strconv"
-	"strings"
-
-	"github.com/digitalocean/godo"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-)
-
-var (
-	digitalOceanProjectsFilterKeys = []string{
-		"name",
-		"purpose",
-		"description",
-		"environment",
-		"is_default",
-	}
-
-	digitalOceanProjectsSortKeys = []string{
-		"name",
-		"purpose",
-		"description",
-		"environment",
-	}
+	"github.com/terraform-providers/terraform-provider-digitalocean/internal/datalist"
 )
 
 func dataSourceDigitalOceanProjects() *schema.Resource {
-	return &schema.Resource{
-		Read: dataSourceDigitalOceanProjectsRead,
-		Schema: map[string]*schema.Schema{
-			"filter": filterSchema(digitalOceanProjectsFilterKeys),
-			"sort":   sortSchema(digitalOceanProjectsSortKeys),
-			"projects": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"description": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"purpose": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"environment": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"owner_uuid": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"owner_id": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"is_default": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"created_at": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "the date and time when the project was created, (ISO8601)",
-						},
-						"updated_at": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "the date and time when the project was last updated, (ISO8601)",
-						},
-						//"resources": {
-						//	Type:     schema.TypeSet,
-						//	Computed: true,
-						//	Elem:     &schema.Schema{Type: schema.TypeString},
-						//},
-					},
-				},
-			},
+	dataListConfig := &datalist.ResourceConfig{
+		RecordSchema: projectSchema(),
+		FilterKeys: []string{
+			"name",
+			"purpose",
+			"description",
+			"environment",
+			"is_default",
+		},
+		SortKeys: []string{
+			"name",
+			"purpose",
+			"description",
+			"environment",
+		},
+		ResultAttributeName: "projects",
+		FlattenRecord:       flattenDigitalOceanProject,
+		GetRecords: func(meta interface{}) ([]interface{}, error) {
+			client := meta.(*CombinedConfig).godoClient()
+			projects, err := getDigitalOceanProjects(client)
+			if err == nil {
+				var rawProjects []interface{}
+				for _, project := range projects {
+					rawProjects = append(rawProjects, project)
+				}
+				return rawProjects, nil
+			} else {
+				return nil, err
+			}
 		},
 	}
-}
 
-func getDigitalOceanProjects(client *godo.Client) ([]*godo.Project, error) {
-	allProjects := []*godo.Project{}
-
-	opts := &godo.ListOptions{
-		Page:    1,
-		PerPage: 200,
-	}
-
-	for {
-		projects, resp, err := client.Projects.List(context.Background(), opts)
-
-		if err != nil {
-			return nil, fmt.Errorf("Error retrieving projects: %s", err)
-		}
-
-		for _, project := range projects {
-			allProjects = append(allProjects, &project)
-		}
-
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, fmt.Errorf("Error retrieving projects: %s", err)
-		}
-
-		opts.Page = page + 1
-	}
-
-	return allProjects, nil
-}
-
-func dataSourceDigitalOceanProjectsRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*CombinedConfig).godoClient()
-
-	projects, err := getDigitalOceanProjects(client)
-	if err != nil {
-		return err
-	}
-	log.Printf("projects = %+v", projects)
-
-	if v, ok := d.GetOk("filter"); ok {
-		filters := expandFilters(v.(*schema.Set).List())
-		log.Printf("filters = %+v", filters)
-		log.Printf("projects (before filter) = %+v", projects)
-		projects = filterDigitalOceanProjects(projects, filters)
-		log.Printf("projects (after filter) = %+v", projects)
-	}
-
-	if v, ok := d.GetOk("sort"); ok {
-		sorts := expandSorts(v.([]interface{}))
-		log.Printf("sorts = %+v", sorts)
-		log.Printf("projects (before sort) = %+v", projects)
-		projects = sortDigitalOceanProjects(projects, sorts)
-		log.Printf("projects (after sort) = %+v", projects)
-	}
-
-	d.SetId(resource.UniqueId())
-
-	flattenedProjects := make([]map[string]interface{}, len(projects))
-	for i, project := range projects {
-		flattenedProjects[i] = flattenProject(project)
-	}
-
-	if err := d.Set("projects", flattenedProjects); err != nil {
-		return fmt.Errorf("Unable to set `project_ids` attribute: %s", err)
-	}
-
-	return nil
-}
-
-func flattenProject(project *godo.Project) map[string]interface{} {
-	flattenedProject := map[string]interface{}{}
-
-	flattenedProject["id"] = project.ID
-	flattenedProject["name"] = project.Name
-	flattenedProject["description"] = project.Description
-	flattenedProject["purpose"] = project.Purpose
-	flattenedProject["environment"] = project.Environment
-	flattenedProject["owner_uuid"] = project.OwnerUUID
-	flattenedProject["owner_id"] = project.OwnerID
-	flattenedProject["created_at"] = project.CreatedAt
-	flattenedProject["updated_at"] = project.UpdatedAt
-	flattenedProject["is_default"] = project.IsDefault
-
-	return flattenedProject
-}
-
-func filterDigitalOceanProjects(projects []*godo.Project, filters []commonFilter) []*godo.Project {
-	for _, f := range filters {
-		var filteredProjects []*godo.Project
-
-		filterFunc := func(project *godo.Project) bool {
-			result := false
-
-			for _, filterValue := range f.values {
-				switch f.key {
-				case "name":
-					result = result || strings.EqualFold(filterValue, project.Name)
-
-				case "purpose":
-					result = result || strings.EqualFold(filterValue, project.Purpose)
-
-				case "description":
-					result = result || strings.EqualFold(filterValue, project.Description)
-
-				case "environment":
-					result = result || strings.EqualFold(filterValue, project.Environment)
-
-				case "is_default":
-					if isDefault, err := strconv.ParseBool(filterValue); err == nil {
-						result = result || isDefault == project.IsDefault
-					}
-				default:
-				}
-			}
-
-			return result
-		}
-
-		for _, project := range projects {
-			if filterFunc(project) {
-				filteredProjects = append(filteredProjects, project)
-			}
-		}
-
-		projects = filteredProjects
-	}
-
-	return projects
-}
-
-func sortDigitalOceanProjects(projects []*godo.Project, sorts []commonSort) []*godo.Project {
-	sort.Slice(projects, func(_i, _j int) bool {
-		for _, s := range sorts {
-			// Handle multiple sorts by applying them in order
-
-			i := _i
-			j := _j
-			if strings.EqualFold(s.direction, "desc") {
-				// If the direction is desc, reverse index to compare
-				i = _j
-				j = _i
-			}
-
-			switch s.key {
-			case "name":
-				if !strings.EqualFold(projects[i].Name, projects[j].Name) {
-					return strings.Compare(projects[i].Name, projects[j].Name) <= 0
-				}
-
-			case "purpose":
-				if !strings.EqualFold(projects[i].Purpose, projects[j].Purpose) {
-					return strings.Compare(projects[i].Purpose, projects[j].Purpose) <= 0
-				}
-
-			case "description":
-				if !strings.EqualFold(projects[i].Description, projects[j].Description) {
-					return strings.Compare(projects[i].Description, projects[j].Description) <= 0
-				}
-
-			case "environment":
-				if !strings.EqualFold(projects[i].Environment, projects[j].Environment) {
-					return strings.Compare(projects[i].Environment, projects[j].Environment) <= 0
-				}
-			}
-		}
-
-		return true
-	})
-
-	return projects
+	return datalist.NewResource(dataListConfig)
 }

--- a/digitalocean/datasource_digitalocean_projects.go
+++ b/digitalocean/datasource_digitalocean_projects.go
@@ -1,0 +1,272 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+var (
+	digitalOceanProjectsFilterKeys = []string{
+		"name",
+		"purpose",
+		"description",
+		"environment",
+		"is_default",
+	}
+
+	digitalOceanProjectsSortKeys = []string{
+		"name",
+		"purpose",
+		"description",
+		"environment",
+	}
+)
+
+func dataSourceDigitalOceanProjects() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDigitalOceanProjectsRead,
+		Schema: map[string]*schema.Schema{
+			"filter": filterSchema(digitalOceanProjectsFilterKeys),
+			"sort":   sortSchema(digitalOceanProjectsSortKeys),
+			"projects": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"purpose": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"environment": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"owner_uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"owner_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"is_default": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "the date and time when the project was created, (ISO8601)",
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "the date and time when the project was last updated, (ISO8601)",
+						},
+						//"resources": {
+						//	Type:     schema.TypeSet,
+						//	Computed: true,
+						//	Elem:     &schema.Schema{Type: schema.TypeString},
+						//},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getDigitalOceanProjects(client *godo.Client) ([]*godo.Project, error) {
+	allProjects := []*godo.Project{}
+
+	opts := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	for {
+		projects, resp, err := client.Projects.List(context.Background(), opts)
+
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving projects: %s", err)
+		}
+
+		for _, project := range projects {
+			allProjects = append(allProjects, &project)
+		}
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving projects: %s", err)
+		}
+
+		opts.Page = page + 1
+	}
+
+	return allProjects, nil
+}
+
+func dataSourceDigitalOceanProjectsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*CombinedConfig).godoClient()
+
+	projects, err := getDigitalOceanProjects(client)
+	if err != nil {
+		return err
+	}
+	log.Printf("projects = %+v", projects)
+
+	if v, ok := d.GetOk("filter"); ok {
+		filters := expandFilters(v.(*schema.Set).List())
+		log.Printf("filters = %+v", filters)
+		log.Printf("projects (before filter) = %+v", projects)
+		projects = filterDigitalOceanProjects(projects, filters)
+		log.Printf("projects (after filter) = %+v", projects)
+	}
+
+	if v, ok := d.GetOk("sort"); ok {
+		sorts := expandSorts(v.([]interface{}))
+		log.Printf("sorts = %+v", sorts)
+		log.Printf("projects (before sort) = %+v", projects)
+		projects = sortDigitalOceanProjects(projects, sorts)
+		log.Printf("projects (after sort) = %+v", projects)
+	}
+
+	d.SetId(resource.UniqueId())
+
+	flattenedProjects := make([]map[string]interface{}, len(projects))
+	for i, project := range projects {
+		flattenedProjects[i] = flattenProject(project)
+	}
+
+	if err := d.Set("projects", flattenedProjects); err != nil {
+		return fmt.Errorf("Unable to set `project_ids` attribute: %s", err)
+	}
+
+	return nil
+}
+
+func flattenProject(project *godo.Project) map[string]interface{} {
+	flattenedProject := map[string]interface{}{}
+
+	flattenedProject["id"] = project.ID
+	flattenedProject["name"] = project.Name
+	flattenedProject["description"] = project.Description
+	flattenedProject["purpose"] = project.Purpose
+	flattenedProject["environment"] = project.Environment
+	flattenedProject["owner_uuid"] = project.OwnerUUID
+	flattenedProject["owner_id"] = project.OwnerID
+	flattenedProject["created_at"] = project.CreatedAt
+	flattenedProject["updated_at"] = project.UpdatedAt
+	flattenedProject["is_default"] = project.IsDefault
+
+	return flattenedProject
+}
+
+func filterDigitalOceanProjects(projects []*godo.Project, filters []commonFilter) []*godo.Project {
+	for _, f := range filters {
+		var filteredProjects []*godo.Project
+
+		filterFunc := func(project *godo.Project) bool {
+			result := false
+
+			for _, filterValue := range f.values {
+				switch f.key {
+				case "name":
+					result = result || strings.EqualFold(filterValue, project.Name)
+
+				case "purpose":
+					result = result || strings.EqualFold(filterValue, project.Purpose)
+
+				case "description":
+					result = result || strings.EqualFold(filterValue, project.Description)
+
+				case "environment":
+					result = result || strings.EqualFold(filterValue, project.Environment)
+
+				case "is_default":
+					if isDefault, err := strconv.ParseBool(filterValue); err == nil {
+						result = result || isDefault == project.IsDefault
+					}
+				default:
+				}
+			}
+
+			return result
+		}
+
+		for _, project := range projects {
+			if filterFunc(project) {
+				filteredProjects = append(filteredProjects, project)
+			}
+		}
+
+		projects = filteredProjects
+	}
+
+	return projects
+}
+
+func sortDigitalOceanProjects(projects []*godo.Project, sorts []commonSort) []*godo.Project {
+	sort.Slice(projects, func(_i, _j int) bool {
+		for _, s := range sorts {
+			// Handle multiple sorts by applying them in order
+
+			i := _i
+			j := _j
+			if strings.EqualFold(s.direction, "desc") {
+				// If the direction is desc, reverse index to compare
+				i = _j
+				j = _i
+			}
+
+			switch s.key {
+			case "name":
+				if !strings.EqualFold(projects[i].Name, projects[j].Name) {
+					return strings.Compare(projects[i].Name, projects[j].Name) <= 0
+				}
+
+			case "purpose":
+				if !strings.EqualFold(projects[i].Purpose, projects[j].Purpose) {
+					return strings.Compare(projects[i].Purpose, projects[j].Purpose) <= 0
+				}
+
+			case "description":
+				if !strings.EqualFold(projects[i].Description, projects[j].Description) {
+					return strings.Compare(projects[i].Description, projects[j].Description) <= 0
+				}
+
+			case "environment":
+				if !strings.EqualFold(projects[i].Environment, projects[j].Environment) {
+					return strings.Compare(projects[i].Environment, projects[j].Environment) <= 0
+				}
+			}
+		}
+
+		return true
+	})
+
+	return projects
+}

--- a/digitalocean/datasource_digitalocean_projects.go
+++ b/digitalocean/datasource_digitalocean_projects.go
@@ -23,19 +23,7 @@ func dataSourceDigitalOceanProjects() *schema.Resource {
 		},
 		ResultAttributeName: "projects",
 		FlattenRecord:       flattenDigitalOceanProject,
-		GetRecords: func(meta interface{}) ([]interface{}, error) {
-			client := meta.(*CombinedConfig).godoClient()
-			projects, err := getDigitalOceanProjects(client)
-			if err == nil {
-				var rawProjects []interface{}
-				for _, project := range projects {
-					rawProjects = append(rawProjects, project)
-				}
-				return rawProjects, nil
-			} else {
-				return nil, err
-			}
-		},
+		GetRecords:          getDigitalOceanProjects,
 	}
 
 	return datalist.NewResource(dataListConfig)

--- a/digitalocean/datasource_digitalocean_projects_test.go
+++ b/digitalocean/datasource_digitalocean_projects_test.go
@@ -1,0 +1,68 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceDigitalOceanProjects_Basic(t *testing.T) {
+	config := `
+resource "digitalocean_project" "prod" {
+	name = "A production project"
+	environment = "Production"
+}
+
+resource "digitalocean_project" "staging" {
+	name = "A staging project"
+	environment = "Staging"
+}
+
+data "digitalocean_projects" "prod" {
+	filter {
+      key = "environment"
+      values = ["Production"]
+    }
+	depends_on = [digitalocean_project.prod, digitalocean_project.staging]
+}
+
+data "digitalocean_projects" "staging" {
+	filter {
+      key = "name"
+      values = ["A staging project"]
+    }
+	depends_on = [digitalocean_project.prod, digitalocean_project.staging]
+}
+
+data "digitalocean_projects" "both" {
+	filter {
+      key = "environment"
+      values = ["Production"]
+    }
+	filter {
+      key = "name"
+      values = ["A staging project"]
+    }
+	depends_on = [digitalocean_project.prod, digitalocean_project.staging]
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.digitalocean_projects.prod", "projects.#", "1"),
+					resource.TestCheckResourceAttr("data.digitalocean_projects.prod", "projects.0.name", "A production project"),
+					resource.TestCheckResourceAttr("data.digitalocean_projects.prod", "projects.0.environment", "Production"),
+					resource.TestCheckResourceAttr("data.digitalocean_projects.staging", "projects.#", "1"),
+					resource.TestCheckResourceAttr("data.digitalocean_projects.staging", "projects.0.name", "A staging project"),
+					resource.TestCheckResourceAttr("data.digitalocean_projects.staging", "projects.0.environment", "Staging"),
+					resource.TestCheckResourceAttr("data.digitalocean_projects.staging", "projects.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/digitalocean/datasource_digitalocean_projects_test.go
+++ b/digitalocean/datasource_digitalocean_projects_test.go
@@ -33,7 +33,6 @@ data "digitalocean_projects" "prod" {
       key = "is_default"
       values = ["false"]
     }
-	#depends_on = [digitalocean_project.prod, digitalocean_project.staging]
 }
 
 data "digitalocean_projects" "staging" {
@@ -45,7 +44,6 @@ data "digitalocean_projects" "staging" {
       key = "is_default"
       values = ["false"]
     }
-	#depends_on = [digitalocean_project.prod, digitalocean_project.staging]
 }
 
 data "digitalocean_projects" "both" {
@@ -57,7 +55,6 @@ data "digitalocean_projects" "both" {
       key = "name"
       values = ["%s"]
     }
-	#depends_on = [digitalocean_project.prod, digitalocean_project.staging]
 }
 `, stagingProjectName, stagingProjectName)
 	resource.Test(t, resource.TestCase{

--- a/digitalocean/projects.go
+++ b/digitalocean/projects.go
@@ -1,0 +1,119 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func projectSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Type: schema.TypeString,
+		},
+		"name": {
+			Type: schema.TypeString,
+		},
+		"description": {
+			Type: schema.TypeString,
+		},
+		"purpose": {
+			Type: schema.TypeString,
+		},
+		"environment": {
+			Type: schema.TypeString,
+		},
+		"owner_uuid": {
+			Type: schema.TypeString,
+		},
+		"owner_id": {
+			Type: schema.TypeInt,
+		},
+		"is_default": {
+			Type: schema.TypeBool,
+		},
+		"created_at": {
+			Type:        schema.TypeString,
+			Description: "the date and time when the project was created, (ISO8601)",
+		},
+		"updated_at": {
+			Type:        schema.TypeString,
+			Description: "the date and time when the project was last updated, (ISO8601)",
+		},
+		"resources": {
+			Type: schema.TypeSet,
+			Elem: &schema.Schema{Type: schema.TypeString},
+		},
+	}
+}
+
+func getDigitalOceanProjects(client *godo.Client) ([]*godo.Project, error) {
+	allProjects := []*godo.Project{}
+
+	opts := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	for {
+		projects, resp, err := client.Projects.List(context.Background(), opts)
+
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving projects: %s", err)
+		}
+
+		for _, project := range projects {
+			allProjects = append(allProjects, &project)
+		}
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving projects: %s", err)
+		}
+
+		opts.Page = page + 1
+	}
+
+	return allProjects, nil
+}
+
+func flattenDigitalOceanProject(rawProject interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*CombinedConfig).godoClient()
+
+	project, ok := rawProject.(*godo.Project)
+	if !ok {
+		return nil, fmt.Errorf("Unable to convert to *godo.Project")
+	}
+
+	flattenedProject := map[string]interface{}{}
+	flattenedProject["id"] = project.ID
+	flattenedProject["name"] = project.Name
+	flattenedProject["purpose"] = strings.TrimPrefix(project.Purpose, "Other: ")
+	flattenedProject["description"] = project.Description
+	flattenedProject["environment"] = project.Environment
+	flattenedProject["owner_uuid"] = project.OwnerUUID
+	flattenedProject["owner_id"] = project.OwnerID
+	flattenedProject["is_default"] = project.IsDefault
+	flattenedProject["created_at"] = project.CreatedAt
+	flattenedProject["updated_at"] = project.UpdatedAt
+
+	urns, err := loadResourceURNs(client, project.ID)
+	if err != nil {
+		return nil, fmt.Errorf("Error loading project resource URNs for project ID %s: %s", project.ID, err)
+	}
+
+	flattenedURNS := schema.NewSet(schema.HashString, []interface{}{})
+	for _, urn := range *urns {
+		flattenedURNS.Add(urn)
+	}
+	flattenedProject["resources"] = flattenedURNS
+
+	return flattenedProject, nil
+}

--- a/digitalocean/projects.go
+++ b/digitalocean/projects.go
@@ -50,8 +50,10 @@ func projectSchema() map[string]*schema.Schema {
 	}
 }
 
-func getDigitalOceanProjects(client *godo.Client) ([]*godo.Project, error) {
-	allProjects := []*godo.Project{}
+func getDigitalOceanProjects(meta interface{}) ([]interface{}, error) {
+	client := meta.(*CombinedConfig).godoClient()
+
+	var allProjects []interface{}
 
 	opts := &godo.ListOptions{
 		Page:    1,
@@ -66,7 +68,7 @@ func getDigitalOceanProjects(client *godo.Client) ([]*godo.Project, error) {
 		}
 
 		for _, project := range projects {
-			allProjects = append(allProjects, &project)
+			allProjects = append(allProjects, project)
 		}
 
 		if resp.Links == nil || resp.Links.IsLastPage() {
@@ -87,9 +89,9 @@ func getDigitalOceanProjects(client *godo.Client) ([]*godo.Project, error) {
 func flattenDigitalOceanProject(rawProject interface{}, meta interface{}) (map[string]interface{}, error) {
 	client := meta.(*CombinedConfig).godoClient()
 
-	project, ok := rawProject.(*godo.Project)
+	project, ok := rawProject.(godo.Project)
 	if !ok {
-		return nil, fmt.Errorf("Unable to convert to *godo.Project")
+		return nil, fmt.Errorf("Unable to convert to godo.Project")
 	}
 
 	flattenedProject := map[string]interface{}{}

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -51,6 +51,7 @@ func Provider() terraform.ResourceProvider {
 			"digitalocean_kubernetes_versions": dataSourceDigitalOceanKubernetesVersions(),
 			"digitalocean_loadbalancer":        dataSourceDigitalOceanLoadbalancer(),
 			"digitalocean_project":             dataSourceDigitalOceanProject(),
+			"digitalocean_projects":            dataSourceDigitalOceanProjects(),
 			"digitalocean_record":              dataSourceDigitalOceanRecord(),
 			"digitalocean_region":              dataSourceDigitalOceanRegion(),
 			"digitalocean_regions":             dataSourceDigitalOceanRegions(),

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -50,6 +50,7 @@ func Provider() terraform.ResourceProvider {
 			"digitalocean_kubernetes_cluster":  dataSourceDigitalOceanKubernetesCluster(),
 			"digitalocean_kubernetes_versions": dataSourceDigitalOceanKubernetesVersions(),
 			"digitalocean_loadbalancer":        dataSourceDigitalOceanLoadbalancer(),
+			"digitalocean_project":             dataSourceDigitalOceanProject(),
 			"digitalocean_record":              dataSourceDigitalOceanRecord(),
 			"digitalocean_region":              dataSourceDigitalOceanRegion(),
 			"digitalocean_regions":             dataSourceDigitalOceanRegions(),

--- a/digitalocean/resource_digitalocean_project.go
+++ b/digitalocean/resource_digitalocean_project.go
@@ -64,6 +64,10 @@ func resourceDigitalOceanProject() *schema.Resource {
 				Computed:    true,
 				Description: "the id of the project owner.",
 			},
+			"is_default": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/digitalocean/resource_digitalocean_project.go
+++ b/digitalocean/resource_digitalocean_project.go
@@ -273,7 +273,7 @@ func assignResourcesToProject(client *godo.Client, projectId string, resources *
 	return &urns, nil
 }
 
-func loadResourceURNs(client *godo.Client, projectId string) (*[]interface{}, error) {
+func loadResourceURNs(client *godo.Client, projectId string) (*[]string, error) {
 	opts := &godo.ListOptions{
 		Page:    1,
 		PerPage: 200,
@@ -302,7 +302,7 @@ func loadResourceURNs(client *godo.Client, projectId string) (*[]interface{}, er
 		opts.Page = page + 1
 	}
 
-	var urns []interface{}
+	var urns []string
 	for _, rsrc := range resourceList {
 		urns = append(urns, rsrc.URN)
 	}

--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -40,6 +40,12 @@
             <li<%= sidebar_current("docs-do-datasource-loadbalancer") %>>
               <a href="/docs/providers/do/d/loadbalancer.html">digitalocean_loadbalancer</a>
             </li>
+            <li<%= sidebar_current("docs-do-datasource-project") %>>
+              <a href="/docs/providers/do/d/project.html">digitalocean_project</a>
+            </li>
+            <li<%= sidebar_current("docs-do-datasource-projects") %>>
+              <a href="/docs/providers/do/d/projects.html">digitalocean_projects</a>
+            </li>
             <li<%= sidebar_current("docs-do-datasource-kubernetes-cluster") %>>
               <a href="/docs/providers/do/d/kubernetes_cluster.html">digitalocean_kubernetes_cluster</a>
             </li>

--- a/website/docs/d/project.html.md
+++ b/website/docs/d/project.html.md
@@ -1,0 +1,40 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_project"
+sidebar_current: "docs-do-datasource-project"
+description: |-
+  Get information on a DigitalOcean project.
+---
+
+# digitalocean_project
+
+Get information on a single DigitalOcean project. If neither the `id` nor `name` attributes is provided,
+then this datasource returns the default project.
+
+## Example Usage
+
+```hcl
+data "digitalocean_project" "default" {
+} 
+
+data "digitalocean_project" "staging" {
+  name = "My Staging Project"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) The id of the project to retrieve
+* `name` - (Optional) The name of the project to retrieve. The datasource will raise an error if more than
+  one project has the provided name.
+
+## Attributes Reference
+
+* `description` - the description of the project
+* `purpose` -  the purpose of the project, (Default: "Web Application")
+* `environment` - the environment of the project's resources. The possible values are: `Development`, `Staging`, `Production`.
+* `resources` - a list of uniform resource names (URNs) for the resources associated with the project
+* `owner_uuid` - the unique universal identifier of the project owner.
+* `owner_id` - the id of the project owner.
+* `created_at` - the date and time when the project was created, (ISO8601)
+* `updated_at` - the date and time when the project was last updated, (ISO8601)

--- a/website/docs/d/projects.html.md
+++ b/website/docs/d/projects.html.md
@@ -1,0 +1,86 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_projects"
+sidebar_current: "docs-do-datasource-projects"
+description: |-
+  Retrieve metadata about DigitalOcean projects.
+---
+
+# digitalocean_projects
+
+Retrieve information about all DigitalOcean projects associated with an account, with
+the ability to filter and sort the results. If no filters are specified, all projects
+will be returned.
+
+Note: You can use the `digitalocean_project` data source to obtain metadata about a single
+project if you already know the `id` to retrieve or the unique `name` of the project.
+
+## Example Usage
+
+Use the `filter` block with a `key` string and `values` list to filter projects.
+
+For example to find all staging environment projects:
+
+```hcl
+data "digitalocean_projects" "staging" {
+  filter {
+    key = "environment"
+    values = ["Staging"]
+  }
+} 
+```
+
+You can filter on multiple fields and sort the results as well:
+
+```hcl
+data "digitalocean_projects" "non-default-production" {
+  filter {
+    key = "environment"
+    values = ["Production"]
+  }
+  filter {
+    key = "is_default"
+    values = ["false"]
+  }
+  sort {
+    key = "name"
+    direction = "asc"
+  }
+}
+```
+
+## Argument Reference
+
+* `filter` - (Optional) Filter the results.
+  The `filter` block is documented below.
+* `sort` - (Optional) Sort the results.
+  The `sort` block is documented below.
+
+`filter` supports the following:
+* `key` - (Required) Filter the projects by this key. This may be one of `name`,
+  `purpose`, `description`, `environment`, or `is_default`.
+  
+* `values` - (Required) A list of values to match against the `key` field. Only retrieves projects
+  where the `key` field takes on one or more of the values provided here.
+
+`sort` supports the following:
+
+* `key` - (Required) Sort the projects by this key. This may be one of `name`,
+  `purpose`, `description`, or `environment`.
+* `direction` - (Required) The sort direction. This may be either `asc` or `desc`.
+
+## Attributes Reference
+
+* `projects` - A set of projects satisfying any `filter` and `sort` criteria. Each project has
+  the following attributes:  
+  - `id` - (Optional) The id of the project to retrieve
+  - `name` - (Optional) The name of the project to retrieve. The datasource will raise an error if more than
+    one project has the provided name.
+  - `description` - the description of the project
+  - `purpose` -  the purpose of the project, (Default: "Web Application")
+  - `environment` - the environment of the project's resources. The possible values are: `Development`, `Staging`, `Production`.
+  - `resources` - a list of uniform resource names (URNs) for the resources associated with the project
+  - `owner_uuid` - the unique universal identifier of the project owner.
+  - `owner_id` - the id of the project owner.
+  - `created_at` - the date and time when the project was created, (ISO8601)
+  - `updated_at` - the date and time when the project was last updated, (ISO8601)


### PR DESCRIPTION
Adds `digitalocean_project` and `digitalocean_projects` datasources using the datalist library to be added in https://github.com/terraform-providers/terraform-provider-digitalocean/pull/385. The test for `digitalocean_projects` still needs a bug fixed, but this generally shows the approach of how to use `datalist` to add a new datasource.

Some modifications to `datalist` were made and will be moved to https://github.com/terraform-providers/terraform-provider-digitalocean/pull/385.