### PR TITLE
load balancers: Add support for backend keepalive (Fixes: #427).

### DIFF
--- a/digitalocean/datasource_digitalocean_loadbalancer.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer.go
@@ -178,6 +178,11 @@ func dataSourceDigitalOceanLoadbalancer() *schema.Resource {
 				Computed:    true,
 				Description: "whether PROXY Protocol should be used to pass information from connecting client requests to the backend service",
 			},
+			"enable_backend_keepalive": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "whether whether HTTP keepalive connections are maintained to target Droplets",
+			},
 			"vpc_uuid": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -238,6 +243,7 @@ func dataSourceDigitalOceanLoadbalancerRead(d *schema.ResourceData, meta interfa
 	d.Set("droplet_tag", loadbalancer.Tag)
 	d.Set("redirect_http_to_https", loadbalancer.RedirectHttpToHttps)
 	d.Set("enable_proxy_protocol", loadbalancer.EnableProxyProtocol)
+	d.Set("enable_backend_keepalive", loadbalancer.EnableBackendKeepalive)
 	d.Set("vpc_uuid", loadbalancer.VPCUUID)
 
 	if err := d.Set("droplet_ids", flattenDropletIds(loadbalancer.DropletIDs)); err != nil {

--- a/digitalocean/datasource_digitalocean_loadbalancer.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer.go
@@ -181,7 +181,7 @@ func dataSourceDigitalOceanLoadbalancer() *schema.Resource {
 			"enable_backend_keepalive": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "whether whether HTTP keepalive connections are maintained to target Droplets",
+				Description: "whether HTTP keepalive connections are maintained to target Droplets",
 			},
 			"vpc_uuid": {
 				Type:        schema.TypeString,

--- a/digitalocean/datasource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/datasource_digitalocean_loadbalancer_test.go
@@ -53,6 +53,10 @@ func TestAccDataSourceDigitalOceanLoadBalancer_Basic(t *testing.T) {
 						"data.digitalocean_loadbalancer.foobar", "urn", expectedURNRegEx),
 					resource.TestCheckResourceAttrSet(
 						"data.digitalocean_loadbalancer.foobar", "vpc_uuid"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "false"),
+					resource.TestCheckResourceAttr(
+						"data.digitalocean_loadbalancer.foobar", "enable_backend_keepalive", "false"),
 				),
 			},
 		},

--- a/digitalocean/resource_digitalocean_loadbalancer.go
+++ b/digitalocean/resource_digitalocean_loadbalancer.go
@@ -215,6 +215,12 @@ func resourceDigitalOceanLoadbalancer() *schema.Resource {
 				Default:  false,
 			},
 
+			"enable_backend_keepalive": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"vpc_uuid": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -280,12 +286,13 @@ func resourceDigitalOceanLoadbalancer() *schema.Resource {
 
 func buildLoadBalancerRequest(d *schema.ResourceData) (*godo.LoadBalancerRequest, error) {
 	opts := &godo.LoadBalancerRequest{
-		Name:                d.Get("name").(string),
-		Region:              d.Get("region").(string),
-		Algorithm:           d.Get("algorithm").(string),
-		RedirectHttpToHttps: d.Get("redirect_http_to_https").(bool),
-		EnableProxyProtocol: d.Get("enable_proxy_protocol").(bool),
-		ForwardingRules:     expandForwardingRules(d.Get("forwarding_rule").(*schema.Set).List()),
+		Name:                   d.Get("name").(string),
+		Region:                 d.Get("region").(string),
+		Algorithm:              d.Get("algorithm").(string),
+		RedirectHttpToHttps:    d.Get("redirect_http_to_https").(bool),
+		EnableProxyProtocol:    d.Get("enable_proxy_protocol").(bool),
+		EnableBackendKeepalive: d.Get("enable_backend_keepalive").(bool),
+		ForwardingRules:        expandForwardingRules(d.Get("forwarding_rule").(*schema.Set).List()),
 	}
 
 	if v, ok := d.GetOk("droplet_tag"); ok {
@@ -369,6 +376,7 @@ func resourceDigitalOceanLoadbalancerRead(d *schema.ResourceData, meta interface
 	d.Set("region", loadbalancer.Region.Slug)
 	d.Set("redirect_http_to_https", loadbalancer.RedirectHttpToHttps)
 	d.Set("enable_proxy_protocol", loadbalancer.EnableProxyProtocol)
+	d.Set("enable_backend_keepalive", loadbalancer.EnableBackendKeepalive)
 	d.Set("droplet_tag", loadbalancer.Tag)
 	d.Set("vpc_uuid", loadbalancer.VPCUUID)
 

--- a/digitalocean/resource_digitalocean_loadbalancer_test.go
+++ b/digitalocean/resource_digitalocean_loadbalancer_test.go
@@ -92,6 +92,10 @@ func TestAccDigitalOceanLoadbalancer_Basic(t *testing.T) {
 						"digitalocean_loadbalancer.foobar", "vpc_uuid"),
 					resource.TestMatchResourceAttr(
 						"digitalocean_loadbalancer.foobar", "urn", expectedURNRegEx),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "true"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "enable_backend_keepalive", "true"),
 				),
 			},
 		},
@@ -134,6 +138,10 @@ func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
 						"digitalocean_loadbalancer.foobar", "healthcheck.0.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "droplet_ids.#", "1"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "true"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "enable_backend_keepalive", "true"),
 				),
 			},
 			{
@@ -162,6 +170,10 @@ func TestAccDigitalOceanLoadbalancer_Updated(t *testing.T) {
 						"digitalocean_loadbalancer.foobar", "healthcheck.0.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "droplet_ids.#", "2"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "false"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "enable_backend_keepalive", "false"),
 				),
 			},
 		},
@@ -250,6 +262,10 @@ func TestAccDigitalOceanLoadbalancer_minimal(t *testing.T) {
 						"digitalocean_loadbalancer.foobar", "sticky_sessions.0.type", "none"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_loadbalancer.foobar", "droplet_ids.#", "1"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "enable_proxy_protocol", "false"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_loadbalancer.foobar", "enable_backend_keepalive", "false"),
 				),
 			},
 		},
@@ -458,7 +474,7 @@ func testAccCheckDigitalOceanLoadbalancerConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
   name      = "foo-%d"
-  size      = "512mb"
+  size      = "s-1vcpu-1gb"
   image     = "centos-7-x64"
   region    = "nyc3"
 }
@@ -480,7 +496,10 @@ resource "digitalocean_loadbalancer" "foobar" {
     protocol = "tcp"
   }
 
-  droplet_ids = ["${digitalocean_droplet.foobar.id}"]
+  enable_proxy_protocol    = true
+  enable_backend_keepalive = true
+
+  droplet_ids = [digitalocean_droplet.foobar.id]
 }`, rInt, rInt)
 }
 
@@ -488,14 +507,14 @@ func testAccCheckDigitalOceanLoadbalancerConfig_updated(rInt int) string {
 	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
   name      = "foo-%d"
-  size      = "512mb"
+  size      = "s-1vcpu-1gb"
   image     = "centos-7-x64"
   region    = "nyc3"
 }
 
 resource "digitalocean_droplet" "foo" {
   name      = "foo-%d"
-  size      = "512mb"
+  size      = "s-1vcpu-1gb"
   image     = "centos-7-x64"
   region    = "nyc3"
 }
@@ -517,7 +536,10 @@ resource "digitalocean_loadbalancer" "foobar" {
     protocol = "tcp"
   }
 
-  droplet_ids = ["${digitalocean_droplet.foobar.id}","${digitalocean_droplet.foo.id}"]
+  enable_proxy_protocol    = false
+  enable_backend_keepalive = false
+
+  droplet_ids = [digitalocean_droplet.foobar.id, digitalocean_droplet.foo.id]
 }`, rInt, rInt, rInt)
 }
 

--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -110,6 +110,7 @@ Default value is `false`.
 * `enable_proxy_protocol` - (Optional) A boolean value indicating whether PROXY
 Protocol should be used to pass information from connecting client requests to
 the backend service. Default value is `false`.
+* `enable_backend_keepalive` - (Optional) A boolean value indicating whether HTTP keepalive connections are maintained to target Droplets. Default value is `false`.
 * `vpc_uuid` - (Optional) The ID of the VPC where the load balancer will be located.
 * `droplet_ids` (Optional) - A list of the IDs of each droplet to be attached to the Load Balancer.
 * `droplet_tag` (Optional) - The name of a Droplet tag corresponding to Droplets to be assigned to the Load Balancer.
@@ -143,7 +144,7 @@ the backend service. Default value is `false`.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following attributes are exported:
 
 * `id` - The ID of the Load Balancer
 * `ip`- The ip of the Load Balancer


### PR DESCRIPTION
https://developers.digitalocean.com/documentation/changelog/api-v2/backend-keepalive-for-load-balancers/

```
$ make testacc TESTARGS="-run='TestAccDigitalOceanLoadbalancer|TestAccDataSourceDigitalOceanLoadBalancer' -parallel=10 -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccDigitalOceanLoadbalancer|TestAccDataSourceDigitalOceanLoadBalancer' -parallel=10 -count=1 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDataSourceDigitalOceanLoadBalancer_Basic
=== PAUSE TestAccDataSourceDigitalOceanLoadBalancer_Basic
=== RUN   TestAccDataSourceDigitalOceanLoadBalancer_multipleRules
=== PAUSE TestAccDataSourceDigitalOceanLoadBalancer_multipleRules
=== RUN   TestAccDigitalOceanLoadbalancer_Basic
=== PAUSE TestAccDigitalOceanLoadbalancer_Basic
=== RUN   TestAccDigitalOceanLoadbalancer_Updated
=== PAUSE TestAccDigitalOceanLoadbalancer_Updated
=== RUN   TestAccDigitalOceanLoadbalancer_dropletTag
=== PAUSE TestAccDigitalOceanLoadbalancer_dropletTag
=== RUN   TestAccDigitalOceanLoadbalancer_minimal
=== PAUSE TestAccDigitalOceanLoadbalancer_minimal
=== RUN   TestAccDigitalOceanLoadbalancer_stickySessions
=== PAUSE TestAccDigitalOceanLoadbalancer_stickySessions
=== RUN   TestAccDigitalOceanLoadbalancer_sslTermination
=== PAUSE TestAccDigitalOceanLoadbalancer_sslTermination
=== RUN   TestAccDigitalOceanLoadbalancer_multipleRules
=== PAUSE TestAccDigitalOceanLoadbalancer_multipleRules
=== RUN   TestAccDigitalOceanLoadbalancer_WithVPC
=== PAUSE TestAccDigitalOceanLoadbalancer_WithVPC
=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_Basic
=== CONT  TestAccDigitalOceanLoadbalancer_minimal
=== CONT  TestAccDigitalOceanLoadbalancer_dropletTag
=== CONT  TestAccDigitalOceanLoadbalancer_Updated
=== CONT  TestAccDigitalOceanLoadbalancer_multipleRules
=== CONT  TestAccDigitalOceanLoadbalancer_Basic
=== CONT  TestAccDigitalOceanLoadbalancer_WithVPC
=== CONT  TestAccDataSourceDigitalOceanLoadBalancer_multipleRules
=== CONT  TestAccDigitalOceanLoadbalancer_stickySessions
=== CONT  TestAccDigitalOceanLoadbalancer_sslTermination
--- PASS: TestAccDigitalOceanLoadbalancer_multipleRules (89.04s)
--- PASS: TestAccDataSourceDigitalOceanLoadBalancer_multipleRules (91.73s)
--- PASS: TestAccDigitalOceanLoadbalancer_sslTermination (99.87s)
--- PASS: TestAccDigitalOceanLoadbalancer_Basic (130.57s)
--- PASS: TestAccDigitalOceanLoadbalancer_minimal (141.44s)
--- PASS: TestAccDataSourceDigitalOceanLoadBalancer_Basic (142.27s)
--- PASS: TestAccDigitalOceanLoadbalancer_dropletTag (152.50s)
--- PASS: TestAccDigitalOceanLoadbalancer_stickySessions (152.96s)
--- PASS: TestAccDigitalOceanLoadbalancer_WithVPC (163.11s)
--- PASS: TestAccDigitalOceanLoadbalancer_Updated (168.53s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	168.550s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/internal/datalist	0.013s [no tests to run]
```