### PR TITLE
Remove storage_class attribute from spaces_bucket_object.

### DIFF
--- a/digitalocean/resource_digitalocean_spaces_bucket_object.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket_object.go
@@ -109,15 +109,6 @@ func resourceDigitalOceanSpacesBucketObject() *schema.Resource {
 				ConflictsWith: []string{"source", "content"},
 			},
 
-			"storage_class": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					s3.ObjectStorageClassStandard,
-				}, false),
-			},
-
 			"etag": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -203,10 +194,6 @@ func resourceDigitalOceanSpacesBucketObjectPut(d *schema.ResourceData, meta inte
 		Key:    aws.String(key),
 		ACL:    aws.String(d.Get("acl").(string)),
 		Body:   body,
-	}
-
-	if v, ok := d.GetOk("storage_class"); ok {
-		putInput.StorageClass = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("cache_control"); ok {
@@ -297,13 +284,6 @@ func resourceDigitalOceanSpacesBucketObjectRead(d *schema.ResourceData, meta int
 	// See https://forums.aws.amazon.com/thread.jspa?threadID=44003
 	d.Set("etag", strings.Trim(aws.StringValue(resp.ETag), `"`))
 
-	// The "STANDARD" (which is also the default) storage
-	// class when set would not be included in the results.
-	d.Set("storage_class", s3.StorageClassStandard)
-	if resp.StorageClass != nil {
-		d.Set("storage_class", resp.StorageClass)
-	}
-
 	return nil
 }
 
@@ -322,7 +302,6 @@ func resourceDigitalOceanSpacesBucketObjectUpdate(d *schema.ResourceData, meta i
 		"metadata",
 		"server_side_encryption",
 		"source",
-		"storage_class",
 		"website_redirect",
 	} {
 		if d.HasChange(key) {

--- a/website/docs/r/spaces_bucket_object.html.markdown
+++ b/website/docs/r/spaces_bucket_object.html.markdown
@@ -77,7 +77,6 @@ The following arguments are supported:
 * `content_language` - (Optional) The language the content is in e.g. en-US or en-GB.
 * `content_type` - (Optional) A standard MIME type describing the format of the object data, e.g. application/octet-stream. All Valid MIME Types are valid for this input.
 * `website_redirect` - (Optional) Specifies a target URL for [website redirect](http://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html).
-* `storage_class` - (Optional) Provided for compatibility purposes. The value will always be "`STANDARD`".
 * `etag` - (Optional) Used to trigger updates. The only meaningful value is `${filemd5("path/to/file")}` (Terraform 0.11.12 or later) or `${md5(file("path/to/file"))}` (Terraform 0.11.11 or earlier).
 * `metadata` - (Optional) A mapping of keys/values to provision metadata (will be automatically prefixed by `x-amz-meta-`, note that only lowercase label are currently supported by the AWS Go API).
 * `force_destroy` - (Optional) Allow the object to be deleted by removing any legal hold on any object version.


### PR DESCRIPTION
Thinking this over a bit more, `storage_class` as implemented is essentially a no-op right now.

https://github.com/terraform-providers/terraform-provider-digitalocean/blob/master/digitalocean/resource_digitalocean_spaces_bucket_object.go#L300-L305

We should remove it here to not cause confusion around Spaces support for storage classes and protect against any unforeseen ways Spaces might interact with storage classes in the future.

@tdyas, any thoughts here?