### PR TITLE
Fixed incorrect data reference

### DIFF
--- a/website/docs/d/vpc.html.md
+++ b/website/docs/d/vpc.html.md
@@ -39,7 +39,7 @@ resource "digitalocean_droplet" "example" {
   size     = "s-1vcpu-1gb"
   image    = "ubuntu-18-04-x64"
   region   = "nyc3"
-  vpc_uuid = digitalocean_vpc.example.id
+  vpc_uuid = data.digitalocean_vpc.example.id
 }
 ```
 


### PR DESCRIPTION
`.data` is required to access the example vpc data.

https://github.com/terraform-providers/terraform-provider-aws/issues/11258