### PR TITLE
support volumes created before name rules changed

### DIFF
--- a/digitalocean/resource_digitalocean_volume.go
+++ b/digitalocean/resource_digitalocean_volume.go
@@ -37,7 +37,7 @@ func resourceDigitalOceanVolume() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9\-]+$`), "Names must be lowercase and be composed only of numbers, letters and \"-\"."),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9\-_]+$`), "Names must be lowercase and be composed only of numbers, letters and \"-\"."),
 			},
 			"urn": {
 				Type:        schema.TypeString,

--- a/digitalocean/resource_digitalocean_volume.go
+++ b/digitalocean/resource_digitalocean_volume.go
@@ -34,9 +34,11 @@ func resourceDigitalOceanVolume() *schema.Resource {
 			},
 
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				// Underscores (_) allowed for backwards compatibility.
+				// See: https://github.com/terraform-providers/terraform-provider-digitalocean/pull/404
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9\-_]+$`), "Names must be lowercase and be composed only of numbers, letters and \"-\"."),
 			},
 			"urn": {


### PR DESCRIPTION
In 2019, DigitalOcean accepted volumes created with underscores in the name. In 2020, this is no longer the case but it leaves us without a way to work with volumes created in the old rules.

This PR allows underscores so that I can work with a couple volumes that I had created in October or so, detailed in ~~https://github.com/hashicorp/terraform/issues/24468~~ https://github.com/terraform-providers/terraform-provider-digitalocean/issues/405