### PR TITLE
add digitalocean_images datasource

### DIFF
--- a/digitalocean/datasource_digitalocean_image.go
+++ b/digitalocean/datasource_digitalocean_image.go
@@ -90,7 +90,7 @@ func dataSourceDigitalOceanImageRead(d *schema.ResourceData, meta interface{}) e
 		if len(results) == 0 {
 			return fmt.Errorf("no image found with name %s", name)
 		} else if len(results) > 1 {
-			fmt.Errorf("too many images found with name %s (found %d, expected 1)", name, len(results))
+			return fmt.Errorf("too many images found with name %s (found %d, expected 1)", name, len(results))
 		}
 
 		result := results[0].(godo.Image)

--- a/digitalocean/datasource_digitalocean_image_test.go
+++ b/digitalocean/datasource_digitalocean_image_test.go
@@ -45,12 +45,12 @@ func TestAccDigitalOceanImage_Basic(t *testing.T) {
 			},
 			{
 				Config:      testAccCheckDigitalOceanImageConfig_basic(rInt, 0),
-				ExpectError: regexp.MustCompile(`.*too many user images found with name snap-.*\ .found 2, expected 1.`),
+				ExpectError: regexp.MustCompile(`.*too many images found with name snap-.*\ .found 2, expected 1.`),
 			},
 			{
 				Config:      testAccCheckDigitalOceanImageConfig_nonexisting(rInt),
 				Destroy:     false,
-				ExpectError: regexp.MustCompile(`.*no user image found with name snap-.*-nonexisting`),
+				ExpectError: regexp.MustCompile(`.*no image found with name snap-.*-nonexisting`),
 			},
 			{
 				Config: " ",

--- a/digitalocean/datasource_digitalocean_images.go
+++ b/digitalocean/datasource_digitalocean_images.go
@@ -1,0 +1,45 @@
+package digitalocean
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-digitalocean/internal/datalist"
+)
+
+func dataSourceDigitalOceanImages() *schema.Resource {
+	dataListConfig := &datalist.ResourceConfig{
+		RecordSchema: imageSchema(),
+		FilterKeys: []string{
+			"id",
+			"name",
+			"type",
+			"distribution",
+			"slug",
+			"image",
+			"private",
+			"min_disk_size",
+			"size_gigabytes",
+			"regions",
+			"tags",
+			"status",
+			"error_message",
+		},
+		SortKeys: []string{
+			"id",
+			"name",
+			"type",
+			"distribution",
+			"slug",
+			"image",
+			"private",
+			"min_disk_size",
+			"size_gigabytes",
+			"status",
+			"error_message",
+		},
+		ResultAttributeName: "images",
+		FlattenRecord:       flattenDigitalOceanImage,
+		GetRecords:          getDigitalOceanImages,
+	}
+
+	return datalist.NewResource(dataListConfig)
+}

--- a/digitalocean/datasource_digitalocean_images_test.go
+++ b/digitalocean/datasource_digitalocean_images_test.go
@@ -1,0 +1,83 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDataSourceDigitalOceanImages_Basic(t *testing.T) {
+	config := `
+data "digitalocean_images" "ubuntu" {
+  filter {
+    key = "distribution"
+    values = ["Ubuntu"]
+  }
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.digitalocean_images.ubuntu", "images.#"),
+					testResourceInstanceState("data.digitalocean_images.ubuntu", testAccDataSourceDigitalOceanImages_VerifyImageData),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDigitalOceanImages_VerifyImageData(is *terraform.InstanceState) error {
+	ns, ok := is.Attributes["images.#"]
+	if !ok {
+		return fmt.Errorf("images.# attribute not found")
+	}
+
+	n, err := strconv.Atoi(ns)
+	if err != nil {
+		return fmt.Errorf("images.# attribute was not convertible to an integer: %s", err)
+	}
+
+	if n == 0 {
+		return fmt.Errorf("Expected to find Ubuntu images")
+	}
+
+	// Verify the first image to ensure that it matches what the API returned.
+	slug, ok := is.Attributes["images.0.slug"]
+	if !ok {
+		return fmt.Errorf("images.0.slug attribute not found")
+	}
+
+	client := testAccProvider.Meta().(*CombinedConfig).godoClient()
+
+	image, _, err := client.Images.GetBySlug(context.Background(), slug)
+	if err != nil {
+		return err
+	}
+	log.Printf("image=%+v", image)
+
+	if image.Name != is.Attributes["images.0.name"] {
+		return fmt.Errorf("mismatch on `name`: expected=%s, actual=%s",
+			image.Name, is.Attributes["images.0.name"])
+	}
+
+	if image.Type != is.Attributes["images.0.type"] {
+		return fmt.Errorf("mismatch on `type`: expected=%s, actual=%s",
+			image.Type, is.Attributes["images.0.type"])
+	}
+
+	if image.Description != is.Attributes["images.0.description"] {
+		return fmt.Errorf("mismatch on `description`: expected=%s, actual=%s",
+			image.Description, is.Attributes["images.0.description"])
+	}
+
+	return nil
+}

--- a/digitalocean/images.go
+++ b/digitalocean/images.go
@@ -59,7 +59,7 @@ func imageSchema() map[string]*schema.Schema {
 		},
 		"tags": {
 			Type:        schema.TypeSet,
-			Description: "list of the regions that the image is available in",
+			Description: "tags applied to the image",
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 		"status": {

--- a/digitalocean/images.go
+++ b/digitalocean/images.go
@@ -1,0 +1,146 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func imageSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Type:        schema.TypeInt,
+			Description: "id of the image",
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Description: "name of the image",
+		},
+		"type": {
+			Type:        schema.TypeString,
+			Description: "type of the image",
+		},
+		"distribution": {
+			Type:        schema.TypeString,
+			Description: "distribution of the OS of the image",
+		},
+		"slug": {
+			Type:        schema.TypeString,
+			Description: "slug of the image",
+		},
+		"image": {
+			Type:        schema.TypeString,
+			Description: "slug or id of the image",
+		},
+		"private": {
+			Type:        schema.TypeBool,
+			Description: "Is the image private or non-private",
+		},
+		"min_disk_size": {
+			Type:        schema.TypeInt,
+			Description: "minimum disk size required by the image",
+		},
+		"size_gigabytes": {
+			Type:        schema.TypeFloat,
+			Description: "size in GB of the image",
+		},
+		"regions": {
+			Type:        schema.TypeSet,
+			Description: "list of the regions that the image is available in",
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
+		"created": {
+			Type: schema.TypeString,
+		},
+		"tags": {
+			Type:        schema.TypeSet,
+			Description: "list of the regions that the image is available in",
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
+		"status": {
+			Type:        schema.TypeString,
+			Description: "status of the image",
+		},
+		"error_message": {
+			Type:        schema.TypeString,
+			Description: "error message associated with the image",
+		},
+	}
+}
+
+func getDigitalOceanImages(meta interface{}) ([]interface{}, error) {
+	client := meta.(*CombinedConfig).godoClient()
+
+	var allImages []interface{}
+
+	opts := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	for {
+		images, resp, err := client.Images.List(context.Background(), opts)
+
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving images: %s", err)
+		}
+
+		for _, image := range images {
+			allImages = append(allImages, image)
+		}
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving images: %s", err)
+		}
+
+		opts.Page = page + 1
+	}
+
+	return allImages, nil
+}
+
+func flattenDigitalOceanImage(rawImage interface{}, meta interface{}) (map[string]interface{}, error) {
+	image, ok := rawImage.(godo.Image)
+	if !ok {
+		return nil, fmt.Errorf("Unable to convert to godo.Image")
+	}
+
+	flattenedRegions := schema.NewSet(schema.HashString, []interface{}{})
+	for _, region := range image.Regions {
+		flattenedRegions.Add(region)
+	}
+
+	flattenedTags := schema.NewSet(schema.HashString, []interface{}{})
+	for _, tag := range image.Tags {
+		flattenedTags.Add(tag)
+	}
+
+	flattenedImage := map[string]interface{}{
+		"id":             image.ID,
+		"name":           image.Name,
+		"type":           image.Type,
+		"distribution":   image.Distribution,
+		"slug":           image.Slug,
+		"private":        !image.Public,
+		"min_disk_size":  image.MinDiskSize,
+		"size_gigabytes": image.SizeGigaBytes,
+		"created":        image.Created,
+		"regions":        flattenedRegions,
+		"tags":           flattenedTags,
+		"status":         image.Status,
+		"error_message":  image.ErrorMessage,
+
+		// Legacy attributes
+		"image": strconv.Itoa(image.ID),
+	}
+
+	return flattenedImage, nil
+}

--- a/digitalocean/images.go
+++ b/digitalocean/images.go
@@ -122,10 +122,7 @@ func flattenDigitalOceanImage(rawImage interface{}, meta interface{}) (map[strin
 		flattenedRegions.Add(region)
 	}
 
-	flattenedTags := schema.NewSet(schema.HashString, []interface{}{})
-	for _, tag := range image.Tags {
-		flattenedTags.Add(tag)
-	}
+	flattenedTags := flattenTags(image.Tags)
 
 	flattenedImage := map[string]interface{}{
 		"id":             image.ID,

--- a/digitalocean/images.go
+++ b/digitalocean/images.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+type imageListFunc func(ctx context.Context, opt *godo.ListOptions) ([]godo.Image, *godo.Response, error)
+
 func imageSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"id": {
@@ -73,7 +75,10 @@ func imageSchema() map[string]*schema.Schema {
 
 func getDigitalOceanImages(meta interface{}) ([]interface{}, error) {
 	client := meta.(*CombinedConfig).godoClient()
+	return listDigitalOceanImages(client.Images.List)
+}
 
+func listDigitalOceanImages(listImages imageListFunc) ([]interface{}, error) {
 	var allImages []interface{}
 
 	opts := &godo.ListOptions{
@@ -82,8 +87,7 @@ func getDigitalOceanImages(meta interface{}) ([]interface{}, error) {
 	}
 
 	for {
-		images, resp, err := client.Images.List(context.Background(), opts)
-
+		images, resp, err := listImages(context.Background(), opts)
 		if err != nil {
 			return nil, fmt.Errorf("Error retrieving images: %s", err)
 		}

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -47,6 +47,7 @@ func Provider() terraform.ResourceProvider {
 			"digitalocean_droplet_snapshot":    dataSourceDigitalOceanDropletSnapshot(),
 			"digitalocean_floating_ip":         dataSourceDigitalOceanFloatingIp(),
 			"digitalocean_image":               dataSourceDigitalOceanImage(),
+			"digitalocean_images":              dataSourceDigitalOceanImages(),
 			"digitalocean_kubernetes_cluster":  dataSourceDigitalOceanKubernetesCluster(),
 			"digitalocean_kubernetes_versions": dataSourceDigitalOceanKubernetesVersions(),
 			"digitalocean_loadbalancer":        dataSourceDigitalOceanLoadbalancer(),

--- a/go.mod
+++ b/go.mod
@@ -24,3 +24,5 @@ replace github.com/keybase/go-crypto v0.0.0-20190523171820-b785b22cc757 => githu
 replace github.com/terraform-providers/terraform-provider-google v2.17.0+incompatible => github.com/terraform-providers/terraform-provider-google v1.20.1-0.20191008212436-363f2d283518
 
 replace github.com/terraform-providers/terraform-provider-aws v2.32.0+incompatible => github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20191010190908-1261a98537f2
+
+go 1.13

--- a/website/digitalocean.erb
+++ b/website/digitalocean.erb
@@ -37,6 +37,9 @@
             <li<%= sidebar_current("docs-do-datasource-image") %>>
               <a href="/docs/providers/do/d/image.html">digitalocean_image</a>
             </li>
+            <li<%= sidebar_current("docs-do-datasource-images") %>>
+              <a href="/docs/providers/do/d/images.html">digitalocean_images</a>
+            </li>
             <li<%= sidebar_current("docs-do-datasource-loadbalancer") %>>
               <a href="/docs/providers/do/d/loadbalancer.html">digitalocean_loadbalancer</a>
             </li>

--- a/website/docs/d/image.html.md
+++ b/website/docs/d/image.html.md
@@ -59,13 +59,20 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `slug`: Unique text identifier of the image.
 * `id`: The ID of the image.
-* `image` - The id of the image.
+* `name`: The name of the image.
+* `type`: Type of the image.
 * `distribution` - The name of the distribution of the OS of the image.
 * `min_disk_size`: The minimum 'disk' required for the image.
+* `size_gigabytes`: The size of the image in GB.
 * `private` - Is image a public image or not. Public images represent
   Linux distributions or One-Click Applications, while non-public images represent
   snapshots and backups and are only available within your account.
-* `regions`: The regions that the image is available in.
-* `type`: Type of the image.
+* `regions`: A set of the regions that the image is available in.
+* `tags`: A set of tags applied to the image 
+* `created`: When the image was created
+* `status`: Current status of the image
+* `error_message`: Any applicable error message pertaining to the image
+* `image` - The id of the image (legacy parameter).
 

--- a/website/docs/d/image.html.md
+++ b/website/docs/d/image.html.md
@@ -50,10 +50,19 @@ data "digitalocean_image" "example2" {
 
 ## Argument Reference
 
-The following arguments are supported:
+One of the following arguments must be provided:
 
-* `name` - (Optional) The name of the private image.
-* `slug` - (Optional) The slug of the official image.
+* `id` - The id of the image
+* `name` - The name of the image.
+* `slug` - The slug of the official image.
+
+If `name` is specified, you may also specify:
+
+* `source` - (Optional) Restrict the search to one of the following categories of images:
+  - `all` - (Default) All images (whether public or private)
+  - `applications` - One-click applications
+  - `distribution` - Distributions
+  - `user` - User (private) images. In prior versions of this provider, this was the behavior.
 
 ## Attributes Reference
 

--- a/website/docs/d/images.html.md
+++ b/website/docs/d/images.html.md
@@ -1,0 +1,96 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_images"
+sidebar_current: "docs-do-datasource-images"
+description: |-
+  Retrieve metadata about DigitalOcean images (public and private).
+---
+
+# digitalocean_images
+
+Get information on images for use in other resources (e.g. creating a Droplet
+based on snapshot), with the ability to filter and sort the results. If no filters are specified,
+all images will be returned.
+
+This data source provides all of the image properties as configured on your DigitalOcean account.
+This is useful if the image in question is not managed by Terraform or you need to utilize any
+of the image's data.
+
+Note: You can use the `digitalocean_image` data source to obtain metadata about a single
+image if you already know the `slug`, unique `name`, or `id` to retrieve.
+
+## Example Usage
+
+Use the `filter` block with a `key` string and `values` list to filter images.
+
+For example to find all Ubuntu images:
+
+```hcl
+data "digitalocean_images" "ubuntu" {
+  filter {
+    key = "distribution"
+    values = ["Ubuntu"]
+  }
+} 
+```
+
+You can filter on multiple fields and sort the results as well:
+
+```hcl
+data "digitalocean_images" "available" {
+  filter {
+    key = "distribution"
+    values = ["Ubuntu"]
+  }
+  filter {
+    key = "regions"
+    values = ["nyc3"]
+  }
+  sort {
+    key = "created"
+    direction = "desc"
+  }
+}
+```
+
+## Argument Reference
+
+* `filter` - (Optional) Filter the results.
+  The `filter` block is documented below.
+* `sort` - (Optional) Sort the results.
+  The `sort` block is documented below.
+
+`filter` supports the following:
+* `key` - (Required) Filter the images by this key. This may be one of `distribution`, `error_message`,
+  `id`, `image`, `min_disk_size`, `name`, `private`, `regions`, `size_gigabytes`, `slug`, `status`,
+  `tags`, or `type`.
+
+* `values` - (Required) A list of values to match against the `key` field. Only retrieves images
+  where the `key` field takes on one or more of the values provided here.
+
+`sort` supports the following:
+
+* `key` - (Required) Sort the images by this key. This may be one of `distribution`, `error_message`, `id`,
+   `image`, `min_disk_size`, `name`, `private`, `size_gigabytes`, `slug`, `status`, or `type`.
+* `direction` - (Required) The sort direction. This may be either `asc` or `desc`.
+
+## Attributes Reference
+
+* `images` - A set of images satisfying any `filter` and `sort` criteria. Each image has the following attributes:  
+  - `slug`: Unique text identifier of the image.
+  - `id`: The ID of the image.
+  - `name`: The name of the image.
+  - `type`: Type of the image.
+  - `distribution` - The name of the distribution of the OS of the image.
+  - `min_disk_size`: The minimum 'disk' required for the image.
+  - `size_gigabytes`: The size of the image in GB.
+  - `private` - Is image a public image or not. Public images represent
+    Linux distributions or One-Click Applications, while non-public images represent
+    snapshots and backups and are only available within your account.
+  - `regions`: A set of the regions that the image is available in.
+  - `tags`: A set of tags applied to the image 
+  - `created`: When the image was created
+  - `status`: Current status of the image
+  - `error_message`: Any applicable error message pertaining to the image
+  - `image` - The id of the image (legacy parameter).
+


### PR DESCRIPTION
Use the datalist library to add a `digitalocean_images` datasource. Also update the `digitalocean_image` datasource to use the new common code.

This should supersede https://github.com/terraform-providers/terraform-provider-digitalocean/pull/79, although an open question is whether there should be a `type` attribute like in the DO API for applications and distributions.