### PR TITLE
digitalocean_loadbalancer - Adds 'https' to list of acceptable healthcheck protocols

### DIFF
--- a/digitalocean/resource_digitalocean_loadbalancer.go
+++ b/digitalocean/resource_digitalocean_loadbalancer.go
@@ -117,6 +117,7 @@ func resourceDigitalOceanLoadbalancer() *schema.Resource {
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"http",
+								"https",
 								"tcp",
 							}, false),
 						},
@@ -249,6 +250,10 @@ func resourceDigitalOceanLoadbalancer() *schema.Resource {
 				if healthCheckProtocol == "http" {
 					if !hasPath {
 						return fmt.Errorf("health check `path` is required for when protocol is `http`")
+					}
+				} else if healthCheckProtocol == "https" {
+					if !hasPath {
+						return fmt.Errorf("health check `path` is required for when protocol is `https`")
 					}
 				} else {
 					if hasPath {

--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -133,7 +133,7 @@ the backend service. Default value is `false`.
 
 `healthcheck` supports the following:
 
-* `protocol` - (Required) The protocol used for health checks sent to the backend Droplets. The possible values are `http` or `tcp`.
+* `protocol` - (Required) The protocol used for health checks sent to the backend Droplets. The possible values are `http`, `https` or `tcp`.
 * `port` - (Optional) An integer representing the port on the backend Droplets on which the health check will attempt a connection.
 * `path` - (Optional) The path on the backend Droplets to which the Load Balancer instance will send a request.
 * `check_interval_seconds` - (Optional) The number of seconds between between two consecutive health checks. If not specified, the default value is `10`.


### PR DESCRIPTION
DigitalOcean's API supports `https` for load balancer health check configuration, but the Terraform provider does not. This fixes that and updates the documentation.

DigitalOcean API v2
<img width="709" alt="Screen Shot 2020-07-14 at 2 42 48 PM" src="https://user-images.githubusercontent.com/251512/87463956-4d648180-c5e0-11ea-8060-0c4c6c642d52.png">
