### PR TITLE
Set ID in flattenDigitalOceanDroplet.

### DIFF
--- a/digitalocean/datasource_digitalocean_droplets_test.go
+++ b/digitalocean/datasource_digitalocean_droplets_test.go
@@ -48,6 +48,7 @@ data "digitalocean_droplets" "result" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.digitalocean_droplets.result", "droplets.#", "1"),
 					resource.TestCheckResourceAttr("data.digitalocean_droplets.result", "droplets.0.name", name1),
+					resource.TestCheckResourceAttrPair("data.digitalocean_droplets.result", "droplets.0.id", "digitalocean_droplet.foo", "id"),
 				),
 			},
 			{

--- a/digitalocean/droplets.go
+++ b/digitalocean/droplets.go
@@ -153,6 +153,7 @@ func flattenDigitalOceanDroplet(rawDroplet, meta interface{}) (map[string]interf
 	droplet := rawDroplet.(godo.Droplet)
 
 	flattenedDroplet := map[string]interface{}{
+		"id":            droplet.ID,
 		"name":          droplet.Name,
 		"urn":           droplet.URN(),
 		"region":        droplet.Region.Slug,


### PR DESCRIPTION
`data.digitalocean_droplets` does not correctly set the individual Droplet IDs. For example, this config:

```
data "digitalocean_droplets" "list" {
  filter {
    key    = "tags"
    values = ["stage"]
  }
}

output "droplets" {
  value = data.digitalocean_droplets.list.droplets.*.id
}
```

outputs:

```
droplets = [
  0,
  0,
  0,
  0,
  0,
  0,
  0,
]
```

This problem only effected `data.digitalocean_droplets` as other resources call `d.SetId` explicitly. For the data list, the Droplet's ID is not the resource's ID.

New test failing before change:
```
$ make testacc TESTARGS='-run=TestAccDataSourceDigitalOceanDroplets_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDataSourceDigitalOceanDroplets_Basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDataSourceDigitalOceanDroplets_Basic
    TestAccDataSourceDigitalOceanDroplets_Basic: testing.go:640: Step 1 error: Check failed: Check 3/3 error: data.digitalocean_droplets.result: Attribute 'droplets.0.id' expected "195847772", got "0"
--- FAIL: TestAccDataSourceDigitalOceanDroplets_Basic (53.74s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	53.759s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/internal/datalist	(cached) [no tests to run]
FAIL
```

Passing after change:
```
$ make testacc TESTARGS='-run=TestAccDataSourceDigitalOceanDroplets_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDataSourceDigitalOceanDroplets_Basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-digitalocean	[no test files]
=== RUN   TestAccDataSourceDigitalOceanDroplets_Basic
--- PASS: TestAccDataSourceDigitalOceanDroplets_Basic (53.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/digitalocean	(cached)
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-digitalocean/internal/datalist	(cached) [no tests to run]
```

CC: @tdyas 