### PR TITLE
Do not error out if terraform:default-node-pool tag is missing when reading k8s cluster.

### DIFF
--- a/digitalocean/import_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_cluster_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"regexp"
 	"sort"
 	"testing"
 
@@ -25,8 +24,7 @@ func TestAccDigitalOceanKubernetesCluster_ImportBasic(t *testing.T) {
 				Config: testAccDigitalOceanKubernetesConfigBasic(clusterName, testClusterVersion16),
 				// Remove the default node pool tag so that the import code which infers
 				// the need to add the tag gets triggered.
-				Check:       testAccDigitalOceanKubernetesRemoveDefaultNodePoolTag(clusterName),
-				ExpectError: regexp.MustCompile("No default node pool was found"),
+				Check: testAccDigitalOceanKubernetesRemoveDefaultNodePoolTag(clusterName),
 			},
 			{
 				ResourceName:      "digitalocean_kubernetes_cluster.foobar",

--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -250,7 +250,7 @@ func digitaloceanKubernetesClusterRead(client *godo.Client, cluster *godo.Kubern
 		for _, t := range p.Tags {
 			if t == digitaloceanKubernetesDefaultNodePoolTag {
 				if foundDefaultNodePool {
-					return fmt.Errorf("Multiple node pools are marked as the default; only one node pool may have the `%s` tag", digitaloceanKubernetesDefaultNodePoolTag)
+					log.Printf("[WARN] Multiple node pools are marked as the default; only one node pool may have the `%s` tag", digitaloceanKubernetesDefaultNodePoolTag)
 				}
 
 				keyPrefix := fmt.Sprintf("node_pool.%d.", i)
@@ -263,7 +263,7 @@ func digitaloceanKubernetesClusterRead(client *godo.Client, cluster *godo.Kubern
 		}
 	}
 	if !foundDefaultNodePool {
-		return fmt.Errorf("No default node pool was found; the default node pool must have the `%s` tag", digitaloceanKubernetesDefaultNodePoolTag)
+		log.Printf("[WARN] No default node pool was found. The default node pool must have the `%s` tag if created with Terraform.", digitaloceanKubernetesDefaultNodePoolTag)
 	}
 
 	// fetch cluster credentials and update the resource if the credentials are expired.

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-const testClusterVersion15 = "1.15.5-do.1"
-const testClusterVersion16 = "1.16.6-do.0"
+const testClusterVersion15 = "1.15.9-do.2"
+const testClusterVersion16 = "1.16.6-do.2"
 
 func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
In https://github.com/terraform-providers/terraform-provider-digitalocean/pull/365, a check was added to the `digitaloceanKubernetesClusterRead` method for the `terraform:default-node-pool` tag in order to support importing. A latter commit in that PR added a separate  `resourceDigitalOceanKubernetesClusterImportState` method that enforces this. The Kubernetes cluster data source also uses the `digitaloceanKubernetesClusterRead` method and should support accessing cluster information even if a node pool is not tagged. This PR changes the errors into warning as it is still useful for debugging.

Fixes: https://github.com/terraform-providers/terraform-provider-digitalocean/issues/399

CC @tdyas 