### PR TITLE
dbaas: Add support for specifying a VPC for read-only replicas.

### DIFF
--- a/digitalocean/resource_digitalocean_database_replica.go
+++ b/digitalocean/resource_digitalocean_database_replica.go
@@ -48,6 +48,14 @@ func resourceDigitalOceanDatabaseReplica() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"private_network_uuid": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
 			"host": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -116,6 +124,10 @@ func resourceDigitalOceanDatabaseReplicaCreate(d *schema.ResourceData, meta inte
 		Tags:   expandTags(d.Get("tags").(*schema.Set).List()),
 	}
 
+	if v, ok := d.GetOk("private_network_uuid"); ok {
+		opts.PrivateNetworkUUID = v.(string)
+	}
+
 	log.Printf("[DEBUG] DatabaseReplica create configuration: %#v", opts)
 	replica, _, err := client.Databases.CreateReplica(context.Background(), clusterId, opts)
 	if err != nil {
@@ -161,6 +173,7 @@ func resourceDigitalOceanDatabaseReplicaRead(d *schema.ResourceData, meta interf
 	d.Set("database", replica.Connection.Database)
 	d.Set("user", replica.Connection.User)
 	d.Set("password", replica.Connection.Password)
+	d.Set("private_network_uuid", replica.PrivateNetworkUUID)
 
 	return nil
 }


### PR DESCRIPTION
```
$ make testacc TESTARGS="-run='DatabaseReplica' -parallel=20 -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='DatabaseReplica' -parallel=20 -count=1 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDigitalOceanDatabaseReplica_importBasic
--- PASS: TestAccDigitalOceanDatabaseReplica_importBasic (478.12s)
=== RUN   TestAccDigitalOceanDatabaseReplica_Basic
=== PAUSE TestAccDigitalOceanDatabaseReplica_Basic
=== RUN   TestAccDigitalOceanDatabaseReplica_WithVPC
=== PAUSE TestAccDigitalOceanDatabaseReplica_WithVPC
=== CONT  TestAccDigitalOceanDatabaseReplica_Basic
=== CONT  TestAccDigitalOceanDatabaseReplica_WithVPC
--- PASS: TestAccDigitalOceanDatabaseReplica_Basic (462.23s)
--- PASS: TestAccDigitalOceanDatabaseReplica_WithVPC (626.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	1104.213s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/internal/datalist	0.006s [no tests to run]
```

See: https://github.com/digitalocean/api-v2/issues/192