### PR TITLE
default digitalocean_image to user images

### DIFF
--- a/digitalocean/datasource_digitalocean_image.go
+++ b/digitalocean/datasource_digitalocean_image.go
@@ -33,7 +33,7 @@ func dataSourceDigitalOceanImage() *schema.Resource {
 	recordSchema["source"] = &schema.Schema{
 		Type:          schema.TypeString,
 		Optional:      true,
-		Default:       "all",
+		Default:       "user",
 		ValidateFunc:  validation.StringInSlice([]string{"all", "applications", "distributions", "user"}, true),
 		ConflictsWith: []string{"id", "slug"},
 	}

--- a/website/docs/d/image.html.md
+++ b/website/docs/d/image.html.md
@@ -59,10 +59,10 @@ One of the following arguments must be provided:
 If `name` is specified, you may also specify:
 
 * `source` - (Optional) Restrict the search to one of the following categories of images:
-  - `all` - (Default) All images (whether public or private)
+  - `all` - All images (whether public or private)
   - `applications` - One-click applications
   - `distribution` - Distributions
-  - `user` - User (private) images. In prior versions of this provider, this was the behavior.
+  - `user` - (Default) User (private) images
 
 ## Attributes Reference
 

--- a/website/docs/d/image.html.md
+++ b/website/docs/d/image.html.md
@@ -61,7 +61,7 @@ If `name` is specified, you may also specify:
 * `source` - (Optional) Restrict the search to one of the following categories of images:
   - `all` - All images (whether public or private)
   - `applications` - One-click applications
-  - `distribution` - Distributions
+  - `distributions` - Distributions
   - `user` - (Default) User (private) images
 
 ## Attributes Reference


### PR DESCRIPTION
Default `digitalocean_image` to user images to match previous behavior (i.e., principle of least surprise).