### PR TITLE
Fix vpc import syntax

### DIFF
--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -67,5 +67,5 @@ In addition to the above arguments, the following attributes are exported:
 A VPC can be imported using its `id`, e.g.
 
 ```
-terraform import digitalocean_vpc.example.id 506f78a4-e098-11e5-ad9f-000f53306ae1
+terraform import digitalocean_vpc.example 506f78a4-e098-11e5-ad9f-000f53306ae1
 ```


### PR DESCRIPTION
With imports, it's incorrect to specify the attribute. It should just be `<resource_type>.<resource_name> ...`. 