### PR TITLE
fix some minor issues with recently-updated docs

### DIFF
--- a/website/docs/d/image.html.md
+++ b/website/docs/d/image.html.md
@@ -9,7 +9,7 @@ description: |-
 # digitalocean_image
 
 Get information on an image for use in other resources (e.g. creating a Droplet
-based on snapshot). This datasource provides all of the image properties as
+based on snapshot). This data source provides all of the image properties as
 configured on your DigitalOcean account. This is useful if the image in question
 is not managed by Terraform or you need to utilize any of the image's data.
 

--- a/website/docs/d/image.html.md
+++ b/website/docs/d/image.html.md
@@ -3,13 +3,13 @@ layout: "digitalocean"
 page_title: "DigitalOcean: digitalocean_image"
 sidebar_current: "docs-do-datasource-image"
 description: |-
-  Get information on an snapshot.
+  Get information on a DigitalOcean image.
 ---
 
 # digitalocean_image
 
-Get information on an images for use in other resources (e.g. creating a Droplet
-based on snapshot). This data source provides all of the image properties as
+Get information on an image for use in other resources (e.g. creating a Droplet
+based on snapshot). This datasource provides all of the image properties as
 configured on your DigitalOcean account. This is useful if the image in question
 is not managed by Terraform or you need to utilize any of the image's data.
 

--- a/website/docs/d/images.html.md
+++ b/website/docs/d/images.html.md
@@ -12,7 +12,7 @@ Get information on images for use in other resources (e.g. creating a Droplet
 based on a snapshot), with the ability to filter and sort the results. If no filters are specified,
 all images will be returned.
 
-This datasource is useful if the image in question is not managed by Terraform or you need to utilize any
+This data source is useful if the image in question is not managed by Terraform or you need to utilize any
 of the image's data.
 
 Note: You can use the [`digitalocean_image`](/docs/providers/do/d/image.html) data source to obtain metadata

--- a/website/docs/d/images.html.md
+++ b/website/docs/d/images.html.md
@@ -3,21 +3,20 @@ layout: "digitalocean"
 page_title: "DigitalOcean: digitalocean_images"
 sidebar_current: "docs-do-datasource-images"
 description: |-
-  Retrieve metadata about DigitalOcean images (public and private).
+  Retrieve information about DigitalOcean images (public and private).
 ---
 
 # digitalocean_images
 
 Get information on images for use in other resources (e.g. creating a Droplet
-based on snapshot), with the ability to filter and sort the results. If no filters are specified,
+based on a snapshot), with the ability to filter and sort the results. If no filters are specified,
 all images will be returned.
 
-This data source provides all of the image properties as configured on your DigitalOcean account.
-This is useful if the image in question is not managed by Terraform or you need to utilize any
+This datasource is useful if the image in question is not managed by Terraform or you need to utilize any
 of the image's data.
 
-Note: You can use the `digitalocean_image` data source to obtain metadata about a single
-image if you already know the `slug`, unique `name`, or `id` to retrieve.
+Note: You can use the [`digitalocean_image`](/docs/providers/do/d/image.html) data source to obtain metadata
+about a single image if you already know the `slug`, unique `name`, or `id` to retrieve.
 
 ## Example Usage
 
@@ -57,10 +56,12 @@ data "digitalocean_images" "available" {
 
 * `filter` - (Optional) Filter the results.
   The `filter` block is documented below.
+
 * `sort` - (Optional) Sort the results.
   The `sort` block is documented below.
 
-`filter` supports the following:
+`filter` supports the following arguments:
+
 * `key` - (Required) Filter the images by this key. This may be one of `distribution`, `error_message`,
   `id`, `image`, `min_disk_size`, `name`, `private`, `regions`, `size_gigabytes`, `slug`, `status`,
   `tags`, or `type`.
@@ -68,7 +69,7 @@ data "digitalocean_images" "available" {
 * `values` - (Required) A list of values to match against the `key` field. Only retrieves images
   where the `key` field takes on one or more of the values provided here.
 
-`sort` supports the following:
+`sort` supports the following arguments:
 
 * `key` - (Required) Sort the images by this key. This may be one of `distribution`, `error_message`, `id`,
    `image`, `min_disk_size`, `name`, `private`, `size_gigabytes`, `slug`, `status`, or `type`.

--- a/website/docs/d/project.html.md
+++ b/website/docs/d/project.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # digitalocean_project
 
-Get information on a single DigitalOcean project. If neither the `id` nor `name` attributes is provided,
+Get information on a single DigitalOcean project. If neither the `id` nor `name` attributes are provided,
 then this datasource returns the default project.
 
 ## Example Usage
@@ -24,17 +24,17 @@ data "digitalocean_project" "staging" {
 
 ## Argument Reference
 
-* `id` - (Optional) The id of the project to retrieve
-* `name` - (Optional) The name of the project to retrieve. The datasource will raise an error if more than
-  one project has the provided name.
+* `id` - (Optional) the ID of the project to retrieve
+* `name` - (Optional) the name of the project to retrieve. The datasource will raise an error if more than
+  one project has the provided name or if no project has that name.
 
 ## Attributes Reference
 
-* `description` - the description of the project
-* `purpose` -  the purpose of the project, (Default: "Web Application")
-* `environment` - the environment of the project's resources. The possible values are: `Development`, `Staging`, `Production`.
-* `resources` - a list of uniform resource names (URNs) for the resources associated with the project
-* `owner_uuid` - the unique universal identifier of the project owner.
-* `owner_id` - the id of the project owner.
-* `created_at` - the date and time when the project was created, (ISO8601)
-* `updated_at` - the date and time when the project was last updated, (ISO8601)
+* `description` - The description of the project
+* `purpose` -  The purpose of the project, (Default: "Web Application")
+* `environment` - The environment of the project's resources. The possible values are: `Development`, `Staging`, `Production`.
+* `resources` - A set of uniform resource names (URNs) for the resources associated with the project
+* `owner_uuid` - The unique universal identifier of the project owner.
+* `owner_id` - The ID of the project owner.
+* `created_at` - The date and time when the project was created, (ISO8601)
+* `updated_at` - The date and time when the project was last updated, (ISO8601)

--- a/website/docs/d/project.html.md
+++ b/website/docs/d/project.html.md
@@ -9,7 +9,7 @@ description: |-
 # digitalocean_project
 
 Get information on a single DigitalOcean project. If neither the `id` nor `name` attributes are provided,
-then this datasource returns the default project.
+then this data source returns the default project.
 
 ## Example Usage
 
@@ -25,7 +25,7 @@ data "digitalocean_project" "staging" {
 ## Argument Reference
 
 * `id` - (Optional) the ID of the project to retrieve
-* `name` - (Optional) the name of the project to retrieve. The datasource will raise an error if more than
+* `name` - (Optional) the name of the project to retrieve. The data source will raise an error if more than
   one project has the provided name or if no project has that name.
 
 ## Attributes Reference

--- a/website/docs/d/projects.html.md
+++ b/website/docs/d/projects.html.md
@@ -3,7 +3,7 @@ layout: "digitalocean"
 page_title: "DigitalOcean: digitalocean_projects"
 sidebar_current: "docs-do-datasource-projects"
 description: |-
-  Retrieve metadata about DigitalOcean projects.
+  Retrieve information about DigitalOcean projects.
 ---
 
 # digitalocean_projects
@@ -12,8 +12,9 @@ Retrieve information about all DigitalOcean projects associated with an account,
 the ability to filter and sort the results. If no filters are specified, all projects
 will be returned.
 
-Note: You can use the `digitalocean_project` data source to obtain metadata about a single
-project if you already know the `id` to retrieve or the unique `name` of the project.
+Note: You can use the [`digitalocean_project`](/docs/providers/do/d/project.html) data source to
+obtain metadata about a single project if you already know the `id` to retrieve or the unique
+`name` of the project.
 
 ## Example Usage
 
@@ -53,17 +54,19 @@ data "digitalocean_projects" "non-default-production" {
 
 * `filter` - (Optional) Filter the results.
   The `filter` block is documented below.
+
 * `sort` - (Optional) Sort the results.
   The `sort` block is documented below.
 
-`filter` supports the following:
+`filter` supports the following arguments:
+
 * `key` - (Required) Filter the projects by this key. This may be one of `name`,
   `purpose`, `description`, `environment`, or `is_default`.
   
 * `values` - (Required) A list of values to match against the `key` field. Only retrieves projects
   where the `key` field takes on one or more of the values provided here.
 
-`sort` supports the following:
+`sort` supports the following arguments:
 
 * `key` - (Required) Sort the projects by this key. This may be one of `name`,
   `purpose`, `description`, or `environment`.
@@ -73,14 +76,13 @@ data "digitalocean_projects" "non-default-production" {
 
 * `projects` - A set of projects satisfying any `filter` and `sort` criteria. Each project has
   the following attributes:  
-  - `id` - (Optional) The id of the project to retrieve
-  - `name` - (Optional) The name of the project to retrieve. The datasource will raise an error if more than
-    one project has the provided name.
-  - `description` - the description of the project
-  - `purpose` -  the purpose of the project, (Default: "Web Application")
-  - `environment` - the environment of the project's resources. The possible values are: `Development`, `Staging`, `Production`.
-  - `resources` - a list of uniform resource names (URNs) for the resources associated with the project
-  - `owner_uuid` - the unique universal identifier of the project owner.
-  - `owner_id` - the id of the project owner.
-  - `created_at` - the date and time when the project was created, (ISO8601)
-  - `updated_at` - the date and time when the project was last updated, (ISO8601)
+  - `id` - The ID of the project
+  - `name` - The name of the project
+  - `description` - The description of the project
+  - `purpose` -  The purpose of the project (Default: "Web Application")
+  - `environment` - The environment of the project's resources. The possible values are: `Development`, `Staging`, `Production`.
+  - `resources` - A set of uniform resource names (URNs) for the resources associated with the project
+  - `owner_uuid` - The unique universal identifier of the project owner
+  - `owner_id` - The ID of the project owner
+  - `created_at` - The date and time when the project was created, (ISO8601)
+  - `updated_at` - The date and time when the project was last updated, (ISO8601)

--- a/website/docs/d/region.html.md
+++ b/website/docs/d/region.html.md
@@ -32,5 +32,5 @@ output "region_name" {
 * `slug` - A human-readable string that is used as a unique identifier for each region.
 * `name` - The display name of the region.
 * `available` -	A boolean value that represents whether new Droplets can be created in this region.
-* `sizes` - A list of identifying slugs for the Droplet sizes available in this region.
-* `features` - A list of features available in this region.
+* `sizes` - A set of identifying slugs for the Droplet sizes available in this region.
+* `features` - A set of features available in this region.

--- a/website/docs/d/regions.html.md
+++ b/website/docs/d/regions.html.md
@@ -3,7 +3,7 @@ layout: "digitalocean"
 page_title: "DigitalOcean: digitalocean_regions"
 sidebar_current: "docs-do-datasource-regions"
 description: |-
-  Retrieve metadata about DigitalOcean regions.
+  Retrieve information about DigitalOcean regions.
 ---
 
 # digitalocean_regions
@@ -11,8 +11,8 @@ description: |-
 Retrieve information about all supported DigitalOcean regions, with the ability to
 filter and sort the results. If no filters are specified, all regions will be returned.
 
-Note: You can use the `digitalocean_region` data source to obtain metadata about a single
-region if you already know the `slug` to retrieve.
+Note: You can use the [`digitalocean_region`](/docs/providers/do/d/region.html) data source
+to obtain metadata about a single region if you already know the `slug` to retrieve.
 
 ## Example Usage
 
@@ -55,17 +55,18 @@ data "digitalocean_regions" "available" {
 * `sort` - (Optional) Sort the results.
   The `sort` block is documented below.
 
-`filter` supports the following:
+`filter` supports the following arguments:
+
 * `key` - (Required) Filter the regions by this key. This may be one of `slug`,
   `name`, `available`, `features`, or `sizes`.
 
 * `values` - (Required) A list of values to match against the `key` field. Only retrieves regions
   where the `key` field takes on one or more of the values provided here.
 
-`sort` supports the following:
+`sort` supports the following arguments:
 
 * `key` - (Required) Sort the regions by this key. This may be one of `slug`,
-`name`, or `available`.
+  `name`, or `available`.
 * `direction` - (Required) The sort direction. This may be either `asc` or `desc`.
 
 ## Attributes Reference
@@ -73,6 +74,6 @@ data "digitalocean_regions" "available" {
 * `regions` - A set of regions satisfying any `filter` and `sort` criteria. Each region has the following attributes:  
   - `slug` - A human-readable string that is used as a unique identifier for each region.
   - `name` - The display name of the region.
-  - `available` -	A boolean value that represents whether new Droplets can be created in this region.
-  - `sizes` - A list of identifying slugs for the Droplet sizes available in this region.
-  - `features` - A list of features available in this region.
+  - `available` - A boolean value that represents whether new Droplets can be created in this region.
+  - `sizes` - A set of identifying slugs for the Droplet sizes available in this region.
+  - `features` - A set of features available in this region.

--- a/website/docs/d/sizes.html.md
+++ b/website/docs/d/sizes.html.md
@@ -3,12 +3,14 @@ layout: "digitalocean"
 page_title: "DigitalOcean: digitalocean_sizes"
 sidebar_current: "docs-do-datasource-sizes"
 description: |-
-  Retrieve information  DigitalOcean Cloud Firewall resource. This can be used to create, modify, and delete Firewalls.
+  Retrieve information on supported Droplet sizes.
 ---
 
 # digitalocean_sizes
 
-Retrieves information about droplet sizes that DigitalOcean supports. This data source provides all of droplet size properties, with the ability to filter and sort the results.
+Retrieves information about the Droplet sizes that DigitalOcean supports, with
+the ability to filter and sort the results. If no filters are specified, all sizes
+will be returned.
 
 ## Example Usage
 
@@ -85,7 +87,7 @@ The following arguments are supported:
 * `sort` - (Optional) Sort the results.
   The `sort` block is documented below.
 
-`filter` supports the following:
+`filter` supports the following arguments:
 
 * `key` - (Required) Filter the sizes by this key. This may be one of `slug`,
   `regions`, `memory`, `vcpus`, `disk`, `transfer`, `price_monthly`,
@@ -93,7 +95,7 @@ The following arguments are supported:
 * `values` - (Required) Only retrieves images which keys has value that matches
   one of the values provided here.
 
-`sort` supports the following:
+`sort` supports the following arguments:
 
 * `key` - (Required) Sort the sizes by this key. This may be one of `slug`,
   `memory`, `vcpus`, `disk`, `transfer`, `price_monthly`, or `price_hourly`.


### PR DESCRIPTION
Fix some minor issues with some of the docs updated recently. The main issue was that the bullet point documenting `filter` blocks needed a newline between it and the previous line in order to not be folded into the prior line.