### PR TITLE
Fix volume name validation

### DIFF
--- a/digitalocean/resource_digitalocean_volume.go
+++ b/digitalocean/resource_digitalocean_volume.go
@@ -37,7 +37,7 @@ func resourceDigitalOceanVolume() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9]+$`), "Names must be lowercase and alphanumeric"),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9\-]+$`), "Names must be lowercase and be composed only of numbers, letters and \"-\"."),
 			},
 			"urn": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
#386 introduced validation that disallows dashes, which is allowed according to DigitalOcean's API documentation: https://developers.digitalocean.com/documentation/v2/#block-storage

We have several volumes that contain dashes, which means that with the latest version of the provider we cannot update our stack anymore, as it considers the volume names invalid. I assume this would have been caught by the acceptance tests, as they have names like `volume-abcdefghij`, but I suppose they must not have been run (or I am reading them wrong. Go is not my main language).