### PR TITLE
add spaces_endpoint config to provider

### DIFF
--- a/digitalocean/config.go
+++ b/digitalocean/config.go
@@ -85,7 +85,7 @@ func (c *Config) Client() (*CombinedConfig, error) {
 
 	spacesEndpointTemplate, err := template.New("spaces").Parse(c.SpacesAPIEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse spacesEndpoint '%s' as template: %s", c.SpacesAPIEndpoint, err)
+		return nil, fmt.Errorf("unable to parse spaces_endpoint '%s' as template: %s", c.SpacesAPIEndpoint, err)
 	}
 
 	log.Printf("[INFO] DigitalOcean Client configured for URL: %s", godoClient.BaseURL.String())

--- a/digitalocean/config.go
+++ b/digitalocean/config.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/url"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -18,17 +19,19 @@ import (
 )
 
 type Config struct {
-	Token            string
-	APIEndpoint      string
-	AccessID         string
-	SecretKey        string
-	TerraformVersion string
+	Token             string
+	APIEndpoint       string
+	SpacesAPIEndpoint string
+	AccessID          string
+	SecretKey         string
+	TerraformVersion  string
 }
 
 type CombinedConfig struct {
-	client    *godo.Client
-	accessID  string
-	secretKey string
+	client                 *godo.Client
+	spacesEndpointTemplate *template.Template
+	accessID               string
+	secretKey              string
 }
 
 func (c *CombinedConfig) godoClient() *godo.Client { return c.client }
@@ -39,7 +42,13 @@ func (c *CombinedConfig) spacesClient(region string) (*session.Session, error) {
 		return &session.Session{}, err
 	}
 
-	endpoint := fmt.Sprintf("https://%s.digitaloceanspaces.com", region)
+	endpointWriter := strings.Builder{}
+	err := c.spacesEndpointTemplate.Execute(&endpointWriter, map[string]string{"Region": region})
+	if err != nil {
+		return &session.Session{}, err
+	}
+	endpoint := endpointWriter.String()
+
 	client, err := session.NewSession(&aws.Config{
 		Region:      aws.String("us-east-1"),
 		Credentials: credentials.NewStaticCredentials(c.accessID, c.secretKey, ""),
@@ -74,12 +83,18 @@ func (c *Config) Client() (*CombinedConfig, error) {
 	}
 	godoClient.BaseURL = apiURL
 
+	spacesEndpointTemplate, err := template.New("spaces").Parse(c.SpacesAPIEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse spacesEndpoint '%s' as template: %s", c.SpacesAPIEndpoint, err)
+	}
+
 	log.Printf("[INFO] DigitalOcean Client configured for URL: %s", godoClient.BaseURL.String())
 
 	return &CombinedConfig{
-		client:    godoClient,
-		accessID:  c.AccessID,
-		secretKey: c.SecretKey,
+		client:                 godoClient,
+		spacesEndpointTemplate: spacesEndpointTemplate,
+		accessID:               c.AccessID,
+		secretKey:              c.SecretKey,
 	}, nil
 }
 

--- a/digitalocean/provider.go
+++ b/digitalocean/provider.go
@@ -24,6 +24,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("DIGITALOCEAN_API_URL", "https://api.digitalocean.com"),
 				Description: "The URL to use for the DigitalOcean API.",
 			},
+			"spaces_endpoint": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SPACES_ENDPOINT_URL", "https://{{.Region}}.digitaloceanspaces.com"),
+				Description: "The URL to use for the DigitalOcean Spaces API.",
+			},
 			"spaces_access_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -108,11 +114,12 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData, terraformVersion string) (interface{}, error) {
 	config := Config{
-		Token:            d.Get("token").(string),
-		APIEndpoint:      d.Get("api_endpoint").(string),
-		AccessID:         d.Get("spaces_access_id").(string),
-		SecretKey:        d.Get("spaces_secret_key").(string),
-		TerraformVersion: terraformVersion,
+		Token:             d.Get("token").(string),
+		APIEndpoint:       d.Get("api_endpoint").(string),
+		SpacesAPIEndpoint: d.Get("spaces_endpoint").(string),
+		AccessID:          d.Get("spaces_access_id").(string),
+		SecretKey:         d.Get("spaces_secret_key").(string),
+		TerraformVersion:  terraformVersion,
 	}
 
 	return config.Client()

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -49,3 +49,8 @@ The following arguments are supported:
 * `api_endpoint` - (Optional) This can be used to override the base URL for
   DigitalOcean API requests (Defaults to the value of the `DIGITALOCEAN_API_URL`
   environment variable or `https://api.digitalocean.com` if unset).
+* `spaces_endpoint` - (Optional) This can be used to override the endpoint URL
+  used for DigitalOcean Spaces requests. (It defaults to the value of the
+  `SPACES_ENDPOINT_URL` environment variable or `https://{{.Region}}.digitaloceanspaces.com`
+  if unset.) The provider will replace `{{.Region}}` (via Go's templating engine) with the slug
+  of the applicable Spaces region. 


### PR DESCRIPTION
Allow the endpoint URL used for the Spaces client to be configured via a `spaces_endpoint` argument on the provider.  The Go template replacement `{{.Region}}` will be replaced by the applicable Spaces region.

Implements https://github.com/terraform-providers/terraform-provider-digitalocean/issues/384.
