### PR TITLE
Increase timeout on VPC deletion retry.

### DIFF
--- a/digitalocean/resource_digitalocean_vpc.go
+++ b/digitalocean/resource_digitalocean_vpc.go
@@ -68,6 +68,10 @@ func resourceDigitalOceanVPC() *schema.Resource {
 				Description: "The date and time of when the VPC was created",
 			},
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(2 * time.Minute),
+		},
 	}
 }
 
@@ -148,7 +152,7 @@ func resourceDigitalOceanVPCDelete(d *schema.ResourceData, meta interface{}) err
 	client := meta.(*CombinedConfig).godoClient()
 	vpcID := d.Id()
 
-	return resource.Retry(1*time.Minute, func() *resource.RetryError {
+	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		resp, err := client.VPCs.Delete(context.Background(), vpcID)
 		if err != nil {
 			// Retry if VPC still contains member resources to prevent race condition


### PR DESCRIPTION
Sometimes a lag between when a resource is deleted and when it is de-registered from the VPC service can be observed. We currently will retry failed VPC delete requests for one minute before timing out. This PR raises the default to two minutes and makes it user configurable. I'm reluctant to raise the default to a much larger value as this can be a legitimate error (e.g. a Droplet created in the control panel was added to a VPC managed with Terraform).

This should help to resolve https://github.com/terraform-providers/terraform-provider-digitalocean/issues/446