### PR TITLE
load balancers: Fix support for multiple forwarding rules (fixes: #414).

### DIFF
--- a/digitalocean/datasource_digitalocean_loadbalancer.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer.go
@@ -47,7 +47,7 @@ func dataSourceDigitalOceanLoadbalancer() *schema.Resource {
 				Description: "current state of the Load Balancer",
 			},
 			"forwarding_rule": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -84,6 +84,7 @@ func dataSourceDigitalOceanLoadbalancer() *schema.Resource {
 					},
 				},
 				Description: "list of forwarding rules of the load balancer",
+				Set:         hashForwardingRules,
 			},
 			"healthcheck": {
 				Type:     schema.TypeList,

--- a/digitalocean/datasource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccDataSourceDigitalOceanLoadBalancer_Basic(t *testing.T) {
+	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 
@@ -33,13 +34,13 @@ func TestAccDataSourceDigitalOceanLoadBalancer_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_port", "80"),
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_port", "80"),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_protocol", "http"),
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_protocol", "http"),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_port", "80"),
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_port", "80"),
 					resource.TestCheckResourceAttr(
-						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_protocol", "http"),
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_protocol", "http"),
 					resource.TestCheckResourceAttr(
 						"data.digitalocean_loadbalancer.foobar", "healthcheck.#", "1"),
 					resource.TestCheckResourceAttr(

--- a/digitalocean/datasource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer_test.go
@@ -59,6 +59,48 @@ func TestAccDataSourceDigitalOceanLoadBalancer_Basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceDigitalOceanLoadBalancer_multipleRules(t *testing.T) {
+	t.Parallel()
+	var loadbalancer godo.LoadBalancer
+	rName := randomTestName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanLoadbalancerConfig_multipleRules(rName) + testAccCheckDataSourceDigitalOceanLoadBalancerConfig_multipleRules,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "name", rName),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "region", "nyc3"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.#", "2"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.236988772.entry_port", "443"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.236988772.entry_protocol", "https"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.236988772.target_port", "443"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.236988772.target_protocol", "https"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_port", "80"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_protocol", "http"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_port", "80"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_protocol", "http"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDataSourceDigitalOceanLoadBalancerExists(n string, loadbalancer *godo.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -130,3 +172,10 @@ data "digitalocean_loadbalancer" "foobar" {
   name = digitalocean_loadbalancer.foo.name
 }`, rInt, rInt)
 }
+
+const (
+	testAccCheckDataSourceDigitalOceanLoadBalancerConfig_multipleRules = `
+data "digitalocean_loadbalancer" "foobar" {
+  name = digitalocean_loadbalancer.foobar.name
+}`
+)

--- a/digitalocean/loadbalancer.go
+++ b/digitalocean/loadbalancer.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/digitalocean/godo"
@@ -103,7 +102,7 @@ func hashForwardingRules(v interface{}) int {
 	if v, ok := m["tls_passthrough"]; ok {
 		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
 	}
-	log.Printf("[DEBUG] HASH: %v", hashcode.String(buf.String()))
+
 	return hashcode.String(buf.String())
 }
 

--- a/digitalocean/resource_digitalocean_loadbalancer.go
+++ b/digitalocean/resource_digitalocean_loadbalancer.go
@@ -55,7 +55,7 @@ func resourceDigitalOceanLoadbalancer() *schema.Resource {
 			},
 
 			"forwarding_rule": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				MinItems: 1,
 				Elem: &schema.Resource{
@@ -102,6 +102,7 @@ func resourceDigitalOceanLoadbalancer() *schema.Resource {
 						},
 					},
 				},
+				Set: hashForwardingRules,
 			},
 
 			"healthcheck": {
@@ -284,7 +285,7 @@ func buildLoadBalancerRequest(d *schema.ResourceData) (*godo.LoadBalancerRequest
 		Algorithm:           d.Get("algorithm").(string),
 		RedirectHttpToHttps: d.Get("redirect_http_to_https").(bool),
 		EnableProxyProtocol: d.Get("enable_proxy_protocol").(bool),
-		ForwardingRules:     expandForwardingRules(d.Get("forwarding_rule").([]interface{})),
+		ForwardingRules:     expandForwardingRules(d.Get("forwarding_rule").(*schema.Set).List()),
 	}
 
 	if v, ok := d.GetOk("droplet_tag"); ok {

--- a/digitalocean/resource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/resource_digitalocean_loadbalancer_test.go
@@ -51,6 +51,7 @@ func testSweepLoadbalancer(region string) error {
 }
 
 func TestAccDigitalOceanLoadbalancer_Basic(t *testing.T) {
+	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 
@@ -72,13 +73,13 @@ func TestAccDigitalOceanLoadbalancer_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_port", "80"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_port", "80"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_protocol", "http"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_protocol", "http"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_port", "80"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_port", "80"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_protocol", "http"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_protocol", "http"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "healthcheck.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -98,6 +99,7 @@ func TestAccDigitalOceanLoadbalancer_Basic(t *testing.T) {
 }
 
 func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
+	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 
@@ -117,13 +119,13 @@ func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_port", "80"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_port", "80"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_protocol", "http"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_protocol", "http"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_port", "80"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_port", "80"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_protocol", "http"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_protocol", "http"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "healthcheck.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -145,13 +147,13 @@ func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_port", "81"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.2170174198.entry_port", "81"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_protocol", "http"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.2170174198.entry_protocol", "http"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_port", "81"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.2170174198.target_port", "81"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_protocol", "http"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.2170174198.target_protocol", "http"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "healthcheck.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -167,6 +169,7 @@ func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
 }
 
 func TestAccDigitalOceanLoadbalancer_dropletTag(t *testing.T) {
+	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 
@@ -186,13 +189,13 @@ func TestAccDigitalOceanLoadbalancer_dropletTag(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_port", "80"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_port", "80"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_protocol", "http"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_protocol", "http"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_port", "80"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_port", "80"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_protocol", "http"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_protocol", "http"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "healthcheck.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -208,6 +211,7 @@ func TestAccDigitalOceanLoadbalancer_dropletTag(t *testing.T) {
 }
 
 func TestAccDigitalOceanLoadbalancer_minimal(t *testing.T) {
+	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 
@@ -227,13 +231,13 @@ func TestAccDigitalOceanLoadbalancer_minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_port", "80"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_port", "80"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_protocol", "http"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_protocol", "http"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_port", "80"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_port", "80"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_protocol", "http"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_protocol", "http"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "healthcheck.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -253,6 +257,7 @@ func TestAccDigitalOceanLoadbalancer_minimal(t *testing.T) {
 }
 
 func TestAccDigitalOceanLoadbalancer_stickySessions(t *testing.T) {
+	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 
@@ -272,13 +277,13 @@ func TestAccDigitalOceanLoadbalancer_stickySessions(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_port", "80"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_port", "80"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_protocol", "http"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_protocol", "http"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_port", "80"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_port", "80"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_protocol", "http"),
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_protocol", "http"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "healthcheck.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -302,6 +307,7 @@ func TestAccDigitalOceanLoadbalancer_stickySessions(t *testing.T) {
 }
 
 func TestAccDigitalOceanLoadbalancer_sslTermination(t *testing.T) {
+	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	rInt := acctest.RandInt()
 	privateKeyMaterial, leafCertMaterial, certChainMaterial := generateTestCertMaterial(t)
@@ -322,14 +328,6 @@ func TestAccDigitalOceanLoadbalancer_sslTermination(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "forwarding_rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_port", "443"),
-					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.entry_protocol", "https"),
-					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_port", "80"),
-					resource.TestCheckResourceAttr(
-						"digitalocean_loadbalancer.foobar", "forwarding_rule.0.target_protocol", "http"),
-					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "redirect_http_to_https", "true"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "true"),
@@ -339,7 +337,50 @@ func TestAccDigitalOceanLoadbalancer_sslTermination(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanLoadbalancer_multipleRules(t *testing.T) {
+	t.Parallel()
+	var loadbalancer godo.LoadBalancer
+	rName := randomTestName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanLoadbalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanLoadbalancerConfig_multipleRules(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDigitalOceanLoadbalancerExists("digitalocean_loadbalancer.foobar", &loadbalancer),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "name", rName),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "region", "nyc3"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.#", "2"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.236988772.entry_port", "443"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.236988772.entry_protocol", "https"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.236988772.target_port", "443"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.236988772.target_protocol", "https"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_port", "80"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.entry_protocol", "http"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_port", "80"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "forwarding_rule.192790336.target_protocol", "http"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDigitalOceanLoadbalancer_WithVPC(t *testing.T) {
+	t.Parallel()
 	var loadbalancer godo.LoadBalancer
 	lbName := randomTestName()
 
@@ -604,6 +645,31 @@ resource "digitalocean_loadbalancer" "foobar" {
     certificate_id  = "${digitalocean_certificate.foobar.id}"
   }
 }`, rInt, privateKeyMaterial, leafCert, certChain, rInt)
+}
+
+func testAccCheckDigitalOceanLoadbalancerConfig_multipleRules(rName string) string {
+	return fmt.Sprintf(`
+resource "digitalocean_loadbalancer" "foobar" {
+  name                   = "%s"
+  region                 = "nyc3"
+
+  forwarding_rule {
+    entry_port      = 443
+    entry_protocol  = "https"
+
+    target_port     = 443
+    target_protocol = "https"
+
+    tls_passthrough = true
+  }
+
+  forwarding_rule {
+    entry_port      = 80
+    target_protocol = "http"
+    entry_protocol  = "http"
+    target_port     = 80
+  }
+}`, rName)
 }
 
 func testAccCheckDigitalOceanLoadbalancerConfig_WithVPC(name string) string {


### PR DESCRIPTION
Use `TypeSet` instead of `TypeList` as order is not important and add a test case for using multiple rules.

```
$ make testacc TESTARGS="-run='Loadbalancer|LoadBalancer' -parallel=20 -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='Loadbalancer|LoadBalancer' -parallel=20 -count=1 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDataSourceDigitalOceanLoadBalancer_Basic
=== PAUSE TestAccDataSourceDigitalOceanLoadBalancer_Basic
=== RUN   TestAccDigitalOceanLoadBalancer_importBasic
--- PASS: TestAccDigitalOceanLoadBalancer_importBasic (111.93s)
=== RUN   TestAccDigitalOceanLoadbalancer_Basic
=== PAUSE TestAccDigitalOceanLoadbalancer_Basic
=== RUN   TestAccDigitalOceanLoadbalancer_Updated
=== PAUSE TestAccDigitalOceanLoadbalancer_Updated
=== RUN   TestAccDigitalOceanLoadbalancer_dropletTag
=== PAUSE TestAccDigitalOceanLoadbalancer_dropletTag
=== RUN   TestAccDigitalOceanLoadbalancer_minimal
=== PAUSE TestAccDigitalOceanLoadbalancer_minimal
=== RUN   TestAccDigitalOceanLoadbalancer_stickySessions
=== PAUSE TestAccDigitalOceanLoadbalancer_stickySessions
=== RUN   TestAccDigitalOceanLoadbalancer_sslTermination
=== PAUSE TestAccDigitalOceanLoadbalancer_sslTermination
=== RUN   TestAccDigitalOceanLoadbalancer_multipleRules
=== PAUSE TestAccDigitalOceanLoadbalancer_multipleRules
=== RUN   TestAccDigitalOceanLoadbalancer_WithVPC
=== PAUSE TestAccDigitalOceanLoadbalancer_WithVPC
=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_Basic
=== CONT  TestAccDigitalOceanLoadbalancer_WithVPC
=== CONT  TestAccDigitalOceanLoadbalancer_dropletTag
=== CONT  TestAccDigitalOceanLoadbalancer_multipleRules
=== CONT  TestAccDigitalOceanLoadbalancer_Updated
=== CONT  TestAccDigitalOceanLoadbalancer_Basic
=== CONT  TestAccDigitalOceanLoadbalancer_sslTermination
=== CONT  TestAccDigitalOceanLoadbalancer_stickySessions
=== CONT  TestAccDigitalOceanLoadbalancer_minimal
--- PASS: TestAccDigitalOceanLoadbalancer_multipleRules (59.78s)
--- PASS: TestAccDigitalOceanLoadbalancer_sslTermination (71.76s)
--- PASS: TestAccDataSourceDigitalOceanLoadBalancer_Basic (114.45s)
--- PASS: TestAccDigitalOceanLoadbalancer_stickySessions (121.30s)
--- PASS: TestAccDigitalOceanLoadbalancer_minimal (121.63s)
--- PASS: TestAccDigitalOceanLoadbalancer_Basic (123.05s)
--- PASS: TestAccDigitalOceanLoadbalancer_WithVPC (124.81s)
--- PASS: TestAccDigitalOceanLoadbalancer_dropletTag (133.49s)
--- PASS: TestAccDigitalOceanLoadbalancer_Updated (154.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	266.240s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/internal/datalist	0.006s [no tests to run]
```

Fixes #414 