### PR TITLE
Validate connection pool name

### DIFF
--- a/digitalocean/resource_digitalocean_database_connection_pool.go
+++ b/digitalocean/resource_digitalocean_database_connection_pool.go
@@ -32,7 +32,7 @@ func resourceDigitalOceanDatabaseConnectionPool() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.NoZeroValues,
+				ValidateFunc: validation.StringLenBetween(3, 63),
 			},
 
 			"user": {

--- a/digitalocean/resource_digitalocean_project.go
+++ b/digitalocean/resource_digitalocean_project.go
@@ -3,11 +3,12 @@ package digitalocean
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/digitalocean/godo"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"log"
-	"strings"
 )
 
 func resourceDigitalOceanProject() *schema.Resource {

--- a/digitalocean/resource_digitalocean_project.go
+++ b/digitalocean/resource_digitalocean_project.go
@@ -35,7 +35,7 @@ func resourceDigitalOceanProject() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "",
-				Description:  "the descirption of the project",
+				Description:  "the description of the project",
 				ValidateFunc: validation.StringLenBetween(0, 255),
 			},
 			"purpose": {


### PR DESCRIPTION
As mentioned in #381, DO is returning 500 when you try to create a connection pool with a name longer than 60 characters. While generally I prefer relying on DOs validation, so that the provider doesn't have to be kept up to date with whatever changes DO makes, in this case I think adding the validation to the provider is the lesser of two evils - since DO doesn't return any validation error, making it really hard to know what's wrong.

Their UI states that the name has to be between 3 and 63 characters, which is what I've encoded into the validation, assuming that they'll fix the bug and that what they say in their UI is what it's supposed to be.

I also fixed a minor typo that I accidentally spotted.