### PR TITLE
spaces_bucket: Region attribute should be ForceNew.

### DIFF
--- a/digitalocean/resource_digitalocean_spaces_bucket.go
+++ b/digitalocean/resource_digitalocean_spaces_bucket.go
@@ -41,6 +41,7 @@ func resourceDigitalOceanBucket() *schema.Resource {
 			"region": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 				Description: "Bucket region",
 				Default:     "nyc3",
 				StateFunc: func(val interface{}) string {


### PR DESCRIPTION
As noted by @tdyas, the region attribute for `digitalocean_spaces_bucket` should be `ForceNew`
 
https://github.com/terraform-providers/terraform-provider-digitalocean/pull/411#issuecomment-612509653