### PR TITLE
digitalocean_spaces_bucket: support bucket versioning

### DIFF
--- a/digitalocean/resource_digitalocean_spaces_bucket.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket.go
@@ -189,7 +189,6 @@ func resourceDigitalOceanBucketUpdate(d *schema.ResourceData, meta interface{}) 
 
 func resourceDigitalOceanBucketRead(d *schema.ResourceData, meta interface{}) error {
 	region := d.Get("region").(string)
-	log.Printf("[DEBUG] region = %v", region)
 	client, err := meta.(*CombinedConfig).spacesClient(region)
 
 	if err != nil {
@@ -211,7 +210,7 @@ func resourceDigitalOceanBucketRead(d *schema.ResourceData, meta interface{}) er
 		} else {
 			// some of the AWS SDK's errors can be empty strings, so let's add
 			// some additional context.
-			return fmt.Errorf("error reading Spaces bucket \"%s\" (region %v): %s", d.Id(), region, err)
+			return fmt.Errorf("error reading Spaces bucket \"%s\": %s", d.Id(), err)
 		}
 	}
 

--- a/digitalocean/resource_digitalocean_spaces_bucket.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket.go
@@ -86,7 +86,6 @@ func resourceDigitalOceanBucket() *schema.Resource {
 			"versioning": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -96,6 +95,9 @@ func resourceDigitalOceanBucket() *schema.Resource {
 							Default:  false,
 						},
 					},
+				},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == "1" && new == "0"
 				},
 			},
 

--- a/digitalocean/resource_digitalocean_spaces_bucket_test.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket_test.go
@@ -225,6 +225,61 @@ func TestAccDigitalOceanBucket_shouldFailNotFound(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanBucket_Versioning(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "digitalocean_spaces_bucket.bucket"
+
+	makeConfig := func(includeClause, versioning bool) string {
+		versioningClause := ""
+		if includeClause {
+			versioningClause = fmt.Sprintf(`
+  versioning {
+    enabled = %v
+  }
+`, versioning)
+		}
+		return fmt.Sprintf(`
+resource "digitalocean_spaces_bucket" "bucket" {
+  name = "tf-test-bucket-%d"
+  region = "ams3"
+%s
+}
+`, rInt, versioningClause)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: makeConfig(false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanBucketExists(resourceName),
+					testAccCheckDigitalOceanBucketVersioning(
+						resourceName, ""),
+				),
+			},
+			{
+				Config: makeConfig(true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanBucketExists(resourceName),
+					testAccCheckDigitalOceanBucketVersioning(
+						resourceName, s3.BucketVersioningStatusEnabled),
+				),
+			},
+			{
+				Config: makeConfig(true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanBucketExists(resourceName),
+					testAccCheckDigitalOceanBucketVersioning(
+						resourceName, s3.BucketVersioningStatusSuspended),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDigitalOceanBucketDestroy(s *terraform.State) error {
 	return testAccCheckDigitalOceanBucketDestroyWithProvider(s, testAccProvider)
 }
@@ -366,6 +421,44 @@ func testAccCheckDigitalOceanBucketCors(n string, corsRules []*s3.CORSRule) reso
 
 		if !reflect.DeepEqual(out.CORSRules, corsRules) {
 			return fmt.Errorf("bad error cors rule, expected: %v, got %v", corsRules, out.CORSRules)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDigitalOceanBucketVersioning(n string, versioningStatus string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs := s.RootModule().Resources[n]
+
+		sesh, err := session.NewSession(&aws.Config{
+			Region:      aws.String(rs.Primary.Attributes["region"]),
+			Credentials: credentials.NewStaticCredentials(os.Getenv("SPACES_ACCESS_KEY_ID"), os.Getenv("SPACES_SECRET_ACCESS_KEY"), "")},
+		)
+		svc := s3.New(sesh, &aws.Config{
+			Endpoint: aws.String(fmt.Sprintf("https://%s.digitaloceanspaces.com", rs.Primary.Attributes["region"]))},
+		)
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		out, err := svc.GetBucketVersioning(&s3.GetBucketVersioningInput{
+			Bucket: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return fmt.Errorf("GetBucketVersioning error: %v", err)
+		}
+
+		if v := out.Status; v == nil {
+			if versioningStatus != "" {
+				return fmt.Errorf("bad error versioning status, found nil, expected: %s", versioningStatus)
+			}
+		} else {
+			if *v != versioningStatus {
+				return fmt.Errorf("bad error versioning status, expected: %s, got %s", versioningStatus, *v)
+			}
 		}
 
 		return nil

--- a/digitalocean/resource_digitalocean_spaces_bucket_test.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket_test.go
@@ -253,6 +253,7 @@ resource "digitalocean_spaces_bucket" "bucket" {
 		CheckDestroy: testAccCheckDigitalOceanBucketDestroy,
 		Steps: []resource.TestStep{
 			{
+				// No versioning configured.
 				Config: makeConfig(false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists(resourceName),
@@ -261,6 +262,7 @@ resource "digitalocean_spaces_bucket" "bucket" {
 				),
 			},
 			{
+				// Enable versioning
 				Config: makeConfig(true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists(resourceName),
@@ -269,7 +271,26 @@ resource "digitalocean_spaces_bucket" "bucket" {
 				),
 			},
 			{
+				// Explicitly disable versioning
 				Config: makeConfig(true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanBucketExists(resourceName),
+					testAccCheckDigitalOceanBucketVersioning(
+						resourceName, s3.BucketVersioningStatusSuspended),
+				),
+			},
+			{
+				// Re-enable versioning
+				Config: makeConfig(true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanBucketExists(resourceName),
+					testAccCheckDigitalOceanBucketVersioning(
+						resourceName, s3.BucketVersioningStatusEnabled),
+				),
+			},
+			{
+				// Remove the clause completely. Should disable versioning.
+				Config: makeConfig(false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanBucketExists(resourceName),
 					testAccCheckDigitalOceanBucketVersioning(

--- a/website/docs/r/spaces_bucket.html.markdown
+++ b/website/docs/r/spaces_bucket.html.markdown
@@ -78,6 +78,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the bucket
 * `region` - The region where the bucket resides (Defaults to `nyc3`)
 * `acl` - Canned ACL applied on bucket creation (`private` or `public-read`)
+* `cors_rule` - (Optional) A rule of Cross-Origin Resource Sharing (documented below).
+* `versioning` - (Optional) A state of versioning (documented below)
 * `force_destroy` - Unless `true`, the bucket will only be destroyed if empty (Defaults to `false`)
 
 The `cors_rule` object supports the following:
@@ -86,6 +88,11 @@ The `cors_rule` object supports the following:
 * `allowed_methods` - (Required) A list of HTTP methods (e.g. `GET`) which are allowed from the specified origin.
 * `allowed_origins` - (Required) A list of hosts from which requests using the specified methods are allowed. A host may contain one wildcard (e.g. http://*.example.com).
 * `max_age_seconds` - (Optional) The time in seconds that browser can cache the response for a preflight request.
+
+The `versioning` object supports the following:
+
+* `enabled` - (Optional) Enable versioning. Once you version-enable a bucket, it can never return to an unversioned
+state. You can, however, suspend versioning on that bucket.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Support enabling bucket versioning via `versioning` configuration similar to the [`versioning` attribute](https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#versioning) of [`aws_s3_bucket`](https://www.terraform.io/docs/providers/aws/r/s3_bucket.html).