### PR TITLE
kubernetes: Re-work tests to no longer rely on hard-coded versions.

### DIFF
--- a/digitalocean/import_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_cluster_test.go
@@ -21,7 +21,7 @@ func TestAccDigitalOceanKubernetesCluster_ImportBasic(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(clusterName, testClusterVersion16),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion16, clusterName),
 				// Remove the default node pool tag so that the import code which infers
 				// the need to add the tag gets triggered.
 				Check: testAccDigitalOceanKubernetesRemoveDefaultNodePoolTag(clusterName),
@@ -92,11 +92,12 @@ func TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool(t *testing.T)
 	testName1 := randomTestName()
 	testName2 := randomTestName()
 
-	config := fmt.Sprintf(`
+	config := fmt.Sprintf(`%s
+
 resource "digitalocean_kubernetes_cluster" "foobar" {
   name = "%s"
   region = "lon1"
-  version = "%s"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
   node_pool {
     name = "default"
@@ -106,12 +107,12 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 }
 
 resource "digitalocean_kubernetes_node_pool" "barfoo" {
-  cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
+  cluster_id = digitalocean_kubernetes_cluster.foobar.id
   name = "%s"
   size = "s-1vcpu-2gb"
   node_count = 1
 }
-`, testName1, testClusterVersion16, testName2)
+`, testClusterVersion16, testName1, testName2)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/import_digitalocean_kubernetes_node_pool_test.go
@@ -12,11 +12,12 @@ func TestAccDigitalOceanKubernetesNodePool_Import(t *testing.T) {
 	testName1 := randomTestName()
 	testName2 := randomTestName()
 
-	config := fmt.Sprintf(`
+	config := fmt.Sprintf(`%s
+
 resource "digitalocean_kubernetes_cluster" "foobar" {
   name = "%s"
   region = "lon1"
-  version = "%s"
+  version = data.digitalocean_kubernetes_versions.test.latest_version
 
   node_pool {
     name = "default"
@@ -31,7 +32,7 @@ resource "digitalocean_kubernetes_node_pool" "barfoo" {
   size = "s-1vcpu-2gb"
   node_count = 1
 }
-`, testName1, testClusterVersion16, testName2)
+`, testClusterVersion16, testName1, testName2)
 	resourceName := "digitalocean_kubernetes_node_pool.barfoo"
 
 	resource.Test(t, resource.TestCase{

--- a/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_cluster_test.go
@@ -13,8 +13,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-const testClusterVersion15 = "1.15.9-do.2"
-const testClusterVersion16 = "1.16.6-do.2"
+const (
+	testClusterVersion15 = `data "digitalocean_kubernetes_versions" "test" {
+  version_prefix = "1.15."
+}`
+	testClusterVersion16 = `data "digitalocean_kubernetes_versions" "test" {
+  version_prefix = "1.16."
+}`
+)
 
 func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 	t.Parallel()
@@ -27,12 +33,12 @@ func TestAccDigitalOceanKubernetesCluster_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(rName, testClusterVersion16),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "region", "lon1"),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", testClusterVersion16),
+					resource.TestCheckResourceAttrPair("digitalocean_kubernetes_cluster.foobar", "version", "data.digitalocean_kubernetes_versions.test", "latest_version"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "ipv4_address"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "cluster_subnet"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "service_subnet"),
@@ -80,14 +86,14 @@ func TestAccDigitalOceanKubernetesCluster_UpdateCluster(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(rName, testClusterVersion16),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic4(rName+"-updated", testClusterVersion16),
+				Config: testAccDigitalOceanKubernetesConfigBasic4(testClusterVersion16, rName+"-updated"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName+"-updated"),
@@ -112,7 +118,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(rName, testClusterVersion16),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -123,7 +129,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic2(rName, testClusterVersion16),
+				Config: testAccDigitalOceanKubernetesConfigBasic2(testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -152,7 +158,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolSize(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(rName, testClusterVersion16),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -163,7 +169,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolSize(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic3(rName, testClusterVersion16),
+				Config: testAccDigitalOceanKubernetesConfigBasic3(testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -189,11 +195,12 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 		Steps: []resource.TestStep{
 			// Create with auto-scaling and explicit node_count.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 					resource "digitalocean_kubernetes_cluster" "foobar" {
 						name    = "%s"
 						region  = "lon1"
-						version = "%s"
+						version = data.digitalocean_kubernetes_versions.test.latest_version
 
 						node_pool {
 							name = "default"
@@ -204,7 +211,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, rName, testClusterVersion16),
+				`, testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -219,11 +226,12 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 			},
 			// Remove node_count, keep auto-scaling.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 					resource "digitalocean_kubernetes_cluster" "foobar" {
 						name    = "%s"
 						region  = "lon1"
-						version = "%s"
+						version = data.digitalocean_kubernetes_versions.test.latest_version
 
 						node_pool {
 							name = "default"
@@ -233,7 +241,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, rName, testClusterVersion16),
+				`, testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -248,11 +256,12 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 			},
 			// Update node_count, keep auto-scaling.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 					resource "digitalocean_kubernetes_cluster" "foobar" {
 						name    = "%s"
 						region  = "lon1"
-						version = "%s"
+						version = data.digitalocean_kubernetes_versions.test.latest_version
 
 						node_pool {
 							name = "default"
@@ -263,7 +272,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, rName, testClusterVersion16),
+				`, testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -278,11 +287,12 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 			},
 			// Disable auto-scaling.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 					resource "digitalocean_kubernetes_cluster" "foobar" {
 						name    = "%s"
 						region  = "lon1"
-						version = "%s"
+						version = data.digitalocean_kubernetes_versions.test.latest_version
 
 						node_pool {
 							name = "default"
@@ -290,7 +300,7 @@ func TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale(t *testing.T) 
 							node_count = 2
 						}
 					}
-				`, rName, testClusterVersion16),
+				`, testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -319,11 +329,12 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 		Steps: []resource.TestStep{
 			// Create with auto-scaling disabled.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 				resource "digitalocean_kubernetes_cluster" "foobar" {
 					name    = "%s"
 					region  = "lon1"
-					version = "%s"
+					version = data.digitalocean_kubernetes_versions.test.latest_version
 
 					node_pool {
 						name = "default"
@@ -331,7 +342,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 						node_count = 1
 					}
 				}
-			`, rName, testClusterVersion16),
+			`, testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -346,11 +357,12 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 			},
 			// Enable auto-scaling with explicit node_count.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 					resource "digitalocean_kubernetes_cluster" "foobar" {
 						name    = "%s"
 						region  = "lon1"
-						version = "%s"
+						version = data.digitalocean_kubernetes_versions.test.latest_version
 
 						node_pool {
 							name = "default"
@@ -361,7 +373,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, rName, testClusterVersion16),
+				`, testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -376,11 +388,12 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 			},
 			// Remove node_count, keep auto-scaling.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 					resource "digitalocean_kubernetes_cluster" "foobar" {
 						name    = "%s"
 						region  = "lon1"
-						version = "%s"
+						version = data.digitalocean_kubernetes_versions.test.latest_version
 
 						node_pool {
 							name = "default"
@@ -390,7 +403,7 @@ func TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale(t *testing.T) 
 							max_nodes = 3
 						}
 					}
-				`, rName, testClusterVersion16),
+				`, testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "name", rName),
@@ -418,7 +431,7 @@ func TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability(t *
 		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(rName, testClusterVersion16),
+				Config: testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s), resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.raw_config"),
 					resource.TestCheckResourceAttrSet("digitalocean_kubernetes_cluster.foobar", "kube_config.0.cluster_ca_certificate"),
@@ -441,30 +454,31 @@ func TestAccDigitalOceanKubernetesCluster_UpgradeVersion(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(rName, testClusterVersion15),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion15, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", testClusterVersion15),
+					resource.TestCheckResourceAttrPair("digitalocean_kubernetes_cluster.foobar", "version", "data.digitalocean_kubernetes_versions.test", "latest_version"),
 				),
 			},
 			{
-				Config: testAccDigitalOceanKubernetesConfigBasic(rName, testClusterVersion16),
+				Config: testAccDigitalOceanKubernetesConfigBasic(testClusterVersion16, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPtr("digitalocean_kubernetes_cluster.foobar", "id", &k8s.ID),
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
-					resource.TestCheckResourceAttr("digitalocean_kubernetes_cluster.foobar", "version", testClusterVersion16),
+					resource.TestCheckResourceAttrPair("digitalocean_kubernetes_cluster.foobar", "version", "data.digitalocean_kubernetes_versions.test", "latest_version"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDigitalOceanKubernetesConfigBasic(rName string, testClusterVersion string) string {
-	return fmt.Sprintf(`
+func testAccDigitalOceanKubernetesConfigBasic(testClusterVersion string, rName string) string {
+	return fmt.Sprintf(`%s
+
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "%s"
+	version = data.digitalocean_kubernetes_versions.test.latest_version
 	tags    = ["foo","bar", "one"]
 
 	node_pool {
@@ -477,15 +491,16 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
         }
 	}
 }
-`, rName, testClusterVersion)
+`, testClusterVersion, rName)
 }
 
-func testAccDigitalOceanKubernetesConfigBasic2(rName string, testClusterVersion string) string {
-	return fmt.Sprintf(`
+func testAccDigitalOceanKubernetesConfigBasic2(testClusterVersion string, rName string) string {
+	return fmt.Sprintf(`%s
+
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "%s"
+	version = data.digitalocean_kubernetes_versions.test.latest_version
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -499,15 +514,16 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
         }
 	}
 }
-`, rName, testClusterVersion)
+`, testClusterVersion, rName)
 }
 
-func testAccDigitalOceanKubernetesConfigBasic3(rName string, testClusterVersion string) string {
-	return fmt.Sprintf(`
+func testAccDigitalOceanKubernetesConfigBasic3(testClusterVersion string, rName string) string {
+	return fmt.Sprintf(`%s
+
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "%s"
+	version = data.digitalocean_kubernetes_versions.test.latest_version
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -517,15 +533,16 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 		tags  = ["one","two"]
 	}
 }
-`, rName, testClusterVersion)
+`, testClusterVersion, rName)
 }
 
-func testAccDigitalOceanKubernetesConfigBasic4(rName string, testClusterVersion string) string {
-	return fmt.Sprintf(`
+func testAccDigitalOceanKubernetesConfigBasic4(testClusterVersion string, rName string) string {
+	return fmt.Sprintf(`%s
+
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "%s"
+	version = data.digitalocean_kubernetes_versions.test.latest_version
 	tags    = ["one","two"]
 
 	node_pool {
@@ -535,15 +552,16 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 		tags  = ["foo","bar"]
 	}
 }
-`, rName, testClusterVersion)
+`, testClusterVersion, rName)
 }
 
-func testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(rName string, testClusterVersion string) string {
-	return fmt.Sprintf(`
+func testAccDigitalOceanKubernetesConfig_KubernetesProviderInteroperability(testClusterVersion string, rName string) string {
+	return fmt.Sprintf(`%s
+
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "%s"
+	version = data.digitalocean_kubernetes_versions.test.latest_version
 
 	node_pool {
 	  name = "default"
@@ -569,7 +587,7 @@ resource "kubernetes_service_account" "tiller" {
 
   automount_service_account_token = true
 }
-`, rName, testClusterVersion)
+`, testClusterVersion, rName)
 }
 
 func testAccCheckDigitalOceanKubernetesClusterDestroy(s *terraform.State) error {

--- a/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
+++ b/digitalocean/resource_digitalocean_kubernetes_node_pool_test.go
@@ -92,11 +92,12 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create without auto-scaling.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 					resource "digitalocean_kubernetes_cluster" "foobar" {
 						name = "%s"
 						region = "lon1"
-						version = "%s"
+						version = data.digitalocean_kubernetes_versions.test.latest_version
 
 						node_pool {
 							name = "default"
@@ -114,7 +115,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 5
 					}
-				`, rName, testClusterVersion16, rName),
+				`, testClusterVersion16, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -130,11 +131,12 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 			},
 			// Remove node count, keep auto-scaling.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 					resource "digitalocean_kubernetes_cluster" "foobar" {
 						name = "%s"
 						region = "lon1"
-						version = "%s"
+						version = data.digitalocean_kubernetes_versions.test.latest_version
 
 						node_pool {
 							name = "default"
@@ -151,7 +153,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, rName, testClusterVersion16, rName),
+				`, testClusterVersion16, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -167,11 +169,12 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 			},
 			// Update node count, keep auto-scaling.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 					resource "digitalocean_kubernetes_cluster" "foobar" {
 						name = "%s"
 						region = "lon1"
-						version = "%s"
+						version = data.digitalocean_kubernetes_versions.test.latest_version
 
 						node_pool {
 							name = "default"
@@ -189,7 +192,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, rName, testClusterVersion16, rName),
+				`, testClusterVersion16, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -205,11 +208,12 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 			},
 			// Disable auto-scaling.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 					resource "digitalocean_kubernetes_cluster" "foobar" {
 						name = "%s"
 						region = "lon1"
-						version = "%s"
+						version = data.digitalocean_kubernetes_versions.test.latest_version
 
 						node_pool {
 							name = "default"
@@ -224,7 +228,7 @@ func TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale(t *testing.T) {
 						size = "s-1vcpu-2gb"
 						node_count = 2
 					}
-				`, rName, testClusterVersion16, rName),
+				`, testClusterVersion16, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -255,11 +259,12 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create without auto-scaling.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 					resource "digitalocean_kubernetes_cluster" "foobar" {
 						name = "%s"
 						region = "lon1"
-						version = "%s"
+						version = data.digitalocean_kubernetes_versions.test.latest_version
 
 						node_pool {
 							name = "default"
@@ -274,7 +279,7 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 						size = "s-1vcpu-2gb"
 						node_count = 1
 					}
-				`, rName, testClusterVersion16, rName),
+				`, testClusterVersion16, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -290,11 +295,12 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 			},
 			// Update to enable auto-scaling.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 					resource "digitalocean_kubernetes_cluster" "foobar" {
 						name = "%s"
 						region = "lon1"
-						version = "%s"
+						version = data.digitalocean_kubernetes_versions.test.latest_version
 
 						node_pool {
 							name = "default"
@@ -312,7 +318,7 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, rName, testClusterVersion16, rName),
+				`, testClusterVersion16, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -328,11 +334,12 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 			},
 			// Remove node count, keep auto-scaling.
 			{
-				Config: fmt.Sprintf(`
+				Config: fmt.Sprintf(`%s
+
 					resource "digitalocean_kubernetes_cluster" "foobar" {
 						name = "%s"
 						region = "lon1"
-						version = "%s"
+						version = data.digitalocean_kubernetes_versions.test.latest_version
 
 						node_pool {
 							name = "default"
@@ -349,7 +356,7 @@ func TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale(t *testing.T) {
 						min_nodes = 1
 						max_nodes = 3
 					}
-				`, rName, testClusterVersion16, rName),
+				`, testClusterVersion16, rName, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDigitalOceanKubernetesClusterExists("digitalocean_kubernetes_cluster.foobar", &k8s),
 					testAccCheckDigitalOceanKubernetesNodePoolExists("digitalocean_kubernetes_node_pool.barfoo", &k8s, &k8sPool),
@@ -397,11 +404,12 @@ func TestAccDigitalOceanKubernetesNodePool_WithEmptyNodePool(t *testing.T) {
 }
 
 func testAccDigitalOceanKubernetesConfigBasicWithNodePool(rName string) string {
-	return fmt.Sprintf(`
+	return fmt.Sprintf(`%s
+
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "%s"
+	version = data.digitalocean_kubernetes_versions.test.latest_version
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -420,15 +428,16 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 	node_count = 1
 	tags  = ["three","four"]
 }
-`, rName, testClusterVersion16, rName)
+`, testClusterVersion16, rName, rName)
 }
 
 func testAccDigitalOceanKubernetesConfigBasicWithNodePool2(rName string) string {
-	return fmt.Sprintf(`
+	return fmt.Sprintf(`%s
+
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "%s"
+	version = data.digitalocean_kubernetes_versions.test.latest_version
 	tags    = ["foo","bar"]
 
 	node_pool {
@@ -440,7 +449,7 @@ resource "digitalocean_kubernetes_cluster" "foobar" {
 }
 
 resource digitalocean_kubernetes_node_pool "barfoo" {
-  cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
+	cluster_id = "${digitalocean_kubernetes_cluster.foobar.id}"
 
 	name    = "%s-updated"
 	size  = "s-1vcpu-2gb"
@@ -450,15 +459,16 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
       priority = "high"
 	}
 }
-`, rName, testClusterVersion16, rName)
+`, testClusterVersion16, rName, rName)
 }
 
 func testAccDigitalOceanKubernetesConfigWithEmptyNodePool(rName string) string {
-	return fmt.Sprintf(`
+	return fmt.Sprintf(`%s
+
 resource "digitalocean_kubernetes_cluster" "foobar" {
 	name    = "%s"
 	region  = "lon1"
-	version = "%s"
+	version = data.digitalocean_kubernetes_versions.test.latest_version
 
 	node_pool {
 		name       = "default"
@@ -476,7 +486,7 @@ resource digitalocean_kubernetes_node_pool "barfoo" {
 	min_nodes  = 0
 	max_nodes  = 3
 }
-`, rName, testClusterVersion16, rName)
+`, testClusterVersion16, rName, rName)
 }
 
 func testAccCheckDigitalOceanKubernetesNodePoolExists(n string, cluster *godo.KubernetesCluster, pool *godo.KubernetesNodePool) resource.TestCheckFunc {


### PR DESCRIPTION
Since the addition of the `digitalocean_kubernetes_versions` data source, there is no longer any excuse for the hard-coded versions in the test. They need frequent updating. Let's replace them!

```
$ make testacc TESTARGS="-run='Kubernetes' -parallel=20 -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='Kubernetes' -parallel=20 -count=1 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDataSourceDigitalOceanKubernetesCluster_Basic
=== PAUSE TestAccDataSourceDigitalOceanKubernetesCluster_Basic
=== RUN   TestAccDataSourceDigitalOceanKubernetesVersions_Basic
=== PAUSE TestAccDataSourceDigitalOceanKubernetesVersions_Basic
=== RUN   TestAccDataSourceDigitalOceanKubernetesVersions_Filtered
=== PAUSE TestAccDataSourceDigitalOceanKubernetesVersions_Filtered
=== RUN   TestAccDataSourceDigitalOceanKubernetesVersions_CreateCluster
=== PAUSE TestAccDataSourceDigitalOceanKubernetesVersions_CreateCluster
=== RUN   TestAccDigitalOceanKubernetesCluster_ImportBasic
--- PASS: TestAccDigitalOceanKubernetesCluster_ImportBasic (415.31s)
=== RUN   TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool
--- PASS: TestAccDigitalOceanKubernetesCluster_ImportNonDefaultNodePool (496.36s)
=== RUN   TestAccDigitalOceanKubernetesNodePool_Import
--- PASS: TestAccDigitalOceanKubernetesNodePool_Import (587.66s)
=== RUN   TestAccDigitalOceanKubernetesCluster_Basic
=== PAUSE TestAccDigitalOceanKubernetesCluster_Basic
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdateCluster
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== RUN   TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale
=== PAUSE TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale
=== RUN   TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale
=== RUN   TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== PAUSE TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== RUN   TestAccDigitalOceanKubernetesCluster_UpgradeVersion
=== PAUSE TestAccDigitalOceanKubernetesCluster_UpgradeVersion
=== RUN   TestAccDigitalOceanKubernetesNodePool_Basic
=== PAUSE TestAccDigitalOceanKubernetesNodePool_Basic
=== RUN   TestAccDigitalOceanKubernetesNodePool_Update
=== PAUSE TestAccDigitalOceanKubernetesNodePool_Update
=== RUN   TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale
=== PAUSE TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale
=== RUN   TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale
=== PAUSE TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale
=== RUN   TestAccDigitalOceanKubernetesNodePool_WithEmptyNodePool
=== PAUSE TestAccDigitalOceanKubernetesNodePool_WithEmptyNodePool
=== CONT  TestAccDataSourceDigitalOceanKubernetesCluster_Basic
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale
=== CONT  TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale
=== CONT  TestAccDigitalOceanKubernetesNodePool_WithEmptyNodePool
=== CONT  TestAccDigitalOceanKubernetesNodePool_Basic
=== CONT  TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale
=== CONT  TestAccDigitalOceanKubernetesCluster_UpgradeVersion
=== CONT  TestAccDataSourceDigitalOceanKubernetesVersions_Basic
=== CONT  TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability
=== CONT  TestAccDigitalOceanKubernetesNodePool_Update
=== CONT  TestAccDigitalOceanKubernetesCluster_Basic
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolSize
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails
=== CONT  TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale
=== CONT  TestAccDataSourceDigitalOceanKubernetesVersions_CreateCluster
=== CONT  TestAccDataSourceDigitalOceanKubernetesVersions_Filtered
=== CONT  TestAccDigitalOceanKubernetesCluster_UpdateCluster
--- PASS: TestAccDataSourceDigitalOceanKubernetesVersions_Filtered (3.07s)
--- PASS: TestAccDataSourceDigitalOceanKubernetesVersions_Basic (3.38s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpgradeVersion (360.31s)
--- PASS: TestAccDataSourceDigitalOceanKubernetesCluster_Basic (367.62s)
--- PASS: TestAccDataSourceDigitalOceanKubernetesVersions_CreateCluster (385.13s)
--- PASS: TestAccDigitalOceanKubernetesCluster_Basic (425.44s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolWithAutoScale (432.68s)
--- PASS: TestAccDigitalOceanKubernetesCluster_KubernetesProviderInteroperability (441.68s)
--- PASS: TestAccDigitalOceanKubernetesNodePool_WithEmptyNodePool (448.62s)
--- PASS: TestAccDigitalOceanKubernetesCluster_CreatePoolWithAutoScale (497.27s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolDetails (502.07s)
--- PASS: TestAccDigitalOceanKubernetesNodePool_UpdateWithAutoScale (555.73s)
--- PASS: TestAccDigitalOceanKubernetesNodePool_Basic (589.47s)
--- PASS: TestAccDigitalOceanKubernetesNodePool_Update (612.09s)
--- PASS: TestAccDigitalOceanKubernetesNodePool_CreateWithAutoScale (700.31s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdateCluster (749.37s)
--- PASS: TestAccDigitalOceanKubernetesCluster_UpdatePoolSize (779.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	2278.982s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/internal/datalist	0.005s [no tests to run]
```