### PR TITLE
kubernetes: Fail faster on cluster create error (fixes: #434).

### DIFF
--- a/digitalocean/resource_digitalocean_kubernetes_cluster.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster.go
@@ -485,6 +485,11 @@ func waitForKubernetesClusterCreate(client *godo.Client, id string) (*godo.Kuber
 			return cluster, nil
 		}
 
+		if cluster.Status.State == "error" {
+			ticker.Stop()
+			return nil, fmt.Errorf(cluster.Status.Message)
+		}
+
 		if n > timeout {
 			ticker.Stop()
 			break

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-const testClusterVersion15 = "1.15.9-do.2"
-const testClusterVersion16 = "1.16.6-do.2"
+const testClusterVersion15 = "1.15.11-do.0"
+const testClusterVersion16 = "1.16.8-do.0"
 
 func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
I was able to reproduce the issue reported in #434 using the API directly. The `cluster.Status.State` is  actually:

```
    "status": {
      "state": "error",
      "message": "requesting droplet create via droplet service: rpc error: code = Internal desc = An internal error has occurred. Please try again."
    },
```

We are currently only polling for it to move to "running." We could have failed faster here instead of waiting for a timeout. While the error message returned by the API is not great, it would at least have indicated to the user that there was a problem.

```
$ make testacc TESTARGS="-run='TestAccDigitalOceanKubernetesCluster' -parallel=20 -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccDigitalOceanKubernetesCluster' -parallel=20 -count=1 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanKubernetesCluster_ImportBasic
--- PASS: TestAccDigitalOceanKubernetesCluster_ImportBasic (365.71s)
=== RUN   TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool
--- PASS: TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool (575.61s)
=== RUN   TestAccDigitalOceanKubernetesCluster_Basic
=== PAUSE TestAccDigitalOceanKubernetesCluster_Basic
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== RUN   TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale
=== PAUSE TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale
=== RUN   TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== PAUSE TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== RUN   TestAccDigitalOceanKubernetesCluster_UpgradeVersion
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpgradeVersion
=== CONT  TestAccDigitalOceanKubernetesCluster_Basic
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== CONT  TestAccDigitalOceanKubernetesCluster_UpgradeVersion
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== CONT  TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale
=== CONT  TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
--- PASS: TestAccDigitalOceanKubernetesCluster_UpgradeVersion (334.86s)
--- PASS: TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability (394.88s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale (404.69s)
--- PASS: TestAccDigitalOceanKubernetesCluster_Basic (422.46s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails (554.61s)
--- PASS: TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale (603.10s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdateCluster (765.28s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolSize (774.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	1716.054s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/internal/datalist	0.013s [no tests to run]
```