### PR TITLE
Fix handling of CAA records with iodef tag (fixes: #421).

### DIFF
--- a/digitalocean/resource_digitalocean_record.go
+++ b/digitalocean/resource_digitalocean_record.go
@@ -197,7 +197,7 @@ func resourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if t := rec.Type; t == "CNAME" || t == "MX" || t == "NS" || t == "SRV" || t == "CAA" {
-		if rec.Data != "@" {
+		if rec.Data != "@" && rec.Tag != "iodef" {
 			rec.Data += "."
 		}
 	}

--- a/digitalocean/resource_digitalocean_record_test.go
+++ b/digitalocean/resource_digitalocean_record_test.go
@@ -525,6 +525,38 @@ func TestAccDigitalOceanRecord_CaaUpdated(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanRecord_iodefCAA(t *testing.T) {
+	var record godo.DomainRecord
+	domain := fmt.Sprintf("foobar-test-terraform-%s.com", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(
+					testAccCheckDigitalOceanRecordConfig_iodef, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanRecordExists("digitalocean_record.CAA_iodef", &record),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.CAA_iodef", "name", "@"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.CAA_iodef", "domain", domain),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.CAA_iodef", "value", "mailto:caa-failures@example.com"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.CAA_iodef", "type", "CAA"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.CAA_iodef", "flags", "0"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.CAA_iodef", "tag", "iodef"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDigitalOceanRecordDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*CombinedConfig).godoClient()
 
@@ -812,4 +844,17 @@ resource "digitalocean_record" "foo_record" {
   value = "letsencrypt.org."
   flags = "%s"
   tag   = "%s"
+}`
+
+const testAccCheckDigitalOceanRecordConfig_iodef = `
+resource "digitalocean_domain" "foobar" {
+  name       = "%s"
+}
+resource "digitalocean_record" "CAA_iodef" {
+  domain = digitalocean_domain.foobar.name
+  type  = "CAA"
+  tag   = "iodef"
+  flags = "0"
+  name  = "@"
+  value = "mailto:caa-failures@example.com"
 }`


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-digitalocean/issues/421

New test failing before change:

```
asb@asb-home:~/development/gocode/src/github.com/terraform-providers/terraform-provider-digitalocean$ make testacc TESTARGS="-run='TestAccDigitalOceanRecord_iodefCAA' -parallel=20 -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccDigitalOceanRecord_iodefCAA' -parallel=20 -count=1 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanRecord_iodefCAA
--- FAIL: TestAccDigitalOceanRecord_iodefCAA (3.81s)
    testing.go:640: Step 0 error: Check failed: Check 4/7 error: digitalocean_record.CAA_iodef: Attribute 'value' expected "mailto:caa-failures@example.com", got "mailto:caa-failures@example.com."
FAIL
FAIL	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	3.821s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/internal/datalist	0.006s [no tests to run]
FAIL
make: *** [GNUmakefile:18: testacc] Error 1
```

Passing after change:

```
asb@asb-home:~/development/gocode/src/github.com/terraform-providers/terraform-provider-digitalocean$ make testacc TESTARGS="-run='TestAccDigitalOceanRecord_iodefCAA' -parallel=20 -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccDigitalOceanRecord_iodefCAA' -parallel=20 -count=1 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanRecord_iodefCAA
--- PASS: TestAccDigitalOceanRecord_iodefCAA (4.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	4.621s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/internal/datalist	0.006s [no tests to run]
```

CC: @NicholasPCole 